### PR TITLE
add img width fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,13 @@ Yes! We welcome contributions of all kinds, including bug fixes, new features, d
 - `--input`, `-i` - Input file path (default: `AnkiCollection.json`)
 - `--overwrite` - Overwrite existing markdown files
 
+**`fix-image-widths`:**
+- `--deck` - Fix only one deck (includes subdecks by default)
+- `--no-subdecks` - With `--deck`, exclude subdecks (exact deck only)
+- `--tolerance` - Pixel tolerance for near-equal width fixes (default: `5`)
+- `--width` - Force all Markdown images in scope to this width
+- `--no-auto-commit`, `-n` - Skip automatic git commit
+
 **`llm`:**
 - `ankiops llm` - Show LLM status dashboard (tasks + recent jobs)
 - `ankiops llm <task_name> [--model <model>] [--deck <deck_name>]` - Plan one configured task

--- a/ankiops/cli.py
+++ b/ankiops/cli.py
@@ -16,6 +16,7 @@ from ankiops.db import SQLiteDbAdapter
 from ankiops.export_notes import export_collection
 from ankiops.fs import FileSystemAdapter
 from ankiops.git import git_snapshot
+from ankiops.image_widths import fix_image_widths_collection
 from ankiops.import_notes import import_collection
 from ankiops.init import create_tutorial, initialize_collection
 from ankiops.llm.commands import configure_llm_parser
@@ -38,6 +39,20 @@ from ankiops.sync_media import (
 from ankiops.sync_note_types import sync_note_types
 
 logger = logging.getLogger(__name__)
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def _non_negative_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be a non-negative integer")
+    return parsed
 
 
 def run_init(args):
@@ -274,6 +289,48 @@ def run_deserialize(args):
     )
 
 
+def run_fix_image_widths(args):
+    """Fix Markdown image width annotations in local deck files."""
+    if args.no_subdecks and not args.deck:
+        logger.error("--no-subdecks requires --deck")
+        raise SystemExit(2)
+
+    collection_dir = require_collection_dir()
+
+    if not args.no_auto_commit:
+        logger.debug("Creating pre-image-width-fix git snapshot")
+        git_snapshot(collection_dir, "fix-image-widths")
+    else:
+        logger.debug("Auto-commit disabled (--no-auto-commit)")
+
+    try:
+        result = fix_image_widths_collection(
+            collection_dir,
+            deck=args.deck,
+            no_subdecks=args.no_subdecks,
+            tolerance=args.tolerance,
+            width=args.width,
+        )
+    except ValueError as error:
+        logger.error(str(error))
+        raise SystemExit(1) from error
+
+    mode = (
+        f"forced width {args.width}px"
+        if args.width is not None
+        else f"auto tolerance ±{args.tolerance}px"
+    )
+    logger.info(
+        "Image widths: "
+        f"{result.decks_checked} decks, {result.notes_checked} notes, "
+        f"{result.images_checked} images checked ({mode}) — "
+        f"{result.decks_changed} decks, {result.notes_changed} notes, "
+        f"{result.images_changed} images changed"
+    )
+    if result.changed:
+        logger.info("Only local Markdown files were edited. Run 'ankiops ma' to sync.")
+
+
 def run_llm(args):
     """Delegates LLM command handling to the LLM CLI module."""
     run_llm_impl(
@@ -398,6 +455,39 @@ def main():
     )
     deserialize_parser.set_defaults(handler=run_deserialize)
 
+    # Image width fixer parser
+    fix_widths_parser = subparsers.add_parser(
+        "fix-image-widths",
+        help="Normalize or force Markdown image widths via local file edits)",
+    )
+    fix_widths_parser.add_argument(
+        "--deck",
+        help="Fix only this deck (includes subdecks by default)",
+    )
+    fix_widths_parser.add_argument(
+        "--no-subdecks",
+        action="store_true",
+        help="With --deck, fix only the exact deck (exclude subdecks)",
+    )
+    fix_widths_parser.add_argument(
+        "--tolerance",
+        type=_non_negative_int,
+        default=5,
+        help="Pixel tolerance for auto mode (default: 5)",
+    )
+    fix_widths_parser.add_argument(
+        "--width",
+        type=_positive_int,
+        help="Force every Markdown image in scope to this width in pixels",
+    )
+    fix_widths_parser.add_argument(
+        "--no-auto-commit",
+        "-n",
+        action="store_true",
+        help="Skip the automatic git commit for this operation",
+    )
+    fix_widths_parser.set_defaults(handler=run_fix_image_widths)
+
     configure_llm_parser(subparsers, handler=run_llm)
 
     note_types_parser = subparsers.add_parser(
@@ -446,6 +536,7 @@ def main():
         print("  markdown-to-anki  Import Markdown files into Anki (alias: ma)")
         print("  serialize         Serialize Markdown decks to JSON format")
         print("  deserialize       Deserialize JSON file to Markdown decks")
+        print("  fix-image-widths  Normalize or force Markdown image widths")
         print("  llm               Status/plan/run LLM jobs and inspect one LLM job")
         print("  note-types        List note type labels or add note types from Anki")
         print()
@@ -468,6 +559,10 @@ def main():
         print(
             "  ankiops deserialize -i my-deck.json          "
             "# Deserialize file to markdown"
+        )
+        print(
+            "  ankiops fix-image-widths                     "
+            "# Normalize near-equal image widths"
         )
         print(
             "  ankiops llm                                  "

--- a/ankiops/cli.py
+++ b/ankiops/cli.py
@@ -458,7 +458,7 @@ def main():
     # Image width fixer parser
     fix_widths_parser = subparsers.add_parser(
         "fix-image-widths",
-        help="Normalize or force Markdown image widths via local file edits)",
+        help="Normalize or force Markdown image widths via local file edits",
     )
     fix_widths_parser.add_argument(
         "--deck",

--- a/ankiops/image_widths.py
+++ b/ankiops/image_widths.py
@@ -1,0 +1,194 @@
+"""Fix Markdown image widths in serialized AnkiOps decks."""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ankiops.config import NOTE_TYPES_DIR
+from ankiops.serializer import deserialize, serialize
+
+logger = logging.getLogger(__name__)
+
+_MARKDOWN_IMAGE_RE = re.compile(
+    r"(?P<image>!\[[^\]\n]*\]\((?:<[^>\n]*>|[^\)\n]*)\))"
+    r"(?P<width>\{width=(?P<width_value>\d+)\})?"
+)
+
+
+@dataclass
+class ImageWidthFixResult:
+    """Summary for a fix-image-widths run."""
+
+    decks_checked: int = 0
+    notes_checked: int = 0
+    images_checked: int = 0
+    decks_changed: int = 0
+    notes_changed: int = 0
+    images_changed: int = 0
+
+    @property
+    def changed(self) -> bool:
+        return self.images_changed > 0
+
+
+def _replacement_with_width(match: re.Match[str], width: int) -> str:
+    return f"{match.group('image')}{{width={width}}}"
+
+
+def _force_field_width(field_content: str, width: int) -> tuple[str, int, int]:
+    images_checked = 0
+    images_changed = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal images_checked, images_changed
+        images_checked += 1
+        current = match.group("width_value")
+        if current != str(width):
+            images_changed += 1
+        return _replacement_with_width(match, width)
+
+    return (
+        _MARKDOWN_IMAGE_RE.sub(replace, field_content),
+        images_checked,
+        images_changed,
+    )
+
+
+def _cluster_target(width: int, clusters: list[int], tolerance: int) -> int:
+    for cluster_width in clusters:
+        if abs(width - cluster_width) <= tolerance:
+            return cluster_width
+    clusters.append(width)
+    return width
+
+
+def _normalize_field_widths(
+    field_content: str,
+    *,
+    clusters: list[int],
+    tolerance: int,
+) -> tuple[str, int, int]:
+    images_checked = 0
+    images_changed = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal images_checked, images_changed
+        images_checked += 1
+        width_value = match.group("width_value")
+        if width_value is None:
+            return match.group(0)
+
+        width = int(width_value)
+        target_width = _cluster_target(width, clusters, tolerance)
+        if width == target_width:
+            return match.group(0)
+
+        images_changed += 1
+        return _replacement_with_width(match, target_width)
+
+    return (
+        _MARKDOWN_IMAGE_RE.sub(replace, field_content),
+        images_checked,
+        images_changed,
+    )
+
+
+def fix_image_widths_in_data(
+    data: dict[str, Any],
+    *,
+    tolerance: int,
+    width: int | None = None,
+) -> ImageWidthFixResult:
+    """Fix Markdown image widths in a serialized AnkiOps collection mapping."""
+    result = ImageWidthFixResult()
+    decks = data.get("decks")
+    if not isinstance(decks, list):
+        return result
+
+    for deck in decks:
+        if not isinstance(deck, dict):
+            continue
+
+        result.decks_checked += 1
+        deck_changed = False
+        notes = deck.get("notes")
+        if not isinstance(notes, list):
+            continue
+
+        for note in notes:
+            if not isinstance(note, dict):
+                continue
+
+            result.notes_checked += 1
+            note_changed = False
+            clusters: list[int] = []
+            fields = note.get("fields")
+            if not isinstance(fields, dict):
+                continue
+
+            for field_name, field_content in list(fields.items()):
+                if not isinstance(field_content, str):
+                    continue
+
+                if width is None:
+                    new_content, checked, changed = _normalize_field_widths(
+                        field_content,
+                        clusters=clusters,
+                        tolerance=tolerance,
+                    )
+                else:
+                    new_content, checked, changed = _force_field_width(
+                        field_content,
+                        width,
+                    )
+
+                result.images_checked += checked
+                result.images_changed += changed
+
+                if new_content != field_content:
+                    fields[field_name] = new_content
+                    note_changed = True
+
+            if note_changed:
+                result.notes_changed += 1
+                deck_changed = True
+
+        if deck_changed:
+            result.decks_changed += 1
+
+    return result
+
+
+def fix_image_widths_collection(
+    collection_dir: Path,
+    *,
+    deck: str | None = None,
+    no_subdecks: bool = False,
+    tolerance: int = 5,
+    width: int | None = None,
+    note_types_dir: Path | None = None,
+) -> ImageWidthFixResult:
+    """Serialize, fix image widths, and rewrite changed scoped decks."""
+    resolved_note_types_dir = note_types_dir or (collection_dir / NOTE_TYPES_DIR)
+    data = serialize(
+        collection_dir,
+        deck=deck,
+        no_subdecks=no_subdecks,
+        note_types_dir=resolved_note_types_dir,
+    )
+    result = fix_image_widths_in_data(data, tolerance=tolerance, width=width)
+
+    if result.changed:
+        deserialize(
+            data,
+            collection_dir=collection_dir,
+            note_types_dir=resolved_note_types_dir,
+            overwrite=True,
+            quiet=True,
+        )
+
+    return result

--- a/tests/integration/cli/test_cli_sync.py
+++ b/tests/integration/cli/test_cli_sync.py
@@ -8,8 +8,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from ankiops.anki_client import AnkiConnectError
-from ankiops.cli import main, run_am, run_ma, run_serialize
+from ankiops.cli import main, run_am, run_fix_image_widths, run_ma, run_serialize
 from ankiops.config import ANKIOPS_DB, deck_name_to_file_stem
+from ankiops.image_widths import ImageWidthFixResult
 from ankiops.models import (
     Change,
     ChangeType,
@@ -362,5 +363,83 @@ def test_run_serialize_rejects_no_subdecks_without_deck(tmp_path):
     with patch("ankiops.cli.require_collection_dir", return_value=tmp_path):
         with pytest.raises(SystemExit) as exc:
             run_serialize(args)
+
+    assert exc.value.code == 2
+
+
+def test_run_fix_image_widths_passes_deck_scope_and_snapshots(tmp_path):
+    args = SimpleNamespace(
+        deck="Parent",
+        no_subdecks=True,
+        tolerance=7,
+        width=None,
+        no_auto_commit=False,
+    )
+    result = ImageWidthFixResult(
+        decks_checked=1,
+        notes_checked=2,
+        images_checked=3,
+        decks_changed=1,
+        notes_changed=1,
+        images_changed=1,
+    )
+
+    with (
+        patch("ankiops.cli.require_collection_dir", return_value=tmp_path),
+        patch("ankiops.cli.git_snapshot") as snapshot_mock,
+        patch(
+            "ankiops.cli.fix_image_widths_collection",
+            return_value=result,
+        ) as fix_mock,
+    ):
+        run_fix_image_widths(args)
+
+    snapshot_mock.assert_called_once_with(tmp_path, "fix-image-widths")
+    fix_mock.assert_called_once_with(
+        tmp_path,
+        deck="Parent",
+        no_subdecks=True,
+        tolerance=7,
+        width=None,
+    )
+
+
+def test_run_fix_image_widths_can_skip_snapshot_and_logs_sync_reminder(
+    tmp_path, caplog
+):
+    args = SimpleNamespace(
+        deck=None,
+        no_subdecks=False,
+        tolerance=5,
+        width=320,
+        no_auto_commit=True,
+    )
+    result = ImageWidthFixResult(images_changed=2)
+
+    with (
+        patch("ankiops.cli.require_collection_dir", return_value=tmp_path),
+        patch("ankiops.cli.git_snapshot") as snapshot_mock,
+        patch("ankiops.cli.fix_image_widths_collection", return_value=result),
+        caplog.at_level(logging.INFO),
+    ):
+        run_fix_image_widths(args)
+
+    snapshot_mock.assert_not_called()
+    assert "Only local Markdown files were edited" in caplog.text
+    assert "ankiops ma" in caplog.text
+
+
+def test_run_fix_image_widths_rejects_no_subdecks_without_deck(tmp_path):
+    args = SimpleNamespace(
+        deck=None,
+        no_subdecks=True,
+        tolerance=5,
+        width=None,
+        no_auto_commit=True,
+    )
+
+    with patch("ankiops.cli.require_collection_dir", return_value=tmp_path):
+        with pytest.raises(SystemExit) as exc:
+            run_fix_image_widths(args)
 
     assert exc.value.code == 2

--- a/tests/integration/serialization/test_image_widths_collection.py
+++ b/tests/integration/serialization/test_image_widths_collection.py
@@ -1,0 +1,85 @@
+from ankiops.config import deck_name_to_file_stem
+from ankiops.db import SQLiteDbAdapter
+from ankiops.fs import FileSystemAdapter
+from ankiops.image_widths import fix_image_widths_collection
+
+
+def _make_collection(tmp_path):
+    db = SQLiteDbAdapter.open(tmp_path)
+    try:
+        db.set_profile_name("test")
+    finally:
+        db.close()
+
+    fs = FileSystemAdapter()
+    note_types_dir = tmp_path / "note_types"
+    fs.eject_builtin_note_types(note_types_dir)
+    return note_types_dir
+
+
+def _write_qa_deck(tmp_path, deck_name: str, answer: str):
+    path = tmp_path / f"{deck_name_to_file_stem(deck_name)}.md"
+    note_key = deck_name.replace("::", "-").replace(" ", "-")
+    path.write_text(
+        f"<!-- note_key: {note_key}-1 -->\nQ: Question\nA: {answer}",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_fix_image_widths_collection_includes_subdecks_by_default(tmp_path):
+    note_types_dir = _make_collection(tmp_path)
+    parent = _write_qa_deck(
+        tmp_path,
+        "Parent",
+        "![a](a.png){width=400}\n![b](b.png){width=404}",
+    )
+    child = _write_qa_deck(
+        tmp_path,
+        "Parent::Child",
+        "![a](a.png){width=300}\n![b](b.png){width=304}",
+    )
+    other = _write_qa_deck(
+        tmp_path,
+        "Other",
+        "![a](a.png){width=200}\n![b](b.png){width=204}",
+    )
+
+    result = fix_image_widths_collection(
+        tmp_path,
+        deck="Parent",
+        no_subdecks=False,
+        tolerance=5,
+        note_types_dir=note_types_dir,
+    )
+
+    assert result.decks_checked == 2
+    assert "{width=404}" not in parent.read_text(encoding="utf-8")
+    assert "{width=304}" not in child.read_text(encoding="utf-8")
+    assert "{width=204}" in other.read_text(encoding="utf-8")
+
+
+def test_fix_image_widths_collection_can_exclude_subdecks(tmp_path):
+    note_types_dir = _make_collection(tmp_path)
+    parent = _write_qa_deck(
+        tmp_path,
+        "Parent",
+        "![a](a.png){width=400}\n![b](b.png){width=404}",
+    )
+    child = _write_qa_deck(
+        tmp_path,
+        "Parent::Child",
+        "![a](a.png){width=300}\n![b](b.png){width=304}",
+    )
+
+    result = fix_image_widths_collection(
+        tmp_path,
+        deck="Parent",
+        no_subdecks=True,
+        tolerance=5,
+        note_types_dir=note_types_dir,
+    )
+
+    assert result.decks_checked == 1
+    assert "{width=404}" not in parent.read_text(encoding="utf-8")
+    assert "{width=304}" in child.read_text(encoding="utf-8")

--- a/tests/unit/usecases/test_image_widths.py
+++ b/tests/unit/usecases/test_image_widths.py
@@ -1,0 +1,91 @@
+from ankiops.image_widths import fix_image_widths_in_data
+
+
+def _data(answer: str, extra: str = ""):
+    return {
+        "decks": [
+            {
+                "name": "Deck",
+                "notes": [
+                    {
+                        "note_key": "nk-1",
+                        "note_type": "AnkiOpsQA",
+                        "fields": {"Answer": answer, "Extra": extra},
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def test_auto_normalizes_near_equal_widths_to_first_width():
+    data = _data(
+        "![a](<media/a.png>){width=700}\n"
+        "![b](<media/b.png>){width=703}\n"
+        "![c](<media/c.png>){width=705}"
+    )
+
+    result = fix_image_widths_in_data(data, tolerance=5)
+
+    assert result.images_checked == 3
+    assert result.images_changed == 2
+    fields = data["decks"][0]["notes"][0]["fields"]
+    assert fields["Answer"].count("{width=700}") == 3
+
+
+def test_auto_keeps_separate_clusters_within_one_note():
+    data = _data(
+        "![a](a.png){width=40}\n"
+        "![b](b.png){width=39}\n"
+        "![c](c.png){width=41}\n"
+        "![d](d.png){width=100}\n"
+        "![e](e.png){width=101}"
+    )
+
+    result = fix_image_widths_in_data(data, tolerance=5)
+
+    assert result.images_changed == 3
+    fields = data["decks"][0]["notes"][0]["fields"]
+    assert fields["Answer"].count("{width=40}") == 3
+    assert fields["Answer"].count("{width=100}") == 2
+
+
+def test_auto_ignores_images_without_explicit_width():
+    data = _data("![a](a.png)\n![b](b.png){width=402}\n![c](c.png){width=400}")
+
+    result = fix_image_widths_in_data(data, tolerance=5)
+
+    assert result.images_checked == 3
+    assert result.images_changed == 1
+    fields = data["decks"][0]["notes"][0]["fields"]
+    assert "![a](a.png)\n" in fields["Answer"]
+    assert "{width=402}" in fields["Answer"]
+    assert "{width=400}" not in fields["Answer"]
+
+
+def test_auto_uses_one_cluster_set_across_fields_in_note():
+    data = _data(
+        "![a](a.png){width=500}",
+        extra="![b](b.png){width=504}",
+    )
+
+    result = fix_image_widths_in_data(data, tolerance=5)
+
+    assert result.notes_changed == 1
+    fields = data["decks"][0]["notes"][0]["fields"]
+    assert fields["Extra"] == "![b](b.png){width=500}"
+
+
+def test_force_replaces_existing_widths_and_adds_missing_widths():
+    data = _data(
+        "![a](<media/a.png>){width=700}\n![b](<media/b.png>)\n![c](c.png){width=250}"
+    )
+
+    result = fix_image_widths_in_data(data, tolerance=5, width=320)
+
+    assert result.images_checked == 3
+    assert result.images_changed == 3
+    fields = data["decks"][0]["notes"][0]["fields"]
+    assert fields["Answer"].count("{width=320}") == 3
+    assert "{width=700}" not in fields["Answer"]
+    assert "{width=250}" not in fields["Answer"]


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `fix-image-widths` CLI command that normalizes Markdown image width annotations in serialized AnkiOps collections, either by clustering near-equal widths within a note (auto mode) or forcing all images to a specific pixel width (force mode).

- **`ankiops/image_widths.py`** — new module with a regex-based substitution engine, a greedy first-occurrence cluster algorithm for auto mode, and a `fix_image_widths_collection` entry point that serialize→patch→deserialize round-trips only when changes are detected.
- **`ankiops/cli.py`** — adds the `fix-image-widths` subparser with deck scoping (`--deck`, `--no-subdecks`), `--tolerance`, `--width`, and `--no-auto-commit` flags, plus `_positive_int`/`_non_negative_int` argparse type validators.
- **Tests** — unit tests cover all major clustering scenarios and force mode; integration tests verify file-level round-trip correctness and deck-scope filtering.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the new command only edits local Markdown files after taking a git snapshot, and no existing behavior is changed.

The feature is self-contained: serialize → patch in memory → deserialize only when changes are detected. The clustering algorithm is order-dependent by design (first-seen width wins), which is intentional and documented. Input validation, deck scoping, and the git-snapshot guard all work correctly. Unit and integration test coverage is solid across auto mode, force mode, and CLI behavior.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ankiops/image_widths.py | New module implementing image-width normalization (auto cluster-based) and force modes via regex substitution; logic is correct and well-guarded. |
| ankiops/cli.py | Adds fix-image-widths subcommand with deck scoping, tolerance, width, and no-auto-commit flags; input validation helpers and argument wiring look correct. |
| tests/unit/usecases/test_image_widths.py | Unit tests cover auto-mode clustering (multiple clusters, no-width images, cross-field sharing) and force mode; all assertions align with the implementation. |
| tests/integration/serialization/test_image_widths_collection.py | Integration tests verify deck scoping (with/without subdecks) by writing real markdown files and checking post-fix content; coverage is sufficient. |
| tests/integration/cli/test_cli_sync.py | CLI-level tests validate snapshot behavior, skip-snapshot path, sync-reminder logging, and the --no-subdecks guard; all look correct. |
| README.md | Documents the five new CLI flags for fix-image-widths; matches the actual argument definitions in cli.py. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ankiops fix-image-widths] --> B{--no-subdecks without --deck?}
    B -- Yes --> C[SystemExit 2]
    B -- No --> D[require_collection_dir]
    D --> E{--no-auto-commit?}
    E -- No --> F[git_snapshot]
    E -- Yes --> G[skip snapshot]
    F --> H[fix_image_widths_collection]
    G --> H
    H --> I[serialize collection to data dict]
    I --> J[fix_image_widths_in_data]
    J --> K{width arg set?}
    K -- Yes / force mode --> L[_force_field_width: add/overwrite every image]
    K -- No / auto mode --> M[_normalize_field_widths: cluster near-equal widths]
    L --> N{result.changed?}
    M --> N
    N -- Yes --> O[deserialize data back to disk]
    N -- No --> P[no files written]
    O --> Q[log summary + sync reminder]
    P --> R[log summary only]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Update ankiops/cli.py"](https://github.com/visserle/ankiops/commit/ba1a9f0bd51ef88f3e651787cf5dda0dd6c8a095) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33994210)</sub>

<!-- /greptile_comment -->