### PR TITLE
Batch LLM requests

### DIFF
--- a/ankiops/html_converter.py
+++ b/ankiops/html_converter.py
@@ -8,7 +8,7 @@ from html_to_markdown import ConversionOptions, HeadingStyle, HighlightStyle
 from html_to_markdown import convert as convert_html_to_markdown
 
 from ankiops.config import LOCAL_MEDIA_DIR
-from ankiops.math_delimiters import normalize_double_escaped_math_delimiters
+from ankiops.math_delimiters import normalize_escaped_math_delimiters
 
 # Use Unicode placeholders (zero-width joiners + unique pattern)
 _MD_SPECIAL_CHARS = {
@@ -56,7 +56,7 @@ def _looks_like_html(text: str) -> bool:
 
 def _escape_special_chars(text: str) -> str:
     """Escape markdown special chars while preserving explicit LaTeX math blocks."""
-    text = normalize_double_escaped_math_delimiters(text)
+    text = normalize_escaped_math_delimiters(text)
 
     def _escape_segment(segment: str) -> str:
         preserved_runs: dict[str, str] = {}

--- a/ankiops/llm/commands.py
+++ b/ankiops/llm/commands.py
@@ -423,7 +423,10 @@ def _show_plan(
     logger.info("%s", plan.format_full_prompt())
     logger.info("")
     logger.info("Request estimate: %s", _format_count(plan.requests_estimate))
-    logger.info("Cost estimate (worst-case): %s", plan.format_cost_estimate())
+    logger.info(
+        "Cost estimate (assuming number of input tokens equals output tokens): %s",
+        plan.format_cost_estimate(),
+    )
     run_command = f"ankiops llm {plan.task_name} --run"
     if model_override:
         run_command = f"{run_command} --model {model_override}"

--- a/ankiops/llm/config_loader.py
+++ b/ankiops/llm/config_loader.py
@@ -35,8 +35,8 @@ _SUPPORTED_TASK_KEYS = (
     "fields",
 )
 _SUPPORTED_REQUEST_KEYS = (
+    "notes_per_request",
     "temperature",
-    "max_output_tokens",
     "reasoning",
 )
 _SUPPORTED_REASONING_EFFORTS = (
@@ -380,7 +380,7 @@ def _parse_access_rules_by_note_type(
 def _parse_request_options(value: Any, *, path: Path) -> TaskRequestOptions:
     defaults = TaskRequestOptions()
     if value is None:
-        return defaults
+        raise LlmConfigError(f"{path}: 'request.notes_per_request' is required")
     if not isinstance(value, dict):
         raise LlmConfigError(f"{path}: 'request' must be a mapping")
 
@@ -391,6 +391,19 @@ def _parse_request_options(value: Any, *, path: Path) -> TaskRequestOptions:
             f"{path}: unknown request key(s): {', '.join(unknown)}. "
             f"Allowed request keys: {allowed}"
         )
+
+    raw_notes_per_request = value.get("notes_per_request")
+    if raw_notes_per_request is None:
+        raise LlmConfigError(f"{path}: 'request.notes_per_request' is required")
+    if isinstance(raw_notes_per_request, bool) or not isinstance(
+        raw_notes_per_request,
+        int,
+    ):
+        raise LlmConfigError(
+            f"{path}: 'request.notes_per_request' must be an integer"
+        )
+    if raw_notes_per_request < 1:
+        raise LlmConfigError(f"{path}: 'request.notes_per_request' must be >= 1")
 
     temperature = defaults.temperature
     if "temperature" in value:
@@ -404,23 +417,6 @@ def _parse_request_options(value: Any, *, path: Path) -> TaskRequestOptions:
             raise LlmConfigError(f"{path}: 'request.temperature' must be numeric")
         else:
             temperature = float(raw_temperature)
-
-    max_output_tokens = defaults.max_output_tokens
-    if "max_output_tokens" in value:
-        raw_max_output_tokens = value.get("max_output_tokens")
-        if raw_max_output_tokens is None:
-            max_output_tokens = None
-        elif isinstance(raw_max_output_tokens, bool) or not isinstance(
-            raw_max_output_tokens,
-            int,
-        ):
-            raise LlmConfigError(
-                f"{path}: 'request.max_output_tokens' must be an integer or null"
-            )
-        elif raw_max_output_tokens < 1:
-            raise LlmConfigError(f"{path}: 'request.max_output_tokens' must be >= 1")
-        else:
-            max_output_tokens = raw_max_output_tokens
 
     reasoning = defaults.reasoning
     if "reasoning" in value:
@@ -441,8 +437,8 @@ def _parse_request_options(value: Any, *, path: Path) -> TaskRequestOptions:
             reasoning = normalized
 
     return TaskRequestOptions(
+        notes_per_request=raw_notes_per_request,
         temperature=temperature,
-        max_output_tokens=max_output_tokens,
         reasoning=reasoning,
     )
 

--- a/ankiops/llm/llm_db.py
+++ b/ankiops/llm/llm_db.py
@@ -19,7 +19,8 @@ from .types import LlmItemStatus, LlmJobStatus, TaskRunSummary
 _DEFAULT_JOB_LIST_LIMIT = 20
 _JOB_TABLE = "llm_job"
 _ITEM_TABLE = "llm_job_item"
-_ATTEMPT_TABLE = "llm_attempt"
+_REQUEST_TABLE = "llm_request"
+_REQUEST_ITEM_TABLE = "llm_request_item"
 EnumT = TypeVar("EnumT", bound=Enum)
 
 
@@ -202,10 +203,11 @@ class LlmDb:
             (item_status.value, error_message, _as_json(changed_fields or []), item_id),
         )
 
-    def insert_attempt(
+    def insert_request(
         self,
         *,
-        item_id: int,
+        job_id: int,
+        item_ids: list[int],
         outcome: str,
         request_json: dict[str, Any],
         parsed_response_json: dict[str, Any] | None,
@@ -215,17 +217,33 @@ class LlmDb:
         input_tokens: int,
         output_tokens: int,
     ) -> int:
+        if self._tx_depth == 0:
+            with self.write_tx():
+                return self.insert_request(
+                    job_id=job_id,
+                    item_ids=item_ids,
+                    outcome=outcome,
+                    request_json=request_json,
+                    parsed_response_json=parsed_response_json,
+                    response_json=response_json,
+                    error_message=error_message,
+                    latency_ms=latency_ms,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                )
+        if not item_ids:
+            raise ValueError("LLM request must be linked to at least one job item")
         now = _utc_now()
         cursor = self._write(
             f"""
-            INSERT INTO {_ATTEMPT_TABLE} (
-                job_item_id, outcome, request_json,
+            INSERT INTO {_REQUEST_TABLE} (
+                job_id, outcome, request_json,
                 parsed_response_json, response_json, error_message,
                 latency_ms, input_tokens, output_tokens, created_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
-                item_id,
+                job_id,
                 outcome,
                 _as_json(request_json),
                 _as_json(parsed_response_json) if parsed_response_json else None,
@@ -237,7 +255,15 @@ class LlmDb:
                 now,
             ),
         )
-        return _lastrowid(cursor, _ATTEMPT_TABLE)
+        request_id = _lastrowid(cursor, _REQUEST_TABLE)
+        self._conn.executemany(
+            f"""
+            INSERT INTO {_REQUEST_ITEM_TABLE} (request_id, job_item_id)
+            VALUES (?, ?)
+            """,
+            [(request_id, item_id) for item_id in item_ids],
+        )
+        return request_id
 
     def mark_unfinished_items_canceled(self, *, job_id: int) -> int:
         cursor = self._write(
@@ -329,19 +355,18 @@ class LlmDb:
         ).fetchone()
         assert item_counts is not None
 
-        attempts = self._conn.execute(
+        requests = self._conn.execute(
             f"""
             SELECT COUNT(*) requests,
                    COALESCE(SUM(input_tokens), 0) input_tokens,
                    COALESCE(SUM(output_tokens), 0) output_tokens,
                    COALESCE(SUM(latency_ms), 0) latency_ms
-            FROM {_ATTEMPT_TABLE} a
-            JOIN {_ITEM_TABLE} i ON i.id = a.job_item_id
-            WHERE i.job_id = ?
+            FROM {_REQUEST_TABLE}
+            WHERE job_id = ?
             """,
             (job_id,),
         ).fetchone()
-        assert attempts is not None
+        assert requests is not None
 
         summary.eligible = int(item_counts["eligible"] or 0)
         summary.updated = int(item_counts["updated"] or 0)
@@ -349,10 +374,10 @@ class LlmDb:
         summary.skipped_no_editable_fields = int(item_counts["skipped"] or 0)
         summary.errors = int(item_counts["errors"] or 0)
         summary.canceled = int(item_counts["canceled"] or 0)
-        summary.requests = int(attempts["requests"] or 0)
-        summary.input_tokens = int(attempts["input_tokens"] or 0)
-        summary.output_tokens = int(attempts["output_tokens"] or 0)
-        summary.provider_latency_ms_total = int(attempts["latency_ms"] or 0)
+        summary.requests = int(requests["requests"] or 0)
+        summary.input_tokens = int(requests["input_tokens"] or 0)
+        summary.output_tokens = int(requests["output_tokens"] or 0)
+        summary.provider_latency_ms_total = int(requests["latency_ms"] or 0)
 
         status = _parse_enum(LlmJobStatus, row["status"])
         persisted = bool(row["persisted"])
@@ -421,12 +446,13 @@ class LlmDb:
             f"""
             SELECT i.ordinal, i.note_key, i.deck_name, i.note_type, i.item_status,
                    i.error_message, i.changed_fields_json,
-                   COUNT(a.id) attempts,
-                   COALESCE(SUM(a.input_tokens), 0) input_tokens,
-                   COALESCE(SUM(a.output_tokens), 0) output_tokens,
-                   COALESCE(SUM(a.latency_ms), 0) latency_ms
+                   COUNT(r.id) attempts,
+                   COALESCE(SUM(r.input_tokens), 0) input_tokens,
+                   COALESCE(SUM(r.output_tokens), 0) output_tokens,
+                   COALESCE(SUM(r.latency_ms), 0) latency_ms
             FROM {_ITEM_TABLE} i
-            LEFT JOIN {_ATTEMPT_TABLE} a ON a.job_item_id = i.id
+            LEFT JOIN {_REQUEST_ITEM_TABLE} ri ON ri.job_item_id = i.id
+            LEFT JOIN {_REQUEST_TABLE} r ON r.id = ri.request_id
             WHERE i.job_id = ?
             GROUP BY i.id
             ORDER BY i.ordinal ASC
@@ -508,9 +534,9 @@ class LlmDb:
                     FOREIGN KEY(job_id) REFERENCES {_JOB_TABLE}(id) ON DELETE CASCADE
                 );
 
-                CREATE TABLE IF NOT EXISTS {_ATTEMPT_TABLE} (
+                CREATE TABLE IF NOT EXISTS {_REQUEST_TABLE} (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    job_item_id INTEGER NOT NULL,
+                    job_id INTEGER NOT NULL,
                     outcome TEXT NOT NULL,
                     request_json TEXT NOT NULL,
                     parsed_response_json TEXT,
@@ -520,6 +546,15 @@ class LlmDb:
                     input_tokens INTEGER NOT NULL,
                     output_tokens INTEGER NOT NULL,
                     created_at TEXT NOT NULL,
+                    FOREIGN KEY(job_id) REFERENCES {_JOB_TABLE}(id) ON DELETE CASCADE
+                );
+
+                CREATE TABLE IF NOT EXISTS {_REQUEST_ITEM_TABLE} (
+                    request_id INTEGER NOT NULL,
+                    job_item_id INTEGER NOT NULL,
+                    PRIMARY KEY(request_id, job_item_id),
+                    FOREIGN KEY(request_id)
+                        REFERENCES {_REQUEST_TABLE}(id) ON DELETE CASCADE,
                     FOREIGN KEY(job_item_id)
                         REFERENCES {_ITEM_TABLE}(id) ON DELETE CASCADE
                 );
@@ -534,15 +569,19 @@ class LlmDb:
                 f"ON {_ITEM_TABLE}(job_id)"
             )
             self._conn.execute(
-                f"CREATE INDEX IF NOT EXISTS idx_llm_attempt_item "
-                f"ON {_ATTEMPT_TABLE}(job_item_id)"
+                f"CREATE INDEX IF NOT EXISTS idx_llm_request_job "
+                f"ON {_REQUEST_TABLE}(job_id)"
+            )
+            self._conn.execute(
+                f"CREATE INDEX IF NOT EXISTS idx_llm_request_item_item "
+                f"ON {_REQUEST_ITEM_TABLE}(job_item_id)"
             )
         self._assert_schema()
 
     def _assert_schema(self) -> None:
-        required_attempt_columns = {
+        required_request_columns = {
             "id",
-            "job_item_id",
+            "job_id",
             "outcome",
             "request_json",
             "parsed_response_json",
@@ -553,11 +592,21 @@ class LlmDb:
             "output_tokens",
             "created_at",
         }
-        attempt_columns = {
+        request_columns = {
             str(row["name"])
-            for row in self._conn.execute(f"PRAGMA table_info({_ATTEMPT_TABLE})")
+            for row in self._conn.execute(f"PRAGMA table_info({_REQUEST_TABLE})")
         }
-        if required_attempt_columns - attempt_columns:
+        required_request_item_columns = {"request_id", "job_item_id"}
+        request_item_columns = {
+            str(row["name"])
+            for row in self._conn.execute(
+                f"PRAGMA table_info({_REQUEST_ITEM_TABLE})"
+            )
+        }
+        if (
+            required_request_columns - request_columns
+            or required_request_item_columns - request_item_columns
+        ):
             raise RuntimeError(
                 "LLM DB schema is from an older AnkiOps build. "
                 f"Delete '{self._db_path}' to reinitialize it."

--- a/ankiops/llm/resources/artifacts.yaml
+++ b/ankiops/llm/resources/artifacts.yaml
@@ -11,3 +11,6 @@ fields:
     "*": ["AI Notes"]
   read_only:
     "AnkiOpsChoice": ["Answer"]
+
+request:
+  notes_per_request: 4

--- a/ankiops/llm/resources/grammar.yaml
+++ b/ankiops/llm/resources/grammar.yaml
@@ -14,4 +14,5 @@ fields:
     "AnkiOpsChoice": ["Answer"]
 
 request:
+  notes_per_request: 4
   reasoning: low

--- a/ankiops/llm/resources/review.yaml
+++ b/ankiops/llm/resources/review.yaml
@@ -12,4 +12,5 @@ fields:
     "AnkiOpsImageOcclusion": ["*"]
 
 request:
+  notes_per_request: 4
   reasoning: high

--- a/ankiops/llm/resources/translate.yaml
+++ b/ankiops/llm/resources/translate.yaml
@@ -11,3 +11,6 @@ fields:
     "*": ["AI Notes"]
   read_only:
     "AnkiOpsChoice": ["Answer"]
+
+request:
+  notes_per_request: 4

--- a/ankiops/llm/runner.py
+++ b/ankiops/llm/runner.py
@@ -76,6 +76,38 @@ class OpenAIResult:
     fatal: bool = False
 
 
+@dataclass(frozen=True)
+class EligibleBatch:
+    note_type: str
+    note_type_config: NoteTypeConfig
+    candidates: list[EligibleCandidate]
+
+    @property
+    def item_ids(self) -> list[int]:
+        return [candidate.item_id for candidate in self.candidates]
+
+    @property
+    def note_count(self) -> int:
+        return len(self.candidates)
+
+    @property
+    def payloads(self) -> list[NotePayload]:
+        return [candidate.payload for candidate in self.candidates]
+
+
+@dataclass(frozen=True)
+class _BatchProcessResult:
+    statuses: tuple[LlmItemStatus, ...]
+
+
+@dataclass(frozen=True)
+class _CandidateApplyResult:
+    candidate: EligibleCandidate
+    status: LlmItemStatus
+    changed_fields: list[str]
+    error_message: str | None = None
+
+
 @dataclass
 class _ExecutionProgressState:
     job_id: int
@@ -183,6 +215,7 @@ class LlmTaskExecutor:
                 try:
                     await self._execute_candidates(
                         db=db,
+                        job_id=job_id,
                         task=task,
                         candidates=candidates,
                         progress_state=progress_state,
@@ -231,6 +264,7 @@ class LlmTaskExecutor:
         self,
         *,
         db: LlmDb,
+        job_id: int,
         task: TaskConfig,
         candidates: list[EligibleCandidate],
         progress_state: _ExecutionProgressState,
@@ -243,40 +277,56 @@ class LlmTaskExecutor:
             max_retries=0,
         )
         try:
-            in_flight_limit = min(max(task.model.concurrency, 1), len(candidates))
+            batches = _build_candidate_batches(
+                candidates,
+                notes_per_request=task.request.notes_per_request,
+            )
+            in_flight_limit = min(max(task.model.concurrency, 1), len(batches))
             next_index = 0
-            in_flight: set[asyncio.Task[LlmItemStatus]] = set()
+            in_flight: dict[asyncio.Task[_BatchProcessResult], EligibleBatch] = {}
 
-            def start(candidate: EligibleCandidate) -> asyncio.Task[LlmItemStatus]:
-                return asyncio.create_task(
-                    self._process_candidate(
+            def in_flight_notes() -> int:
+                return sum(batch.note_count for batch in in_flight.values())
+
+            def start(batch: EligibleBatch) -> None:
+                task_handle = asyncio.create_task(
+                    self._process_batch(
                         db=db,
+                        job_id=job_id,
                         task=task,
                         client=client,
-                        candidate=candidate,
+                        batch=batch,
                     )
                 )
+                in_flight[task_handle] = batch
 
             while next_index < in_flight_limit:
-                in_flight.add(start(candidates[next_index]))
+                start(batches[next_index])
                 next_index += 1
 
             first_fatal: RuntimeError | None = None
             while in_flight:
-                done, pending = await asyncio.wait(
-                    in_flight,
+                done, _pending = await asyncio.wait(
+                    set(in_flight),
                     return_when=asyncio.FIRST_COMPLETED,
                 )
-                in_flight = set(pending)
                 for completed in done:
+                    batch = in_flight.pop(completed)
                     try:
-                        status = await completed
-                        progress_state.record_status(status)
+                        result = await completed
+                        for status in result.statuses:
+                            progress_state.record_status(status)
                     except RuntimeError as error:
-                        progress_state.record_status(LlmItemStatus.FATAL_ERROR)
+                        progress_state.record_status(
+                            LlmItemStatus.FATAL_ERROR,
+                            count=batch.note_count,
+                        )
                         if first_fatal is None:
                             first_fatal = error
-                    self._emit_progress(progress_state, in_flight=len(in_flight))
+                    self._emit_progress(
+                        progress_state,
+                        in_flight=in_flight_notes(),
+                    )
 
                 if first_fatal is not None:
                     for pending_task in in_flight:
@@ -284,24 +334,25 @@ class LlmTaskExecutor:
                     await asyncio.gather(*in_flight, return_exceptions=True)
                     raise first_fatal
 
-                while next_index < len(candidates) and len(in_flight) < in_flight_limit:
-                    in_flight.add(start(candidates[next_index]))
+                while next_index < len(batches) and len(in_flight) < in_flight_limit:
+                    start(batches[next_index])
                     next_index += 1
         finally:
             await client.close()
 
-    async def _process_candidate(
+    async def _process_batch(
         self,
         *,
         db: LlmDb,
+        job_id: int,
         task: TaskConfig,
         client: AsyncOpenAI,
-        candidate: EligibleCandidate,
-    ) -> LlmItemStatus:
+        batch: EligibleBatch,
+    ) -> _BatchProcessResult:
         result = await _call_openai(
             client=client,
             task=task,
-            candidate=candidate,
+            batch=batch,
         )
         if result.parsed_response is None:
             status = (
@@ -310,8 +361,9 @@ class LlmTaskExecutor:
                 else LlmItemStatus.PROVIDER_ERROR
             )
             with db.write_tx():
-                db.insert_attempt(
-                    item_id=candidate.item_id,
+                db.insert_request(
+                    job_id=job_id,
+                    item_ids=batch.item_ids,
                     outcome=result.outcome,
                     request_json=result.request_json,
                     parsed_response_json=result.parsed_response_json,
@@ -321,26 +373,32 @@ class LlmTaskExecutor:
                     input_tokens=result.input_tokens,
                     output_tokens=result.output_tokens,
                 )
-                db.update_job_item_status(
-                    item_id=candidate.item_id,
-                    item_status=status,
-                    error_message=result.error_message,
-                )
+                for candidate in batch.candidates:
+                    db.update_job_item_status(
+                        item_id=candidate.item_id,
+                        item_status=status,
+                        error_message=result.error_message,
+                    )
             if result.fatal:
                 raise RuntimeError(result.error_message or "Fatal OpenAI error")
-            _log_note_error(candidate, result.error_message or "OpenAI request failed")
-            return status
+            for candidate in batch.candidates:
+                _log_note_error(
+                    candidate,
+                    result.error_message or "OpenAI request failed",
+                )
+            return _BatchProcessResult(statuses=tuple(status for _ in batch.candidates))
 
         try:
-            changed_fields = _apply_parsed_response(
+            apply_results = _apply_batch_parsed_response(
                 parsed_response=result.parsed_response,
-                candidate=candidate,
+                batch=batch,
             )
         except ValueError as error:
             message = str(error)
             with db.write_tx():
-                db.insert_attempt(
-                    item_id=candidate.item_id,
+                db.insert_request(
+                    job_id=job_id,
+                    item_ids=batch.item_ids,
                     outcome="validation_error",
                     request_json=result.request_json,
                     parsed_response_json=result.parsed_response_json,
@@ -350,45 +408,59 @@ class LlmTaskExecutor:
                     input_tokens=result.input_tokens,
                     output_tokens=result.output_tokens,
                 )
-                db.update_job_item_status(
-                    item_id=candidate.item_id,
-                    item_status=LlmItemStatus.NOTE_ERROR,
-                    error_message=message,
-                )
-            _log_note_error(candidate, message)
-            return LlmItemStatus.NOTE_ERROR
+                for candidate in batch.candidates:
+                    db.update_job_item_status(
+                        item_id=candidate.item_id,
+                        item_status=LlmItemStatus.NOTE_ERROR,
+                        error_message=message,
+                    )
+            for candidate in batch.candidates:
+                _log_note_error(candidate, message)
+            return _BatchProcessResult(
+                statuses=tuple(LlmItemStatus.NOTE_ERROR for _ in batch.candidates)
+            )
 
-        status = (
-            LlmItemStatus.SUCCEEDED_UPDATED
-            if changed_fields
-            else LlmItemStatus.SUCCEEDED_UNCHANGED
-        )
+        errors = [
+            f"{item.candidate.payload.note_key}: {item.error_message}"
+            for item in apply_results
+            if item.error_message
+        ]
+        outcome = "validation_error" if errors else "success"
+        request_error = "; ".join(errors) if errors else None
         with db.write_tx():
-            db.insert_attempt(
-                item_id=candidate.item_id,
-                outcome="success",
+            db.insert_request(
+                job_id=job_id,
+                item_ids=batch.item_ids,
+                outcome=outcome,
                 request_json=result.request_json,
                 parsed_response_json=result.parsed_response_json,
                 response_json=result.response_json,
-                error_message=None,
+                error_message=request_error,
                 latency_ms=result.latency_ms,
                 input_tokens=result.input_tokens,
                 output_tokens=result.output_tokens,
             )
-            db.update_job_item_status(
-                item_id=candidate.item_id,
-                item_status=status,
-                changed_fields=changed_fields,
-            )
-        if changed_fields:
-            logger.debug(
-                "  Updated %s in '%s' (%s): fields=%s",
-                candidate.payload.note_key,
-                candidate.deck_name,
-                candidate.payload.note_type,
-                ",".join(changed_fields),
-            )
-        return status
+            for item in apply_results:
+                db.update_job_item_status(
+                    item_id=item.candidate.item_id,
+                    item_status=item.status,
+                    error_message=item.error_message,
+                    changed_fields=item.changed_fields,
+                )
+        for item in apply_results:
+            if item.error_message is not None:
+                _log_note_error(item.candidate, item.error_message)
+            elif item.changed_fields:
+                logger.debug(
+                    "  Updated %s in '%s' (%s): fields=%s",
+                    item.candidate.payload.note_key,
+                    item.candidate.deck_name,
+                    item.candidate.payload.note_type,
+                    ",".join(item.changed_fields),
+                )
+        return _BatchProcessResult(
+            statuses=tuple(item.status for item in apply_results)
+        )
 
     def _emit_progress(
         self,
@@ -825,25 +897,62 @@ def _record_discovery_item(
     )
 
 
+def _build_candidate_batches(
+    candidates: list[EligibleCandidate],
+    *,
+    notes_per_request: int,
+) -> list[EligibleBatch]:
+    by_note_type: dict[str, list[EligibleCandidate]] = {}
+    for candidate in candidates:
+        by_note_type.setdefault(candidate.payload.note_type, []).append(candidate)
+
+    batches: list[EligibleBatch] = []
+    for note_type, grouped_candidates in by_note_type.items():
+        for start in range(0, len(grouped_candidates), notes_per_request):
+            chunk = grouped_candidates[start : start + notes_per_request]
+            batches.append(
+                EligibleBatch(
+                    note_type=note_type,
+                    note_type_config=chunk[0].note_type_config,
+                    candidates=chunk,
+                )
+            )
+    return batches
+
+
+def _build_payload_batches(
+    payloads: list[NotePayload],
+    *,
+    notes_per_request: int,
+) -> list[list[NotePayload]]:
+    by_note_type: dict[str, list[NotePayload]] = {}
+    for payload in payloads:
+        by_note_type.setdefault(payload.note_type, []).append(payload)
+
+    batches: list[list[NotePayload]] = []
+    for grouped_payloads in by_note_type.values():
+        for start in range(0, len(grouped_payloads), notes_per_request):
+            batches.append(grouped_payloads[start : start + notes_per_request])
+    return batches
+
+
 async def _call_openai(
     *,
     client: AsyncOpenAI,
     task: TaskConfig,
-    candidate: EligibleCandidate,
+    batch: EligibleBatch,
 ) -> OpenAIResult:
     response_model = build_response_model(
-        note_type=candidate.payload.note_type,
-        payloads=[candidate.payload],
+        note_type=batch.note_type,
+        payloads=batch.payloads,
     )
-    instructions, user_input = _build_request_content(task=task, candidate=candidate)
+    instructions, user_input = _build_request_content(task=task, batch=batch)
     request_kwargs: dict[str, Any] = {
         "model": task.model.model_id,
         "instructions": instructions,
         "input": user_input,
         "text_format": response_model,
     }
-    if task.request.max_output_tokens is not None:
-        request_kwargs["max_output_tokens"] = task.request.max_output_tokens
     if task.request.temperature is not None:
         request_kwargs["temperature"] = task.request.temperature
     if task.request.reasoning is not None:
@@ -933,16 +1042,23 @@ async def _call_openai(
 def _build_request_content(
     *,
     task: TaskConfig,
-    candidate: EligibleCandidate,
+    batch: EligibleBatch,
 ) -> tuple[str, str]:
+    notes: list[dict[str, object]] = []
+    for candidate in batch.candidates:
+        note_payload: dict[str, object] = {
+            "note_key": candidate.payload.note_key,
+            "editable_fields": candidate.payload.editable_fields,
+        }
+        if candidate.payload.read_only_fields:
+            note_payload["read_only_fields"] = candidate.payload.read_only_fields
+        notes.append(note_payload)
+
     payload = {
         "user_prompt": task.user_prompt,
-        "note_key": candidate.payload.note_key,
-        "note_type": candidate.payload.note_type,
-        "editable_fields": candidate.payload.editable_fields,
+        "note_type": batch.note_type,
+        "notes": notes,
     }
-    if candidate.payload.read_only_fields:
-        payload["read_only_fields"] = candidate.payload.read_only_fields
     return (
         task.system_prompt.strip(),
         json.dumps(payload, ensure_ascii=False),
@@ -977,13 +1093,85 @@ def _apply_parsed_response(
     candidate: EligibleCandidate,
 ) -> list[str]:
     updates = parsed_updates(parsed_response)
+    unexpected_note_keys = sorted(
+        {note_key for note_key, _field_name, _value in updates}
+        - {candidate.payload.note_key}
+    )
+    if unexpected_note_keys:
+        raise ValueError(
+            "Model returned update for unexpected note_key "
+            f"'{unexpected_note_keys[0]}'"
+        )
+    return _apply_candidate_updates(candidate=candidate, updates=updates)
+
+
+def _apply_batch_parsed_response(
+    *,
+    parsed_response: object,
+    batch: EligibleBatch,
+) -> list[_CandidateApplyResult]:
+    updates = parsed_updates(parsed_response)
+    candidates_by_note_key = {
+        candidate.payload.note_key: candidate for candidate in batch.candidates
+    }
+    unexpected_note_keys = sorted(
+        {
+            note_key
+            for note_key, _field_name, _value in updates
+            if note_key not in candidates_by_note_key
+        }
+    )
+    if unexpected_note_keys:
+        raise ValueError(
+            "Model returned update for unexpected note_key "
+            f"'{unexpected_note_keys[0]}'"
+        )
+
+    updates_by_note_key: dict[str, list[tuple[str, str, str]]] = {
+        note_key: [] for note_key in candidates_by_note_key
+    }
+    for update in updates:
+        updates_by_note_key[update[0]].append(update)
+
+    results: list[_CandidateApplyResult] = []
+    for candidate in batch.candidates:
+        try:
+            changed_fields = _apply_candidate_updates(
+                candidate=candidate,
+                updates=updates_by_note_key[candidate.payload.note_key],
+            )
+        except ValueError as error:
+            results.append(
+                _CandidateApplyResult(
+                    candidate=candidate,
+                    status=LlmItemStatus.NOTE_ERROR,
+                    changed_fields=[],
+                    error_message=str(error),
+                )
+            )
+        else:
+            results.append(
+                _CandidateApplyResult(
+                    candidate=candidate,
+                    status=(
+                        LlmItemStatus.SUCCEEDED_UPDATED
+                        if changed_fields
+                        else LlmItemStatus.SUCCEEDED_UNCHANGED
+                    ),
+                    changed_fields=changed_fields,
+                )
+            )
+    return results
+
+
+def _apply_candidate_updates(
+    *,
+    candidate: EligibleCandidate,
+    updates: list[tuple[str, str, str]],
+) -> list[str]:
     seen_fields: set[str] = set()
     edits: dict[str, str] = {}
-    for note_key, field_name, value in updates:
-        if note_key != candidate.payload.note_key:
-            raise ValueError(
-                f"Model returned update for unexpected note_key '{note_key}'"
-            )
+    for _note_key, field_name, value in updates:
         if field_name in seen_fields:
             raise ValueError(f"Model returned duplicate update for '{field_name}'")
         seen_fields.add(field_name)
@@ -1102,6 +1290,10 @@ def _build_task_plan_result(
     eligible_payloads = [
         item.payload for item in eligible_items if item.payload is not None
     ]
+    payload_batches = _build_payload_batches(
+        eligible_payloads,
+        notes_per_request=task.request.notes_per_request,
+    )
     skipped = sum(
         1
         for item in snapshot.items
@@ -1111,7 +1303,8 @@ def _build_task_plan_result(
         1 for item in snapshot.items if item.item_status is LlmItemStatus.INVALID_NOTE
     )
     input_tokens_estimate = sum(
-        _estimate_note_input_tokens(task, payload) for payload in eligible_payloads
+        _estimate_batch_input_tokens(task, payload_batch)
+        for payload_batch in payload_batches
     )
     summary = TaskRunSummary(
         task_name=task.name,
@@ -1122,7 +1315,7 @@ def _build_task_plan_result(
         eligible=len(eligible_items),
         skipped_no_editable_fields=skipped,
         errors=errors,
-        requests=len(eligible_items),
+        requests=len(payload_batches),
     )
     return TaskPlanResult(
         task_name=task.name,
@@ -1146,13 +1339,8 @@ def _build_task_plan_result(
             note_type_configs=note_type_configs,
             snapshot_items=snapshot.items,
         ),
-        requests_estimate=len(eligible_items),
+        requests_estimate=len(payload_batches),
         input_tokens_estimate=input_tokens_estimate,
-        output_tokens_cap=(
-            None
-            if task.request.max_output_tokens is None
-            else len(eligible_items) * task.request.max_output_tokens
-        ),
     )
 
 
@@ -1202,18 +1390,32 @@ def _build_plan_field_surface(
     return surface
 
 
-def _estimate_note_input_tokens(task: TaskConfig, payload: NotePayload) -> int:
-    parts = [
-        task.system_prompt,
-        task.user_prompt,
-        payload.note_key,
-        payload.note_type,
-    ]
-    for name, value in sorted(payload.editable_fields.items()):
-        parts.extend([name, value])
-    for name, value in sorted(payload.read_only_fields.items()):
-        parts.extend([name, value])
-    return _estimate_tokens("\n".join(parts))
+def _estimate_batch_input_tokens(task: TaskConfig, payloads: list[NotePayload]) -> int:
+    if not payloads:
+        return 0
+    notes: list[dict[str, object]] = []
+    for payload in payloads:
+        note_payload: dict[str, object] = {
+            "note_key": payload.note_key,
+            "editable_fields": payload.editable_fields,
+        }
+        if payload.read_only_fields:
+            note_payload["read_only_fields"] = payload.read_only_fields
+        notes.append(note_payload)
+
+    request_payload = {
+        "user_prompt": task.user_prompt,
+        "note_type": payloads[0].note_type,
+        "notes": notes,
+    }
+    return _estimate_tokens(
+        "\n".join(
+            [
+                task.system_prompt,
+                json.dumps(request_payload, ensure_ascii=False),
+            ]
+        )
+    )
 
 
 def _estimate_tokens(text: str) -> int:
@@ -1240,11 +1442,7 @@ def _format_serializer_scope(task: TaskConfig) -> str:
 
 
 def _format_request_defaults(request: TaskRequestOptions) -> str:
-    parts = [
-        "max_output_tokens=unset"
-        if request.max_output_tokens is None
-        else f"max_output_tokens={request.max_output_tokens}"
-    ]
+    parts = [f"notes_per_request={request.notes_per_request}"]
     if request.temperature is not None:
         parts.append(f"temperature={request.temperature:g}")
     if request.reasoning is not None:

--- a/ankiops/llm/types.py
+++ b/ankiops/llm/types.py
@@ -71,8 +71,8 @@ class FieldAccessRule:
 
 @dataclass(frozen=True)
 class TaskRequestOptions:
+    notes_per_request: int = 1
     temperature: float | None = None
-    max_output_tokens: int | None = None
     reasoning: str | None = None
 
 
@@ -248,7 +248,6 @@ class TaskPlanResult:
     field_surface: list[PlanFieldSurface]
     requests_estimate: int
     input_tokens_estimate: int
-    output_tokens_cap: int | None
 
     def format_full_prompt(self) -> str:
         return (
@@ -257,11 +256,10 @@ class TaskPlanResult:
         )
 
     def format_cost_estimate(self) -> str:
-        if self.output_tokens_cap is None:
-            return "n/a (max_output_tokens unset)"
         estimate = self.model.estimate_cost(
             input_tokens=self.input_tokens_estimate,
-            output_tokens=self.output_tokens_cap,
+            # we assume input and output tokens are the same for estimation purposes
+            output_tokens=self.input_tokens_estimate,
         )
         if estimate is None:
             return "n/a"

--- a/ankiops/markdown_converter.py
+++ b/ankiops/markdown_converter.py
@@ -12,7 +12,7 @@ from pygments.lexers import get_lexer_by_name
 from pygments.util import ClassNotFound
 
 from ankiops.config import LOCAL_MEDIA_DIR
-from ankiops.math_delimiters import normalize_double_escaped_math_delimiters
+from ankiops.math_delimiters import normalize_escaped_math_delimiters
 
 _IMG_WIDTH_RE = re.compile(r'(<img src="[^"]*" alt="[^"]*")>\{width=(\d+)\}')
 # Rewrite [text](url_with_(parens)) to [text](<url>) so mistune doesn't
@@ -159,7 +159,7 @@ class MarkdownToHTML:
 
         # Normalize NBSP to space
         markdown = markdown.replace("\u00a0", " ")
-        markdown = normalize_double_escaped_math_delimiters(markdown)
+        markdown = normalize_escaped_math_delimiters(markdown)
 
         # Arrow replacements: Replace before parsing to avoid conflicts
         # with markdown syntax (== is used for highlighting)

--- a/ankiops/math_delimiters.py
+++ b/ankiops/math_delimiters.py
@@ -4,31 +4,30 @@ from __future__ import annotations
 
 import re
 
-_DOUBLE_ESCAPED_INLINE_MATH_PAREN_PATTERN = re.compile(
-    r"\\{2,}\((?P<dipm_text>(?:(?!\\{2,}\))[\s\S])+?)\\{2,}\)"
+_ESCAPED_INLINE_MATH_PAREN_PATTERN = re.compile(
+    r"\\{1,}\((?P<ipm_text>(?:(?!\\{1,}\))[\s\S])+?)\\{1,}\)"
 )
-_DOUBLE_ESCAPED_INLINE_MATH_BRACKET_PATTERN = re.compile(
-    r"\\{2,}\[(?P<dibm_text>(?:(?!\\{2,}\])[\s\S])+?)\\{2,}\]"
+_ESCAPED_INLINE_MATH_BRACKET_PATTERN = re.compile(
+    r"\\{1,}\[(?P<ibm_text>(?:(?!\\{1,}\])[\s\S])+?)\\{1,}\]"
 )
 _MATH_BODY_HINT_PATTERN = re.compile(r"(\\[A-Za-z]+|[_^{}])")
 
 
-def normalize_double_escaped_math_delimiters(text: str) -> str:
-    """Canonicalize doubly escaped math delimiters to single-escaped form."""
+def normalize_escaped_math_delimiters(text: str) -> str:
+    """Canonicalize escaped math delimiter runs to single-escaped form."""
 
     def _replace_paren(match: re.Match[str]) -> str:
-        body = match.group("dipm_text")
+        body = match.group("ipm_text")
         if not _MATH_BODY_HINT_PATTERN.search(body):
             return match.group(0)
         return "\\(" + body + "\\)"
 
     def _replace_bracket(match: re.Match[str]) -> str:
-        body = match.group("dibm_text")
+        body = match.group("ibm_text")
         if not _MATH_BODY_HINT_PATTERN.search(body):
             return match.group(0)
         return "\\[" + body + "\\]"
 
-    text = _DOUBLE_ESCAPED_INLINE_MATH_PAREN_PATTERN.sub(_replace_paren, text)
-    text = _DOUBLE_ESCAPED_INLINE_MATH_BRACKET_PATTERN.sub(_replace_bracket, text)
+    text = _ESCAPED_INLINE_MATH_PAREN_PATTERN.sub(_replace_paren, text)
+    text = _ESCAPED_INLINE_MATH_BRACKET_PATTERN.sub(_replace_bracket, text)
     return text
-

--- a/tests/integration/sync/test_sync_matrix_import.py
+++ b/tests/integration/sync/test_sync_matrix_import.py
@@ -279,6 +279,30 @@ def test_imp_fresh_create_002_literal_double_underscore_deck_name(world):
         assert "Literal::Deck" not in world.mock_anki.decks
 
 
+def test_imp_fresh_create_003_display_math_is_not_shortened(world):
+    """IMP-FRESH-CREATE-003."""
+    markdown = (
+        r"\\[\sigma^2=\frac{1}{N} "
+        r"\sum_{i=1}^N\left(x_i-\mu\right)^2\]"
+    )
+    expected = (
+        r"\[\sigma^2=\frac{1}{N} "
+        r"\sum_{i=1}^N\left(x_i-\mu\right)^2\]"
+    )
+    world.write_qa_deck("MathDeck", [("Math Q", markdown, None)])
+
+    with world.db_session() as db:
+        result = world.sync_import(db)
+
+        assert_summary(
+            result.summary, created=1, updated=0, moved=0, deleted=0, errors=0
+        )
+        note = next(iter(world.mock_anki.notes.values()))
+        value = note["fields"]["Answer"]["value"]
+        assert value == expected
+        assert "<sup>" not in value
+
+
 def test_imp_run_rename_001_tracks_deck_rename_from_markdown_filename(world):
     """IMP-RUN-RENAME-001."""
     note_key = "imp-run-rename-001"

--- a/tests/unit/conversion/test_converters.py
+++ b/tests/unit/conversion/test_converters.py
@@ -873,23 +873,33 @@ class TestMathRoundTrips:
         assert "E=mc^2" in back
         assert "famous" in back
 
-    def test_double_escaped_display_math_delimiters_are_canonicalized(
-        self, md_to_html, html_to_md
+    @pytest.mark.parametrize(
+        "markdown",
+        [
+            (
+                r"\[\sigma^2=\frac{1}{N} "
+                r"\sum_{i=1}^N\left(x_i-\mu\right)^2\]"
+            ),
+            (
+                r"\\[\sigma^2=\frac{1}{N} "
+                r"\sum_{i=1}^N\left(x_i-\mu\right)^2\]"
+            ),
+            (
+                r"\\[\sigma^2=\frac{1}{N} "
+                r"\sum_{i=1}^N\left(x_i-\mu\right)^2\\]"
+            ),
+        ],
+    )
+    def test_display_math_delimiters_are_canonicalized_without_shortening(
+        self, md_to_html, html_to_md, markdown
     ):
-        md_legacy = (
-            r"\\[\sigma^2=\frac{1}{N} "
-            r"\sum_{i=1}^N\left(x_i-\mu\right)^2\\]"
-        )
-        html = (
-            r"<div>\\[\sigma^2=\frac{1}{N} "
-            r"\sum_{i=1}^N\left(x_i-\mu\right)^2\\]</div>"
-        )
+        html = f"<div>{markdown}</div>"
         expected_math = (
             r"\[\sigma^2=\frac{1}{N} "
             r"\sum_{i=1}^N\left(x_i-\mu\right)^2\]"
         )
 
-        html_from_legacy_md = md_to_html.convert(md_legacy)
+        html_from_legacy_md = md_to_html.convert(markdown)
         assert "<sup>" not in html_from_legacy_md
         assert expected_math in html_from_legacy_md
 

--- a/tests/unit/llm/test_config_loader.py
+++ b/tests/unit/llm/test_config_loader.py
@@ -23,8 +23,8 @@ def test_load_llm_task_catalog_loads_files_fields_and_request(
         system_prompt: !file prompts/system.md
         user_prompt: !file prompts/user.md
         request:
+          notes_per_request: 3
           temperature: 0.25
-          max_output_tokens: 512
           reasoning: low
         fields:
           default_access: read_only
@@ -50,8 +50,8 @@ def test_load_llm_task_catalog_loads_files_fields_and_request(
     )
     assert task.user_prompt_path == (llm_collection / "llm/prompts/user.md").resolve()
     assert task.request == TaskRequestOptions(
+        notes_per_request=3,
         temperature=0.25,
-        max_output_tokens=512,
         reasoning="low",
     )
     assert task.field_access("AnkiOpsQA", "Question") is FieldAccess.READ_ONLY
@@ -77,9 +77,9 @@ def test_load_llm_task_catalog_loads_files_fields_and_request(
             system_prompt: system
             user_prompt: user
             request:
-              max_output_tokens: 0
+              max_output_tokens: 512
             """,
-            "max_output_tokens' must be >= 1",
+            "unknown request key(s): max_output_tokens",
         ),
         (
             """
@@ -87,9 +87,19 @@ def test_load_llm_task_catalog_loads_files_fields_and_request(
             system_prompt: system
             user_prompt: user
             request:
-              max_output_tokens: false
+              notes_per_request: 0
             """,
-            "max_output_tokens' must be an integer or null",
+            "request.notes_per_request' must be >= 1",
+        ),
+        (
+            """
+            model: test
+            system_prompt: system
+            user_prompt: user
+            request:
+              notes_per_request: false
+            """,
+            "request.notes_per_request' must be an integer",
         ),
         (
             """
@@ -105,6 +115,7 @@ def test_load_llm_task_catalog_loads_files_fields_and_request(
             system_prompt: system
             user_prompt: user
             request:
+              notes_per_request: 1
               reasoning: extreme
             """,
             "request.reasoning' must be one of",
@@ -130,7 +141,7 @@ def test_load_llm_task_catalog_reports_invalid_task_config(
     assert expected_error in catalog.errors[str(llm_collection / "llm/grammar.yaml")]
 
 
-def test_load_llm_task_catalog_defaults_to_unset_max_output_tokens(
+def test_load_llm_task_catalog_requires_notes_per_request(
     llm_collection,
     write_file,
     llm_qa_config,
@@ -149,5 +160,7 @@ def test_load_llm_task_catalog_defaults_to_unset_max_output_tokens(
         note_type_configs=[llm_qa_config],
     )
 
-    assert not catalog.errors
-    assert catalog.tasks_by_name["grammar"].request.max_output_tokens is None
+    assert not catalog.tasks_by_name
+    assert "request.notes_per_request' is required" in catalog.errors[
+        str(llm_collection / "llm/grammar.yaml")
+    ]

--- a/tests/unit/llm/test_llm_db.py
+++ b/tests/unit/llm/test_llm_db.py
@@ -26,7 +26,7 @@ def test_resolve_job_id_accepts_numeric_and_latest(tmp_path):
         db.close()
 
 
-def test_write_tx_rolls_back_attempt(tmp_path):
+def test_write_tx_rolls_back_request(tmp_path):
     db = LlmDb.open(tmp_path)
     try:
         job_id = _start_job(db)
@@ -42,8 +42,9 @@ def test_write_tx_rolls_back_attempt(tmp_path):
 
         with pytest.raises(RuntimeError, match="boom"):
             with db.write_tx():
-                db.insert_attempt(
-                    item_id=item_id,
+                db.insert_request(
+                    job_id=job_id,
+                    item_ids=[item_id],
                     outcome="provider_error",
                     request_json={"model": "gpt-test"},
                     parsed_response_json=None,
@@ -55,9 +56,14 @@ def test_write_tx_rolls_back_attempt(tmp_path):
                 )
                 raise RuntimeError("boom")
 
-        row = db._conn.execute("SELECT COUNT(*) AS total FROM llm_attempt").fetchone()
+        row = db._conn.execute("SELECT COUNT(*) AS total FROM llm_request").fetchone()
+        link_row = db._conn.execute(
+            "SELECT COUNT(*) AS total FROM llm_request_item"
+        ).fetchone()
         assert row is not None
+        assert link_row is not None
         assert int(row["total"]) == 0
+        assert int(link_row["total"]) == 0
     finally:
         db.close()
 

--- a/tests/unit/llm/test_runner_execution.py
+++ b/tests/unit/llm/test_runner_execution.py
@@ -18,6 +18,7 @@ from ankiops.llm.types import (
     LlmItemStatus,
     NotePayload,
     TaskConfig,
+    TaskRequestOptions,
 )
 
 
@@ -68,7 +69,12 @@ def _fatal_error() -> OpenAIResult:
     )
 
 
-def _context(llm_qa_config, *, concurrency: int = 2) -> MaterializedTaskContext:
+def _context(
+    llm_qa_config,
+    *,
+    notes_per_request: int = 2,
+    concurrency: int = 2,
+) -> MaterializedTaskContext:
     task = TaskConfig(
         name="grammar",
         model=ModelSpec(
@@ -80,6 +86,7 @@ def _context(llm_qa_config, *, concurrency: int = 2) -> MaterializedTaskContext:
         ),
         system_prompt="system",
         user_prompt="user",
+        request=TaskRequestOptions(notes_per_request=notes_per_request),
     )
     notes = [
         {
@@ -140,14 +147,16 @@ def test_executor_persists_successful_updates(
     context = _context(llm_qa_config)
     persisted = {}
 
-    async def fake_call_openai(*, candidate, **_kwargs):
-        if candidate.payload.note_key == "nk-1":
-            return _success(
-                _parsed_response(("nk-1", "Question", "Fixed question")),
-                input_tokens=11,
-                output_tokens=5,
-            )
-        return _success(_parsed_response(), input_tokens=7, output_tokens=3)
+    async def fake_call_openai(*, batch, **_kwargs):
+        assert [candidate.payload.note_key for candidate in batch.candidates] == [
+            "nk-1",
+            "nk-2",
+        ]
+        return _success(
+            _parsed_response(("nk-1", "Question", "Fixed question")),
+            input_tokens=12,
+            output_tokens=6,
+        )
 
     def fake_deserialize(data, **_kwargs):
         persisted["data"] = data
@@ -169,9 +178,9 @@ def test_executor_persists_successful_updates(
     assert result.persisted
     assert result.summary.updated == 1
     assert result.summary.unchanged == 1
-    assert result.summary.requests == 2
-    assert result.summary.input_tokens == 18
-    assert result.summary.output_tokens == 8
+    assert result.summary.requests == 1
+    assert result.summary.input_tokens == 12
+    assert result.summary.output_tokens == 6
     assert persisted["data"]["decks"][0]["notes"][0]["fields"]["Question"] == (
         "Fixed question"
     )
@@ -182,7 +191,7 @@ def test_executor_cancels_queued_items_after_fatal_error(
     monkeypatch,
     llm_qa_config,
 ):
-    context = _context(llm_qa_config, concurrency=1)
+    context = _context(llm_qa_config, notes_per_request=1, concurrency=1)
 
     async def fake_call_openai(**_kwargs):
         return _fatal_error()

--- a/tests/unit/llm/test_runner_plan.py
+++ b/tests/unit/llm/test_runner_plan.py
@@ -21,6 +21,8 @@ def test_plan_task_summarizes_scope_surface_and_does_not_persist(
           You are a strict editor.
         user_prompt: |
           Fix grammar.
+        request:
+          notes_per_request: 4
         fields:
           default_access: editable
           read_only:
@@ -66,6 +68,16 @@ def test_plan_task_summarizes_scope_surface_and_does_not_persist(
                                 "AI Notes": "private",
                             },
                         },
+                        {
+                            "note_key": "nk-3",
+                            "note_type": "AnkiOpsQA",
+                            "fields": {
+                                "Question": "another broken question",
+                                "Answer": "another answer",
+                                "Source": "article",
+                                "AI Notes": "private",
+                            },
+                        },
                     ],
                 }
             ]
@@ -84,12 +96,16 @@ def test_plan_task_summarizes_scope_surface_and_does_not_persist(
     assert plan.task_name == "grammar"
     assert plan.summary.decks_seen == 1
     assert plan.summary.decks_matched == 1
-    assert plan.summary.notes_seen == 2
-    assert plan.summary.eligible == 2
+    assert plan.summary.notes_seen == 3
+    assert plan.summary.eligible == 3
     assert plan.requests_estimate == 2
-    assert plan.output_tokens_cap is None
     assert plan.input_tokens_estimate > 0
-    assert plan.format_cost_estimate() == "n/a (max_output_tokens unset)"
+    expected_cost = plan.model.estimate_cost(
+        input_tokens=plan.input_tokens_estimate,
+        output_tokens=plan.input_tokens_estimate,
+    )
+    assert expected_cost is not None
+    assert plan.format_cost_estimate() == expected_cost.format()
     assert "<system>\nYou are a strict editor.\n</system>" in plan.format_full_prompt()
 
     surface_by_type = {surface.note_type: surface for surface in plan.field_surface}


### PR DESCRIPTION
## Summary
- batch LLM execution by note type using request.notes_per_request
- persist provider calls as requests linked to one or more job items
- update plan estimates, bundled task configs, and focused unit coverage

## Tests
- uv run pytest tests/unit/llm/test_config_loader.py tests/unit/llm/test_llm_db.py tests/unit/llm/test_runner_execution.py tests/unit/llm/test_runner_plan.py