### PR TITLE
Report LLM usage by request

### DIFF
--- a/ankiops/llm/commands.py
+++ b/ankiops/llm/commands.py
@@ -9,7 +9,7 @@ import shlex
 import shutil
 import sys
 import textwrap
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
@@ -33,6 +33,7 @@ from ankiops.config import (
 from ankiops.fs import FileSystemAdapter
 
 from .config_loader import load_llm_task_catalog
+from .llm_db import LlmJobRequestNoteRef
 from .model_registry import MODEL_REGISTRY_FILE_NAME
 from .runner import list_jobs as list_llm_jobs
 from .runner import plan_task, run_task, show_job
@@ -227,9 +228,7 @@ def _show_job(
                 item.deck_name,
                 item.note_type or "unknown",
                 item.item_status.value,
-                str(item.attempts),
-                f"{_format_count(item.input_tokens)}/{_format_count(item.output_tokens)}",
-                f"{item.latency_ms / 1000:.2f}s",
+                str(item.request_count),
                 _format_field_list(item.changed_fields),
             ]
         )
@@ -241,9 +240,7 @@ def _show_job(
             "Deck",
             "Type",
             "Final",
-            "Attempts",
-            "Tokens",
-            "Latency",
+            "Requests",
             "Changed",
         ],
         item_rows,
@@ -251,6 +248,30 @@ def _show_job(
     for item in detail.items:
         if item.error_message:
             logger.error("  #%d error=%s", item.ordinal, item.error_message)
+
+    logger.info("")
+    logger.info("Requests:")
+    if not detail.requests:
+        logger.info("  none")
+        return
+
+    request_rows: list[list[str]] = []
+    for request in detail.requests:
+        request_rows.append(
+            [
+                str(request.request_id),
+                request.outcome,
+                f"{_format_count(request.input_tokens)}/{_format_count(request.output_tokens)}",
+                f"{request.latency_ms / 1000:.2f}s",
+                _format_request_notes(request.notes),
+                request.error_message or "-",
+            ]
+        )
+
+    _log_table(
+        ["Request", "Outcome", "Tokens", "Latency", "Notes", "Error"],
+        request_rows,
+    )
 
 
 def _show_status(
@@ -470,6 +491,11 @@ def _usage_error(message: str) -> None:
 
 def _format_field_list(fields: list[str]) -> str:
     return ", ".join(fields) if fields else "-"
+
+
+def _format_request_notes(notes: Iterable[LlmJobRequestNoteRef]) -> str:
+    formatted = [f"#{note.ordinal} {note.note_key or 'unknown'}" for note in notes]
+    return ", ".join(formatted) if formatted else "-"
 
 
 def _format_count(value: int) -> str:

--- a/ankiops/llm/llm_db.py
+++ b/ankiops/llm/llm_db.py
@@ -44,10 +44,25 @@ class LlmJobItemDetail:
     item_status: LlmItemStatus
     error_message: str | None
     changed_fields: list[str]
-    attempts: int
+    request_count: int
+
+
+@dataclass(frozen=True)
+class LlmJobRequestNoteRef:
+    ordinal: int
+    note_key: str | None
+
+
+@dataclass(frozen=True)
+class LlmJobRequestDetail:
+    request_id: int
+    outcome: str
+    error_message: str | None
     input_tokens: int
     output_tokens: int
     latency_ms: int
+    created_at: str
+    notes: tuple[LlmJobRequestNoteRef, ...]
 
 
 @dataclass(frozen=True)
@@ -64,6 +79,7 @@ class LlmJobDetail:
     fatal_error: str | None
     summary: TaskRunSummary
     items: list[LlmJobItemDetail]
+    requests: list[LlmJobRequestDetail]
 
 
 @dataclass(frozen=True)
@@ -446,13 +462,9 @@ class LlmDb:
             f"""
             SELECT i.ordinal, i.note_key, i.deck_name, i.note_type, i.item_status,
                    i.error_message, i.changed_fields_json,
-                   COUNT(r.id) attempts,
-                   COALESCE(SUM(r.input_tokens), 0) input_tokens,
-                   COALESCE(SUM(r.output_tokens), 0) output_tokens,
-                   COALESCE(SUM(r.latency_ms), 0) latency_ms
+                   COUNT(ri.request_id) request_count
             FROM {_ITEM_TABLE} i
             LEFT JOIN {_REQUEST_ITEM_TABLE} ri ON ri.job_item_id = i.id
-            LEFT JOIN {_REQUEST_TABLE} r ON r.id = ri.request_id
             WHERE i.job_id = ?
             GROUP BY i.id
             ORDER BY i.ordinal ASC
@@ -471,12 +483,55 @@ class LlmDb:
                     str(item["error_message"]) if item["error_message"] else None
                 ),
                 changed_fields=_parse_json_list(item["changed_fields_json"]),
-                attempts=int(item["attempts"] or 0),
-                input_tokens=int(item["input_tokens"] or 0),
-                output_tokens=int(item["output_tokens"] or 0),
-                latency_ms=int(item["latency_ms"] or 0),
+                request_count=int(item["request_count"] or 0),
             )
             for item in item_rows
+        ]
+
+        request_rows = self._conn.execute(
+            f"""
+            SELECT r.id request_id, r.outcome, r.error_message, r.input_tokens,
+                   r.output_tokens, r.latency_ms, r.created_at,
+                   i.ordinal, i.note_key
+            FROM {_REQUEST_TABLE} r
+            LEFT JOIN {_REQUEST_ITEM_TABLE} ri ON ri.request_id = r.id
+            LEFT JOIN {_ITEM_TABLE} i ON i.id = ri.job_item_id
+            WHERE r.job_id = ?
+            ORDER BY r.id ASC, i.ordinal ASC
+            """,
+            (job_id,),
+        ).fetchall()
+        request_metadata: dict[int, sqlite3.Row] = {}
+        request_notes: dict[int, list[LlmJobRequestNoteRef]] = {}
+        for request in request_rows:
+            request_id = int(request["request_id"])
+            if request_id not in request_metadata:
+                request_metadata[request_id] = request
+                request_notes[request_id] = []
+            if request["ordinal"] is not None:
+                request_notes[request_id].append(
+                    LlmJobRequestNoteRef(
+                        ordinal=int(request["ordinal"]),
+                        note_key=(
+                            str(request["note_key"]) if request["note_key"] else None
+                        ),
+                    )
+                )
+
+        requests = [
+            LlmJobRequestDetail(
+                request_id=request_id,
+                outcome=str(request["outcome"]),
+                error_message=(
+                    str(request["error_message"]) if request["error_message"] else None
+                ),
+                input_tokens=int(request["input_tokens"] or 0),
+                output_tokens=int(request["output_tokens"] or 0),
+                latency_ms=int(request["latency_ms"] or 0),
+                created_at=str(request["created_at"]),
+                notes=tuple(request_notes[request_id]),
+            )
+            for request_id, request in request_metadata.items()
         ]
 
         return LlmJobDetail(
@@ -492,6 +547,7 @@ class LlmDb:
             fatal_error=(str(row["fatal_error"]) if row["fatal_error"] else None),
             summary=aggregate.summary,
             items=items,
+            requests=requests,
         )
 
     def _create_schema(self) -> None:
@@ -599,9 +655,7 @@ class LlmDb:
         required_request_item_columns = {"request_id", "job_item_id"}
         request_item_columns = {
             str(row["name"])
-            for row in self._conn.execute(
-                f"PRAGMA table_info({_REQUEST_ITEM_TABLE})"
-            )
+            for row in self._conn.execute(f"PRAGMA table_info({_REQUEST_ITEM_TABLE})")
         }
         if (
             required_request_columns - request_columns

--- a/ankiops/llm/runner.py
+++ b/ankiops/llm/runner.py
@@ -80,7 +80,7 @@ class OpenAIResult:
 class EligibleBatch:
     note_type: str
     note_type_config: NoteTypeConfig
-    candidates: list[EligibleCandidate]
+    candidates: tuple[EligibleCandidate, ...]
 
     @property
     def item_ids(self) -> list[int]:
@@ -914,7 +914,7 @@ def _build_candidate_batches(
                 EligibleBatch(
                     note_type=note_type,
                     note_type_config=chunk[0].note_type_config,
-                    candidates=chunk,
+                    candidates=tuple(chunk),
                 )
             )
     return batches
@@ -1087,24 +1087,6 @@ def _openai_error_result(
     )
 
 
-def _apply_parsed_response(
-    *,
-    parsed_response: object,
-    candidate: EligibleCandidate,
-) -> list[str]:
-    updates = parsed_updates(parsed_response)
-    unexpected_note_keys = sorted(
-        {note_key for note_key, _field_name, _value in updates}
-        - {candidate.payload.note_key}
-    )
-    if unexpected_note_keys:
-        raise ValueError(
-            "Model returned update for unexpected note_key "
-            f"'{unexpected_note_keys[0]}'"
-        )
-    return _apply_candidate_updates(candidate=candidate, updates=updates)
-
-
 def _apply_batch_parsed_response(
     *,
     parsed_response: object,
@@ -1123,8 +1105,7 @@ def _apply_batch_parsed_response(
     )
     if unexpected_note_keys:
         raise ValueError(
-            "Model returned update for unexpected note_key "
-            f"'{unexpected_note_keys[0]}'"
+            f"Model returned update for unexpected note_key '{unexpected_note_keys[0]}'"
         )
 
     updates_by_note_key: dict[str, list[tuple[str, str, str]]] = {

--- a/tests/unit/llm/test_llm_db.py
+++ b/tests/unit/llm/test_llm_db.py
@@ -68,6 +68,70 @@ def test_write_tx_rolls_back_request(tmp_path):
         db.close()
 
 
+def test_get_job_detail_reports_usage_at_request_level(tmp_path):
+    db = LlmDb.open(tmp_path)
+    try:
+        job_id = _start_job(db)
+        first_id = db.insert_job_item(
+            job_id=job_id,
+            ordinal=1,
+            deck_name="Deck",
+            note_key="nk-1",
+            note_type="AnkiOpsQA",
+            item_status=LlmItemStatus.SUCCEEDED_UPDATED,
+            skip_reason=None,
+            changed_fields=["Question"],
+        )
+        second_id = db.insert_job_item(
+            job_id=job_id,
+            ordinal=2,
+            deck_name="Deck",
+            note_key="nk-2",
+            note_type="AnkiOpsQA",
+            item_status=LlmItemStatus.SUCCEEDED_UNCHANGED,
+            skip_reason=None,
+        )
+        request_id = db.insert_request(
+            job_id=job_id,
+            item_ids=[second_id, first_id],
+            outcome="success",
+            request_json={"model": "gpt-test"},
+            parsed_response_json={"updates": []},
+            response_json="{}",
+            error_message=None,
+            latency_ms=101,
+            input_tokens=5,
+            output_tokens=2,
+        )
+
+        detail = db.get_job_detail(job_id)
+    finally:
+        db.close()
+
+    assert detail is not None
+    assert [(item.ordinal, item.request_count) for item in detail.items] == [
+        (1, 1),
+        (2, 1),
+    ]
+    assert not hasattr(detail.items[0], "input_tokens")
+    assert not hasattr(detail.items[0], "latency_ms")
+    assert detail.summary.requests == 1
+    assert detail.summary.input_tokens == 5
+    assert detail.summary.output_tokens == 2
+    assert detail.summary.provider_latency_ms_total == 101
+    assert len(detail.requests) == 1
+    request = detail.requests[0]
+    assert request.request_id == request_id
+    assert request.outcome == "success"
+    assert request.input_tokens == 5
+    assert request.output_tokens == 2
+    assert request.latency_ms == 101
+    assert [(note.ordinal, note.note_key) for note in request.notes] == [
+        (1, "nk-1"),
+        (2, "nk-2"),
+    ]
+
+
 def test_mark_unfinished_items_canceled_only_updates_queued(tmp_path):
     db = LlmDb.open(tmp_path)
     try:

--- a/tests/unit/llm/test_schemas.py
+++ b/tests/unit/llm/test_schemas.py
@@ -7,9 +7,9 @@ from types import SimpleNamespace
 import pytest
 from pydantic import ValidationError
 
-from ankiops.llm.runner import _apply_parsed_response
+from ankiops.llm.runner import EligibleBatch, _apply_batch_parsed_response
 from ankiops.llm.schemas import build_response_model
-from ankiops.llm.types import EligibleCandidate, NotePayload
+from ankiops.llm.types import EligibleCandidate, LlmItemStatus, NotePayload
 
 
 def _parsed_response(*updates):
@@ -45,6 +45,14 @@ def _candidate(llm_qa_config) -> EligibleCandidate:
     )
 
 
+def _batch(candidate: EligibleCandidate) -> EligibleBatch:
+    return EligibleBatch(
+        note_type=candidate.payload.note_type,
+        note_type_config=candidate.note_type_config,
+        candidates=(candidate,),
+    )
+
+
 def test_response_model_accepts_only_known_note_keys_and_editable_fields():
     response_model = build_response_model(
         note_type="AnkiOpsQA",
@@ -70,15 +78,18 @@ def test_response_model_accepts_only_known_note_keys_and_editable_fields():
         )
 
 
-def test_apply_parsed_response_updates_editable_fields(llm_qa_config):
+def test_apply_batch_parsed_response_updates_editable_fields(llm_qa_config):
     candidate = _candidate(llm_qa_config)
 
-    changed_fields = _apply_parsed_response(
+    results = _apply_batch_parsed_response(
         parsed_response=_parsed_response(("nk-1", "Question", "Fixed question")),
-        candidate=candidate,
+        batch=_batch(candidate),
     )
 
-    assert changed_fields == ["Question"]
+    assert len(results) == 1
+    assert results[0].status is LlmItemStatus.SUCCEEDED_UPDATED
+    assert results[0].changed_fields == ["Question"]
+    assert results[0].error_message is None
     assert candidate.serialized_note["fields"] == {
         "Question": "Fixed question",
         "Answer": "Existing answer",
@@ -87,13 +98,17 @@ def test_apply_parsed_response_updates_editable_fields(llm_qa_config):
     }
 
 
+def test_apply_batch_parsed_response_rejects_unexpected_note_key(llm_qa_config):
+    with pytest.raises(ValueError, match="unexpected note_key 'nk-2'"):
+        _apply_batch_parsed_response(
+            parsed_response=_parsed_response(("nk-2", "Question", "Fixed question")),
+            batch=_batch(_candidate(llm_qa_config)),
+        )
+
+
 @pytest.mark.parametrize(
     ("updates", "expected_error"),
     [
-        (
-            [("nk-2", "Question", "Fixed question")],
-            "unexpected note_key 'nk-2'",
-        ),
         (
             [
                 ("nk-1", "Question", "Fixed question"),
@@ -111,13 +126,18 @@ def test_apply_parsed_response_updates_editable_fields(llm_qa_config):
         ),
     ],
 )
-def test_apply_parsed_response_rejects_unsafe_updates(
+def test_apply_batch_parsed_response_marks_unsafe_candidate_updates(
     llm_qa_config,
     updates,
     expected_error,
 ):
-    with pytest.raises(ValueError, match=expected_error):
-        _apply_parsed_response(
-            parsed_response=_parsed_response(*updates),
-            candidate=_candidate(llm_qa_config),
-        )
+    results = _apply_batch_parsed_response(
+        parsed_response=_parsed_response(*updates),
+        batch=_batch(_candidate(llm_qa_config)),
+    )
+
+    assert len(results) == 1
+    assert results[0].status is LlmItemStatus.NOTE_ERROR
+    assert results[0].changed_fields == []
+    assert results[0].error_message is not None
+    assert expected_error in results[0].error_message


### PR DESCRIPTION
## Summary
- move job detail usage reporting to exact request-level rows
- keep item rows focused on note outcome plus linked request count
- make batched candidates tuple-backed and move schema tests onto the live batch apply path

## Tests
- uv run pytest tests/unit/llm
- uv run ruff check ankiops/llm/llm_db.py ankiops/llm/commands.py ankiops/llm/runner.py tests/unit/llm/test_schemas.py tests/unit/llm/test_llm_db.py
- uv run ruff format --check ankiops/llm/llm_db.py ankiops/llm/commands.py ankiops/llm/runner.py tests/unit/llm/test_schemas.py tests/unit/llm/test_llm_db.py
- uv run pytest

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restructures how LLM usage metrics are reported: token counts and latency are moved from the per-item row in job detail to a new per-request section, and item rows now only show a linked request count. The `EligibleBatch.candidates` field is changed from `list` to `tuple` to better match its frozen-dataclass ownership semantics, and the now-redundant `_apply_parsed_response` helper is removed in favour of `_apply_batch_parsed_response`.

- **`llm_db.py`**: Adds `LlmJobRequestDetail` and `LlmJobRequestNoteRef` dataclasses; `get_job_detail` now issues a second SQL query that groups token/latency data at the request level and associates each request with its note refs via `_REQUEST_ITEM_TABLE`.
- **`commands.py`**: Updates `_show_job` to render a separate Requests table (with token, latency, note refs, and error columns) after the Items table; removes the old per-item Attempts/Tokens/Latency columns.
- **`runner.py` / `test_schemas.py`**: `EligibleBatch.candidates` narrowed to `tuple`; schema tests migrated from the removed `_apply_parsed_response` to `_apply_batch_parsed_response`, preserving coverage of both the success and error paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the refactor is well-scoped and all callers of the changed dataclass fields are updated consistently.

The changes touch only the job-detail read path and the CLI display layer. The two SQL queries are correct against the existing schema, the dict-based grouping correctly handles multi-item requests, and the tuple narrowing on EligibleBatch.candidates is backward-compatible with every iteration-only call site. The new test covers note-ref ordering with an intentionally reversed insertion order, confirming the ORDER BY i.ordinal ASC clause does its job.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ankiops/llm/llm_db.py | Adds two new frozen dataclasses and a second SQL query in get_job_detail that fetches per-request data with LEFT-JOINed note refs; logic for assembling note-ref lists is correct. |
| ankiops/llm/commands.py | Removes per-item token/latency columns, adds a Requests section to _show_job; early-return when requests is empty is safe. |
| ankiops/llm/runner.py | Narrows EligibleBatch.candidates from list to tuple; all callers are iteration-only so the change is backward-compatible; removes dead _apply_parsed_response helper. |
| tests/unit/llm/test_llm_db.py | Adds test covering per-request token/latency fields, request_count on items, and note-ref ordering with reversed insertion order. |
| tests/unit/llm/test_schemas.py | Tests migrated from _apply_parsed_response to _apply_batch_parsed_response; adds dedicated unexpected-note-key test; parametrized tests now assert on result status instead of raised exceptions. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CLI as _show_job (commands.py)
    participant DB as LlmDb.get_job_detail
    participant ITEM_Q as Item SQL query
    participant REQ_Q as Request SQL query

    CLI->>DB: get_job_detail(job_id)
    DB->>ITEM_Q: SELECT items + COUNT(request_ids)
    ITEM_Q-->>DB: rows → list[LlmJobItemDetail(request_count)]
    DB->>REQ_Q: SELECT requests + LEFT JOIN items (ordinal, note_key)
    REQ_Q-->>DB: rows ordered by r.id ASC, i.ordinal ASC
    DB->>DB: Group rows into request_metadata + request_notes dicts
    DB-->>CLI: LlmJobDetail(items, requests)
    CLI->>CLI: Render Items table (ordinal, status, request_count)
    CLI->>CLI: Render Requests table (id, outcome, tokens, latency, notes, error)
```
</details>

<sub>Reviews (1): Last reviewed commit: ["report llm usage by request"](https://github.com/visserle/ankiops/commit/90c0fc190c648ac34f5fb92fa07530e576780c25) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32892472)</sub>

<!-- /greptile_comment -->