### PR TITLE
improve math delimiters

### DIFF
--- a/ankiops/markdown_converter.py
+++ b/ankiops/markdown_converter.py
@@ -12,7 +12,10 @@ from pygments.lexers import get_lexer_by_name
 from pygments.util import ClassNotFound
 
 from ankiops.config import LOCAL_MEDIA_DIR
-from ankiops.math_delimiters import normalize_escaped_math_delimiters
+from ankiops.math_delimiters import (
+    normalize_escaped_math_delimiters,
+    preserve_math_delimiters_plugin,
+)
 
 _IMG_WIDTH_RE = re.compile(r'(<img src="[^"]*" alt="[^"]*")>\{width=(\d+)\}')
 # Rewrite [text](url_with_(parens)) to [text](<url>) so mistune doesn't
@@ -23,52 +26,6 @@ _LINK_WITH_PARENS_RE = re.compile(
     r"\)"
 )
 _PYGMENTS_FORMATTER = HtmlFormatter(nowrap=True)
-_INLINE_MATH_PAREN_PATTERN = r"\\\((?P<ipm_text>[\s\S]+?)\\\)"
-_INLINE_MATH_BRACKET_PATTERN = r"\\\[(?P<ibm_text>[\s\S]+?)\\\]"
-_BLOCK_MATH_PATTERN = r"^\\\[(?P<bm_text>[\s\S]+?)\\\][ \t]*$"
-
-
-def _math_plugin(md):
-    """Preserve LaTeX math delimiters \\(...\\) and \\[...\\] through parsing."""
-
-    def _parse_token(token_type, group_name):
-        def parser(_, regex_match, state):
-            state.append_token(
-                {"type": token_type, "raw": regex_match.group(group_name)}
-            )
-            return regex_match.end()
-
-        return parser
-
-    def _parse_block(_, regex_match, state):
-        state.append_token({"type": "block_math", "raw": regex_match.group("bm_text")})
-        return regex_match.end() + 1
-
-    md.inline.register(
-        "inline_math_paren",
-        _INLINE_MATH_PAREN_PATTERN,
-        _parse_token("inline_math_paren", "ipm_text"),
-        before="escape",
-    )
-    md.inline.register(
-        "inline_math_bracket",
-        _INLINE_MATH_BRACKET_PATTERN,
-        _parse_token("inline_math_bracket", "ibm_text"),
-        before="escape",
-    )
-    md.block.register("block_math", _BLOCK_MATH_PATTERN, _parse_block, before="list")
-    if md.renderer and md.renderer.NAME == "html":
-        md.renderer.register(
-            "inline_math_paren",
-            lambda _, token_text: "\\(" + token_text + "\\)",
-        )
-        md.renderer.register(
-            "inline_math_bracket",
-            lambda _, token_text: "\\[" + token_text + "\\]",
-        )
-        md.renderer.register(
-            "block_math", lambda _, token_text: "\\[" + token_text + "\\]"
-        )
 
 
 class AnkiRenderer(mistune.HTMLRenderer):
@@ -152,7 +109,7 @@ class MarkdownToHTML:
                 strikethrough,
                 superscript,
                 subscript,
-                _math_plugin,
+                preserve_math_delimiters_plugin,
             ],
         )
 

--- a/ankiops/math_delimiters.py
+++ b/ankiops/math_delimiters.py
@@ -3,31 +3,87 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
+from typing import Any
 
-_ESCAPED_INLINE_MATH_PAREN_PATTERN = re.compile(
-    r"\\{1,}\((?P<ipm_text>(?:(?!\\{1,}\))[\s\S])+?)\\{1,}\)"
+_PAREN_DELIMITED_MATH_PATTERN = r"\\\((?P<paren_math_body>[\s\S]+?)\\\)"
+_BRACKET_DELIMITED_MATH_PATTERN = r"\\\[(?P<bracket_math_body>[\s\S]+?)\\\]"
+_BLOCK_BRACKET_DELIMITED_MATH_PATTERN = (
+    r"^\\\[(?P<block_math_body>[\s\S]+?)\\\][ \t]*$"
 )
-_ESCAPED_INLINE_MATH_BRACKET_PATTERN = re.compile(
-    r"\\{1,}\[(?P<ibm_text>(?:(?!\\{1,}\])[\s\S])+?)\\{1,}\]"
+_ESCAPED_PAREN_DELIMITED_MATH_RE = re.compile(
+    r"\\{1,}\((?P<escaped_paren_math_body>(?:(?!\\{1,}\))[\s\S])+?)\\{1,}\)"
 )
-_MATH_BODY_HINT_PATTERN = re.compile(r"(\\[A-Za-z]+|[_^{}])")
+_ESCAPED_BRACKET_DELIMITED_MATH_RE = re.compile(
+    r"\\{1,}\[(?P<escaped_bracket_math_body>(?:(?!\\{1,}\])[\s\S])+?)\\{1,}\]"
+)
+_MATH_CONTENT_HINT_RE = re.compile(r"(\\[A-Za-z]+|[_^{}])")
+
+
+def preserve_math_delimiters_plugin(md: Any) -> None:
+    """Preserve LaTeX math delimiters \\(...\\) and \\[...\\] through Mistune."""
+
+    def _parse_token(
+        token_type: str, body_group_name: str
+    ) -> Callable[[Any, re.Match[str], Any], int]:
+        def parser(_: Any, regex_match: re.Match[str], state: Any) -> int:
+            state.append_token(
+                {"type": token_type, "raw": regex_match.group(body_group_name)}
+            )
+            return regex_match.end()
+
+        return parser
+
+    def _parse_block(_: Any, regex_match: re.Match[str], state: Any) -> int:
+        state.append_token(
+            {"type": "block_math", "raw": regex_match.group("block_math_body")}
+        )
+        return regex_match.end() + 1
+
+    md.inline.register(
+        "inline_math_paren",
+        _PAREN_DELIMITED_MATH_PATTERN,
+        _parse_token("inline_math_paren", "paren_math_body"),
+        before="escape",
+    )
+    md.inline.register(
+        "inline_math_bracket",
+        _BRACKET_DELIMITED_MATH_PATTERN,
+        _parse_token("inline_math_bracket", "bracket_math_body"),
+        before="escape",
+    )
+    md.block.register(
+        "block_math", _BLOCK_BRACKET_DELIMITED_MATH_PATTERN, _parse_block, before="list"
+    )
+    if md.renderer and md.renderer.NAME == "html":
+        md.renderer.register(
+            "inline_math_paren",
+            lambda _, token_text: "\\(" + token_text + "\\)",
+        )
+        md.renderer.register(
+            "inline_math_bracket",
+            lambda _, token_text: "\\[" + token_text + "\\]",
+        )
+        md.renderer.register(
+            "block_math", lambda _, token_text: "\\[" + token_text + "\\]"
+        )
 
 
 def normalize_escaped_math_delimiters(text: str) -> str:
     """Canonicalize escaped math delimiter runs to single-escaped form."""
 
     def _replace_paren(match: re.Match[str]) -> str:
-        body = match.group("ipm_text")
-        if not _MATH_BODY_HINT_PATTERN.search(body):
+        body = match.group("escaped_paren_math_body")
+        if not _MATH_CONTENT_HINT_RE.search(body):
             return match.group(0)
         return "\\(" + body + "\\)"
 
     def _replace_bracket(match: re.Match[str]) -> str:
-        body = match.group("ibm_text")
-        if not _MATH_BODY_HINT_PATTERN.search(body):
+        body = match.group("escaped_bracket_math_body")
+        if not _MATH_CONTENT_HINT_RE.search(body):
             return match.group(0)
         return "\\[" + body + "\\]"
 
-    text = _ESCAPED_INLINE_MATH_PAREN_PATTERN.sub(_replace_paren, text)
-    text = _ESCAPED_INLINE_MATH_BRACKET_PATTERN.sub(_replace_bracket, text)
+    text = _ESCAPED_PAREN_DELIMITED_MATH_RE.sub(_replace_paren, text)
+    text = _ESCAPED_BRACKET_DELIMITED_MATH_RE.sub(_replace_bracket, text)
     return text


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the LaTeX math delimiter handling by moving the Mistune plugin (`_math_plugin`) from `markdown_converter.py` into `math_delimiters.py` and renaming it `preserve_math_delimiters_plugin`, co-locating all math-related logic in one module.

- Pattern constants and named capture groups are renamed for clarity (`ipm_text` → `paren_math_body`, `ibm_text` → `bracket_math_body`, etc.), and the escaped-delimiter compiled patterns get the same treatment.
- Type annotations (`Any`, `Callable`) are added to the plugin function and its inner helpers.
- `markdown_converter.py` drops the four private pattern constants and the old `_math_plugin` definition, instead importing the equivalent from `math_delimiters`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a straightforward code reorganization with no behavioural changes.

All logic migrated from markdown_converter.py to math_delimiters.py is identical to the original; the only changes are renamed capture groups (consistently updated in both patterns and the code that reads them), added type annotations, and the new public function name. No regex semantics were altered and no new code paths were introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ankiops/math_delimiters.py | Receives the migrated Mistune plugin (renamed preserve_math_delimiters_plugin) with updated capture-group names; also renames the compiled escaped-delimiter patterns and the hint regex — all logic preserved from original. |
| ankiops/markdown_converter.py | Removes the inlined _math_plugin and four private pattern constants, adds preserve_math_delimiters_plugin to the imports, and passes it to mistune.create_markdown — no behavioural changes. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Raw Markdown input] --> B[normalize_escaped_math_delimiters]
    B --> |"\\(...\\) / \\[...\\] with hints normalized to single-escaped form"| C[mistune.create_markdown]
    C --> D{Mistune parsing}
    D --> |"block parser"| E["block_math token\n_BLOCK_BRACKET_DELIMITED_MATH_PATTERN"]
    D --> |"inline parser"| F["inline_math_paren token\n_PAREN_DELIMITED_MATH_PATTERN"]
    D --> |"inline parser"| G["inline_math_bracket token\n_BRACKET_DELIMITED_MATH_PATTERN"]
    E --> H["AnkiRenderer → \\[body\\]"]
    F --> I["AnkiRenderer → \\(body\\)"]
    G --> J["AnkiRenderer → \\[body\\]"]
    H --> K[Final HTML]
    I --> K
    J --> K
```
</details>

<sub>Reviews (1): Last reviewed commit: ["improve math delimiters"](https://github.com/visserle/ankiops/commit/b4b8b7679a126ab52299c8edb173c5b75094c06d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33984693)</sub>

<!-- /greptile_comment -->