### PR TITLE
add support for tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Create a new Markdown file in your initialized AnkiOps folder. For the first imp
 
 ```markdown
 <!-- note_key: 123487556abc -->
+<!-- tags: anatomy::heart high-yield -->
 Q: Question text here
 A: Answer text here
 E: Extra information (optional)
@@ -94,6 +95,7 @@ A: 1, 3
 ```
 
 In this example, the last note is a new note which will get a `note_key` comment assigned on the next import.
+Tags are optional note-level metadata. A `<!-- tags: ... -->` comment uses whitespace-separated Anki tag names and is synced separately from note fields.
 
 ### How are different note types handled?
 
@@ -112,7 +114,7 @@ For the last option specifically, the recommended workflow is:
 
 ### How does it work?
 
-AnkiOps assigns a stable `note_key` to each managed note. It is represented by a single-line HTML tag (e.g., `<!-- note_key: a1b2c3d4e5f6 -->`) above a note in the Markdown. AnkiOps note keys are profile-independent, in contrast to Anki's note IDs. One AnkiOps folder represents one Anki profile. The `.ankiops.db`database stores the mapping between Anki's note IDs and AnkiOps note keys, along with other metadata. When syncing, AnkiOps uses these note keys to determine which notes to create, update, or delete in either Anki or Markdown. Media files are stored in a `media/` folder with hashed file names to avoid conflicts.
+AnkiOps assigns a stable `note_key` to each managed note. It is represented by a single-line HTML tag (e.g., `<!-- note_key: a1b2c3d4e5f6 -->`) above a note in the Markdown. AnkiOps note keys are profile-independent, in contrast to Anki's note IDs. Tags are represented by a separate `<!-- tags: ... -->` comment because Anki treats tags as note metadata rather than note type fields. One AnkiOps folder represents one Anki profile. The `.ankiops.db`database stores the mapping between Anki's note IDs and AnkiOps note keys, along with other metadata. When syncing, AnkiOps uses these note keys to determine which notes to create, update, or delete in either Anki or Markdown. Media files are stored in a `media/` folder with hashed file names to avoid conflicts.
 
 ### What is the recommended workflow?
 

--- a/ankiops/anki.py
+++ b/ankiops/anki.py
@@ -10,6 +10,7 @@ from ankiops.models import (
     Change,
     NoteTypeConfig,
 )
+from ankiops.tags import normalize_tags
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +91,7 @@ class AnkiAdapter:
                 note_type=note_data.get("modelName", ""),
                 fields=fields,
                 card_ids=note_data.get("cards", []),
+                tags=normalize_tags(note_data.get("tags", ())),
             )
         return notes_by_id
 
@@ -316,28 +318,36 @@ class AnkiAdapter:
         cards_to_move: list[int],
     ) -> tuple[list[int | None], list[str]]:
         actions = []
-        tags = []
+        action_tags = []
         errors = []
         created_ids: list[int | None] = []
         create_deck_failed = False
 
         if needs_create_deck:
             actions.append(_action("createDeck", deck=deck_name))
-            tags.append("create_deck")
+            action_tags.append("create_deck")
 
         if cards_to_move:
             actions.append(
                 _action("changeDeck", cards=sorted(set(cards_to_move)), deck=deck_name)
             )
-            tags.append("change_deck")
+            action_tags.append("change_deck")
 
         for update_change in updates:
             note_id = update_change.entity_id
             fields = update_change.context.get("html_fields", {})
+            note_tags = normalize_tags(update_change.context.get("tags", ()))
             actions.append(
-                _action("updateNoteFields", note={"id": note_id, "fields": fields})
+                _action(
+                    "updateNote",
+                    note={
+                        "id": note_id,
+                        "fields": fields,
+                        "tags": list(note_tags),
+                    },
+                )
             )
-            tags.append("update")
+            action_tags.append("update")
 
         if deletes:
             note_ids = [
@@ -346,13 +356,13 @@ class AnkiAdapter:
                 if delete_change.entity_id
             ]
             actions.append(_action("deleteNotes", notes=note_ids))
-            tags.append("delete")
+            action_tags.append("delete")
 
         if actions:
             try:
                 results = invoke("multi", actions=actions)
                 update_idx = 0
-                for tag, action_result in zip(tags, results):
+                for tag, action_result in zip(action_tags, results):
                     if tag == "update":
                         if isinstance(action_result, str):
                             errors.append(
@@ -395,6 +405,7 @@ class AnkiAdapter:
             "deckName": deck_name,
             "modelName": note_type,
             "fields": fields,
+            "tags": list(note.tags) if note else [],
             "options": {"allowDuplicate": False},
         }
 

--- a/ankiops/export_notes.py
+++ b/ankiops/export_notes.py
@@ -23,6 +23,7 @@ from ankiops.models import (
     ProtectedNoteGroup,
     SyncResult,
 )
+from ankiops.tags import format_tags_comment
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +60,7 @@ def _from_html(
         note_key=note_key if note_key else None,
         note_type=anki_note.note_type,
         fields=fields,
+        tags=anki_note.tags,
     )
 
 
@@ -125,7 +127,11 @@ def _resolve_deck_notes(
     for anki_note in anki_notes:
         note_key = note_keys_by_id.get(anki_note.note_id)
         embedded_note_key = anki_note.fields.get("AnkiOps Key", "").strip()
-        observed_anki_hash = note_fingerprint(anki_note.note_type, anki_note.fields)
+        observed_anki_hash = note_fingerprint(
+            anki_note.note_type,
+            anki_note.fields,
+            tags=anki_note.tags,
+        )
 
         # Stale note_id->note_key mapping: prefer embedded note_key from Anki note.
         if note_key and embedded_note_key and note_key != embedded_note_key:
@@ -137,7 +143,11 @@ def _resolve_deck_notes(
 
         local_match = local_notes_by_note_key.get(note_key) if note_key else None
         if note_key and local_match:
-            local_md_hash = note_fingerprint(local_match.note_type, local_match.fields)
+            local_md_hash = note_fingerprint(
+                local_match.note_type,
+                local_match.fields,
+                tags=local_match.tags,
+            )
             cached = note_export_fingerprints_by_note_key.get(note_key)
             if cached == (local_md_hash, observed_anki_hash):
                 result.add_change(
@@ -169,12 +179,20 @@ def _resolve_deck_notes(
 
         domain_note.note_key = note_key
         local_match = local_notes_by_note_key.get(note_key)
-        if local_match and local_match.fields == domain_note.fields:
+        if (
+            local_match
+            and local_match.fields == domain_note.fields
+            and local_match.tags == domain_note.tags
+        ):
             result.add_change(
                 Change(ChangeType.SKIP, anki_note.note_id, domain_note.identifier)
             )
             resolved_notes.append((note_key, anki_note.note_id, local_match))
-            md_hash = note_fingerprint(local_match.note_type, local_match.fields)
+            md_hash = note_fingerprint(
+                local_match.note_type,
+                local_match.fields,
+                tags=local_match.tags,
+            )
             _queue_export_fingerprint(note_key, md_hash, observed_anki_hash)
             continue
 
@@ -206,7 +224,11 @@ def _resolve_deck_notes(
             )
 
         resolved_notes.append((note_key, anki_note.note_id, domain_note))
-        md_hash = note_fingerprint(domain_note.note_type, domain_note.fields)
+        md_hash = note_fingerprint(
+            domain_note.note_type,
+            domain_note.fields,
+            tags=domain_note.tags,
+        )
         _queue_export_fingerprint(note_key, md_hash, observed_anki_hash)
 
     return resolved_notes, errors
@@ -232,7 +254,11 @@ def _order_resolved_notes(
     resolved_by_fingerprint: dict[str, list[_ResolvedDeckNote]] = {}
     for resolved in resolved_notes:
         resolved_note = resolved[_RESOLVED_NOTE_VALUE]
-        resolved_hash = note_fingerprint(resolved_note.note_type, resolved_note.fields)
+        resolved_hash = note_fingerprint(
+            resolved_note.note_type,
+            resolved_note.fields,
+            tags=resolved_note.tags,
+        )
         resolved_by_fingerprint.setdefault(resolved_hash, []).append(resolved)
 
     consumed_note_keys: set[str] = set()
@@ -251,7 +277,11 @@ def _order_resolved_notes(
             consumed_note_keys.add(resolved_key)
             continue
 
-        existing_hash = note_fingerprint(existing_note.note_type, existing_note.fields)
+        existing_hash = note_fingerprint(
+            existing_note.note_type,
+            existing_note.fields,
+            tags=existing_note.tags,
+        )
         candidates = resolved_by_fingerprint.get(existing_hash, [])
         matched = next(
             (
@@ -312,6 +342,9 @@ def _render_notes_to_markdown(
         parts = []
         if note.note_key:
             parts.append(f"<!-- note_key: {note.note_key} -->")
+        tags_comment = format_tags_comment(note.tags)
+        if tags_comment:
+            parts.append(tags_comment)
 
         cfg = config_by_name[note.note_type]
         for field_config in cfg.fields:

--- a/ankiops/fingerprints.py
+++ b/ankiops/fingerprints.py
@@ -3,20 +3,34 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable
 
 from blake3 import blake3
 
+from ankiops.tags import normalize_tags
 
-def _stable_payload(note_type: str, fields: dict[str, str]) -> bytes:
+
+def _stable_payload(
+    note_type: str,
+    fields: dict[str, str],
+    *,
+    tags: Iterable[str] | str | None = (),
+) -> bytes:
     payload = {
         "note_type": note_type,
         "fields": fields,
+        "tags": list(normalize_tags(tags)),
     }
     return json.dumps(
         payload, sort_keys=True, ensure_ascii=False, separators=(",", ":")
     ).encode("utf-8")
 
 
-def note_fingerprint(note_type: str, fields: dict[str, str]) -> str:
-    """Compute a stable note-level fingerprint from type + fields."""
-    return blake3(_stable_payload(note_type, fields)).hexdigest(length=8)
+def note_fingerprint(
+    note_type: str,
+    fields: dict[str, str],
+    *,
+    tags: Iterable[str] | str | None = (),
+) -> str:
+    """Compute a stable note-level fingerprint from type + fields + tags."""
+    return blake3(_stable_payload(note_type, fields, tags=tags)).hexdigest(length=8)

--- a/ankiops/fs.py
+++ b/ankiops/fs.py
@@ -20,10 +20,11 @@ from ankiops.models import (
     Note,
     NoteTypeConfig,
 )
+from ankiops.tags import parse_tags_comment
 
 logger = logging.getLogger(__name__)
 
-_NOTE_KEY_PATTERN = re.compile(r"<!--\s*note_key:\s*([a-zA-Z0-9-]+)\s*-->")
+_NOTE_KEY_PATTERN = re.compile(r"^\s*<!--\s*note_key:\s*([a-zA-Z0-9-]+)\s*-->\s*$")
 _CODE_FENCE_PATTERN = re.compile(r"^(```|~~~)")
 _LABEL_CANDIDATE_PATTERN = re.compile(r"^([A-Za-z][A-Za-z0-9_-]*:)(?:\s|$)")
 _RESERVED_NOTE_FIELD_NAMES = frozenset({ANKIOPS_KEY_FIELD.name})
@@ -109,6 +110,7 @@ class FileSystemAdapter:
 
             lines = stripped_block.split("\n")
             note_key: str | None = None
+            tags: tuple[str, ...] = ()
             fields: dict[str, str] = {}
             current_field: str | None = None
             current_content: list[str] = []
@@ -126,14 +128,19 @@ class FileSystemAdapter:
                         current_content.append(line)
                     continue
 
+                if in_code_block:
+                    if current_field:
+                        current_content.append(line)
+                    continue
+
                 key_match = _NOTE_KEY_PATTERN.match(line)
                 if key_match:
                     note_key = key_match.group(1)
                     continue
 
-                if in_code_block:
-                    if current_field:
-                        current_content.append(line)
+                tag_values = parse_tags_comment(line)
+                if tag_values is not None:
+                    tags = tag_values
                     continue
 
                 matched_field = None
@@ -210,7 +217,12 @@ class FileSystemAdapter:
                         line_number=first_field_line or note_start_line,
                     )
                 ) from error
-            note = Note(note_key=note_key, note_type=note_type, fields=fields)
+            note = Note(
+                note_key=note_key,
+                note_type=note_type,
+                fields=fields,
+                tags=tags,
+            )
 
             # Validate
             note_type_config = config_by_name[note_type]

--- a/ankiops/import_notes.py
+++ b/ankiops/import_notes.py
@@ -22,6 +22,7 @@ from ankiops.models import (
     SyncResult,
     UntrackedDeck,
 )
+from ankiops.tags import TAGS_COMMENT_RE
 
 logger = logging.getLogger(__name__)
 _NOTE_KEY_LINE_RE = re.compile(r"^\s*<!--\s*note_key:\s*([a-zA-Z0-9-]+)\s*-->\s*$")
@@ -90,7 +91,17 @@ def _upsert_note_key_in_block(block: str, note: Note, note_key: str) -> str:
             lines[line_index] = note_key_line
             return "\n".join(lines)
 
-    insert_idx = _find_first_markdown_line_index(note, lines)
+    tag_idx = next(
+        (
+            line_index
+            for line_index, line in enumerate(lines)
+            if TAGS_COMMENT_RE.match(line)
+        ),
+        None,
+    )
+    insert_idx = (
+        tag_idx if tag_idx is not None else _find_first_markdown_line_index(note, lines)
+    )
     lines.insert(insert_idx, note_key_line)
     return "\n".join(lines)
 
@@ -160,6 +171,12 @@ def _html_match(html: dict[str, str], anki: AnkiNote) -> bool:
         anki.fields.get(field_name) == field_value
         for field_name, field_value in html.items()
     )
+
+
+def _anki_note_match(
+    html: dict[str, str], tags: tuple[str, ...], anki: AnkiNote
+) -> bool:
+    return _html_match(html, anki) and anki.tags == tags
 
 
 def _group_note_ids_by_deck_name(anki_cards: dict[int, dict]) -> dict[str, set[int]]:
@@ -298,8 +315,11 @@ def _sync_keyed_note(
                     "note_key": note_key,
                     "md_hash": md_hash,
                     "import_anki_hash": note_fingerprint(
-                        parsed_note.note_type, html_fields
+                        parsed_note.note_type,
+                        html_fields,
+                        tags=parsed_note.tags,
                     ),
+                    "tags": parsed_note.tags,
                 },
             )
         )
@@ -338,7 +358,11 @@ def _sync_keyed_note(
         )
         return
 
-    current_anki_hash = note_fingerprint(anki_note.note_type, anki_note.fields)
+    current_anki_hash = note_fingerprint(
+        anki_note.note_type,
+        anki_note.fields,
+        tags=anki_note.tags,
+    )
     cached = note_import_fingerprints_by_note_key.get(note_key)
     if cached == (md_hash, current_anki_hash):
         result.add_change(Change(ChangeType.SKIP, note_id, parsed_note.identifier))
@@ -349,12 +373,16 @@ def _sync_keyed_note(
     if anki_note.fields.get("AnkiOps Key", "") != note_key:
         html_fields["AnkiOps Key"] = note_key
 
-    if _html_match(html_fields, anki_note):
+    if _anki_note_match(html_fields, parsed_note.tags, anki_note):
         result.add_change(Change(ChangeType.SKIP, note_id, parsed_note.identifier))
         queue_import_fingerprint(note_key, md_hash, current_anki_hash)
         return
 
-    target_anki_hash = note_fingerprint(parsed_note.note_type, html_fields)
+    target_anki_hash = note_fingerprint(
+        parsed_note.note_type,
+        html_fields,
+        tags=parsed_note.tags,
+    )
     result.add_change(
         Change(
             ChangeType.UPDATE,
@@ -365,6 +393,7 @@ def _sync_keyed_note(
                 "note_key": note_key,
                 "md_hash": md_hash,
                 "import_anki_hash": target_anki_hash,
+                "tags": parsed_note.tags,
             },
         )
     )
@@ -398,8 +427,11 @@ def _sync_new_note(
                 "note_key": new_note_key,
                 "md_hash": md_hash,
                 "import_anki_hash": note_fingerprint(
-                    parsed_note.note_type, html_fields
+                    parsed_note.note_type,
+                    html_fields,
+                    tags=parsed_note.tags,
                 ),
+                "tags": parsed_note.tags,
             },
         )
     )
@@ -623,7 +655,11 @@ def _sync_file(
 
     for parsed_note in fs.notes:
         cfg = config_by_name[parsed_note.note_type]
-        md_hash = note_fingerprint(parsed_note.note_type, parsed_note.fields)
+        md_hash = note_fingerprint(
+            parsed_note.note_type,
+            parsed_note.fields,
+            tags=parsed_note.tags,
+        )
 
         if parsed_note.note_key:
             _sync_keyed_note(

--- a/ankiops/import_notes.py
+++ b/ankiops/import_notes.py
@@ -26,6 +26,7 @@ from ankiops.tags import TAGS_COMMENT_RE
 
 logger = logging.getLogger(__name__)
 _NOTE_KEY_LINE_RE = re.compile(r"^\s*<!--\s*note_key:\s*([a-zA-Z0-9-]+)\s*-->\s*$")
+_CODE_FENCE_PATTERN = re.compile(r"^(```|~~~)")
 
 
 @dataclass
@@ -78,6 +79,20 @@ def _find_first_markdown_line_index(note: Note, lines: list[str]) -> int:
     )
 
 
+def _find_tags_comment_index(lines: list[str]) -> int | None:
+    in_code_block = False
+    for line_index, line in enumerate(lines):
+        stripped = line.lstrip()
+        if _CODE_FENCE_PATTERN.match(stripped):
+            in_code_block = not in_code_block
+            continue
+        if in_code_block:
+            continue
+        if TAGS_COMMENT_RE.match(line):
+            return line_index
+    return None
+
+
 def _upsert_note_key_in_block(block: str, note: Note, note_key: str) -> str:
     """Insert or replace note_key in a single markdown note block."""
     note_key_line = f"<!-- note_key: {note_key} -->"
@@ -91,14 +106,7 @@ def _upsert_note_key_in_block(block: str, note: Note, note_key: str) -> str:
             lines[line_index] = note_key_line
             return "\n".join(lines)
 
-    tag_idx = next(
-        (
-            line_index
-            for line_index, line in enumerate(lines)
-            if TAGS_COMMENT_RE.match(line)
-        ),
-        None,
-    )
+    tag_idx = _find_tags_comment_index(lines)
     insert_idx = (
         tag_idx if tag_idx is not None else _find_first_markdown_line_index(note, lines)
     )

--- a/ankiops/llm/runner.py
+++ b/ankiops/llm/runner.py
@@ -24,6 +24,7 @@ from ankiops.fs import FileSystemAdapter
 from ankiops.git import git_snapshot
 from ankiops.models import ANKIOPS_KEY_FIELD, Note, NoteTypeConfig
 from ankiops.serializer import deserialize, serialize
+from ankiops.tags import normalize_tags
 
 from .config_loader import is_task_config_file, load_llm_task_catalog
 from .llm_db import LlmDb, LlmJobDetail, LlmJobListItem
@@ -1185,6 +1186,7 @@ def _apply_candidate_updates(
         note_key=candidate.payload.note_key,
         note_type=candidate.payload.note_type,
         fields=next_fields,
+        tags=normalize_tags(candidate.serialized_note.get("tags", ())),
     )
     errors = [*_validate_cloze_text_fields(note, candidate.note_type_config)]
     errors.extend(note.validate(candidate.note_type_config))

--- a/ankiops/models.py
+++ b/ankiops/models.py
@@ -172,7 +172,7 @@ class Note:
     note_key: str | None
     note_type: str
     fields: dict[str, str]  # {field_name: markdown_content}
-    tags: tuple[str, ...] = field(default_factory=tuple)
+    tags: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         self.tags = normalize_tags(self.tags)

--- a/ankiops/models.py
+++ b/ankiops/models.py
@@ -12,6 +12,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
+from ankiops.tags import normalize_tags
+
 _CLOZE_PATTERN = re.compile(r"\{\{c\d+::")
 
 
@@ -170,6 +172,10 @@ class Note:
     note_key: str | None
     note_type: str
     fields: dict[str, str]  # {field_name: markdown_content}
+    tags: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        self.tags = normalize_tags(self.tags)
 
     @property
     def identifier(self) -> str:
@@ -280,6 +286,10 @@ class AnkiNote:
     note_type: str
     fields: dict[str, str]  # HTML content
     card_ids: list[int]
+    tags: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        self.tags = normalize_tags(self.tags)
 
 
 class ChangeType(Enum):

--- a/ankiops/serializer.py
+++ b/ankiops/serializer.py
@@ -15,6 +15,7 @@ from ankiops.config import (
 )
 from ankiops.fs import FileSystemAdapter
 from ankiops.log import clickable_path
+from ankiops.tags import format_tags_comment, normalize_tags
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +79,7 @@ def serialize(
                     "note_key": note.note_key,
                     "note_type": note.note_type,
                     "fields": note.fields,
+                    "tags": list(note.tags),
                 }
             )
 
@@ -193,6 +195,7 @@ def deserialize(
         for note in notes:
             note_key = note.get("note_key")
             fields = note["fields"]
+            tags = normalize_tags(note.get("tags", ()))
 
             note_type = note.get("note_type")
             config = (
@@ -221,6 +224,9 @@ def deserialize(
 
             if note_key:
                 lines.append(f"<!-- note_key: {note_key} -->")
+            tag_comment = format_tags_comment(tags)
+            if tag_comment:
+                lines.append(tag_comment)
 
             for field in config.fields:
                 field_content = fields.get(field.name)

--- a/ankiops/tags.py
+++ b/ankiops/tags.py
@@ -1,0 +1,36 @@
+"""Helpers for note-level Anki tags."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+TAGS_COMMENT_RE = re.compile(r"^\s*<!--\s*tags:\s*(.*?)\s*-->\s*$")
+
+
+def normalize_tags(tags: Iterable[str] | str | None = None) -> tuple[str, ...]:
+    """Return canonical Anki tags: trimmed, deduped, and sorted."""
+    if tags is None:
+        return ()
+
+    raw_tags = tags.split() if isinstance(tags, str) else tags
+    normalized = {
+        tag.strip() for tag in raw_tags if isinstance(tag, str) and tag.strip()
+    }
+    return tuple(sorted(normalized))
+
+
+def parse_tags_comment(line: str) -> tuple[str, ...] | None:
+    """Parse a full-line tags comment, returning None when it is not one."""
+    match = TAGS_COMMENT_RE.match(line)
+    if not match:
+        return None
+    return normalize_tags(match.group(1))
+
+
+def format_tags_comment(tags: Iterable[str] | str | None) -> str | None:
+    """Format tags as a Markdown metadata comment."""
+    normalized = normalize_tags(tags)
+    if not normalized:
+        return None
+    return f"<!-- tags: {' '.join(normalized)} -->"

--- a/tests/integration/serialization/test_collection_serializer.py
+++ b/tests/integration/serialization/test_collection_serializer.py
@@ -71,6 +71,23 @@ def test_in_memory_serialize(collection, monkeypatch):
     assert result["decks"][0]["notes"][1]["note_key"] == "nk-2"
 
 
+def test_serialize_includes_tags(collection, monkeypatch):
+    _set_collection_paths(monkeypatch, collection)
+    deck_file = collection / f"{deck_name_to_file_stem('TestDeck')}.md"
+    deck_file.write_text(
+        deck_file.read_text(encoding="utf-8").replace(
+            "<!-- note_key: nk-1 -->",
+            "<!-- note_key: nk-1 -->\n<!-- tags: z high-yield -->",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    result = serialize(collection)
+
+    assert result["decks"][0]["notes"][0]["tags"] == ["high-yield", "z"]
+
+
 def test_serialize_single_deck_includes_subdecks_by_default(collection, monkeypatch):
     _set_collection_paths(monkeypatch, collection)
 
@@ -203,6 +220,41 @@ def test_roundtrip_in_memory(collection, tmp_path, monkeypatch):
     content = md_files[0].read_text(encoding="utf-8")
     assert "What is 2+2?" in content
     assert "What is 3+3?" in content
+
+
+def test_roundtrip_preserves_tags(collection, tmp_path, monkeypatch):
+    _set_collection_paths(monkeypatch, collection)
+    deck_file = collection / f"{deck_name_to_file_stem('TestDeck')}.md"
+    deck_file.write_text(
+        deck_file.read_text(encoding="utf-8").replace(
+            "<!-- note_key: nk-1 -->",
+            "<!-- note_key: nk-1 -->\n<!-- tags: z high-yield -->",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    serialized_data = serialize(collection)
+
+    fresh_dir = tmp_path / "fresh-tags"
+    fresh_dir.mkdir()
+    _set_collection_paths(monkeypatch, fresh_dir)
+
+    fs = FileSystemAdapter()
+    note_types_dst = fresh_dir / "note_types"
+    fs.eject_builtin_note_types(note_types_dst)
+
+    deserialize(
+        serialized_data,
+        collection_dir=fresh_dir,
+        note_types_dir=note_types_dst,
+        overwrite=True,
+    )
+
+    md_files = list(fresh_dir.glob("*.md"))
+    assert len(md_files) == 1
+    content = md_files[0].read_text(encoding="utf-8")
+    assert "<!-- tags: high-yield z -->" in content
 
 
 def test_deserialize_unknown_note_type_skips_note_without_orphan_key(

--- a/tests/integration/sync/test_sync_matrix_export.py
+++ b/tests/integration/sync/test_sync_matrix_export.py
@@ -39,6 +39,30 @@ def test_exp_fresh_create_001_exports_anki_note_to_markdown(world):
         assert db.resolve_note_keys([note_id]).get(note_id) == keys[0]
 
 
+def test_exp_fresh_create_004_exports_anki_tags_to_markdown(world):
+    """Export should write Anki tags as note metadata."""
+    world.add_qa_note(
+        deck_name="TaggedExportDeck",
+        question="Q1",
+        answer="A1",
+        tags=("z", "high-yield", "z"),
+    )
+
+    with world.db_session() as db:
+        result = world.sync_export(db)
+
+        assert_summary(
+            result.summary, created=1, updated=0, moved=0, deleted=0, errors=0
+        )
+        _assert_deck_contains(
+            world,
+            "TaggedExportDeck",
+            "<!-- tags: high-yield z -->",
+            "Q: Q1",
+            "A: A1",
+        )
+
+
 def test_exp_run_update_001_updates_existing_markdown_note(world):
     """EXP-RUN-UPDATE-001."""
     note_key = "exp-run-update-001"
@@ -61,6 +85,31 @@ def test_exp_run_update_001_updates_existing_markdown_note(world):
             result.summary, created=0, updated=1, moved=0, deleted=0, errors=0
         )
         _assert_deck_contains(world, "UpdateDeck", "A: New Anki A")
+
+
+def test_exp_run_update_004_tag_only_anki_edit_updates_markdown(world):
+    """Anki tag changes should update Markdown even when fields match."""
+    note_key = "exp-run-update-tags-001"
+    note_id = world.add_qa_note(
+        deck_name="TagExportDeck",
+        question="Q0",
+        answer="A0",
+        note_key=note_key,
+        tags=("old",),
+    )
+
+    with world.db_session() as db:
+        db.upsert_note_links([(note_key, note_id)])
+        first = world.sync_export(db)
+        assert_summary(first.summary, created=1, updated=0, errors=0)
+
+        world.mock_anki.notes[note_id]["tags"] = ["new", "z"]
+        second = world.sync_export(db)
+        assert_summary(second.summary, created=0, updated=1, errors=0)
+        _assert_deck_contains(world, "TagExportDeck", "<!-- tags: new z -->")
+
+        third = world.sync_export(db)
+        assert_summary(third.summary, created=0, updated=0, errors=0)
 
 
 def test_exp_fresh_create_002_preserves_blockquote_citation_links(world):
@@ -251,8 +300,7 @@ def test_exp_run_delete_004_removes_empty_orphan_markdown_file_without_note_dele
     assert_summary(result.summary, created=0, updated=0, moved=0, deleted=0, errors=0)
     assert result.protected_note_groups == []
     assert (
-        "Removed empty orphan markdown deck file: EmptyOrphanDeck.md"
-        in caplog.messages
+        "Removed empty orphan markdown deck file: EmptyOrphanDeck.md" in caplog.messages
     )
 
 

--- a/tests/integration/sync/test_sync_matrix_import.py
+++ b/tests/integration/sync/test_sync_matrix_import.py
@@ -30,6 +30,25 @@ def test_imp_fresh_create_001_creates_note_and_writes_key(world):
         assert db.resolve_note_ids([note_keys[0]]).get(note_keys[0]) == note_id
 
 
+def test_imp_fresh_create_002_creates_note_with_tags(world):
+    """Import should create Anki notes with Markdown tags."""
+    world.write_qa_deck(
+        "TaggedFreshDeck",
+        [("Tagged Q", "Tagged A", None, ("z", "high-yield", "z"))],
+    )
+
+    with world.db_session() as db:
+        result = world.sync_import(db)
+
+        assert_summary(
+            result.summary, created=1, updated=0, moved=0, deleted=0, errors=0
+        )
+        note_id = next(iter(world.mock_anki.notes.keys()))
+        assert world.mock_anki.notes[note_id]["tags"] == ["high-yield", "z"]
+        content = world.read_deck("TaggedFreshDeck")
+        assert content.index("<!-- note_key:") < content.index("<!-- tags:")
+
+
 def test_imp_run_update_001_updates_existing_note(world):
     """IMP-RUN-UPDATE-001."""
     note_key = "imp-run-update-001"
@@ -53,6 +72,55 @@ def test_imp_run_update_001_updates_existing_note(world):
         assert (
             world.mock_anki.notes[note_id]["fields"]["Answer"]["value"] == "Updated A"
         )
+
+
+def test_imp_run_update_003_tag_only_edit_updates_existing_note(world):
+    """Markdown tag changes should update Anki even when fields match."""
+    note_key = "imp-run-update-tags-001"
+    note_id = world.add_qa_note(
+        deck_name="TagUpdateDeck",
+        question="Original Q",
+        answer="Original A",
+        note_key=note_key,
+        tags=("old",),
+    )
+
+    world.write_qa_deck(
+        "TagUpdateDeck",
+        [("Original Q", "Original A", note_key, ("new", "z"))],
+    )
+
+    with world.db_session() as db:
+        db.upsert_note_links([(note_key, note_id)])
+        result = world.sync_import(db)
+
+        assert_summary(
+            result.summary, created=0, updated=1, moved=0, deleted=0, errors=0
+        )
+        assert world.mock_anki.notes[note_id]["tags"] == ["new", "z"]
+
+
+def test_imp_run_update_004_missing_tags_comment_clears_anki_tags(world):
+    """Markdown without tags should make Anki tags empty."""
+    note_key = "imp-run-update-tags-002"
+    note_id = world.add_qa_note(
+        deck_name="TagClearDeck",
+        question="Original Q",
+        answer="Original A",
+        note_key=note_key,
+        tags=("old",),
+    )
+
+    world.write_qa_deck("TagClearDeck", [("Original Q", "Original A", note_key)])
+
+    with world.db_session() as db:
+        db.upsert_note_links([(note_key, note_id)])
+        result = world.sync_import(db)
+
+        assert_summary(
+            result.summary, created=0, updated=1, moved=0, deleted=0, errors=0
+        )
+        assert world.mock_anki.notes[note_id]["tags"] == []
 
 
 def test_imp_run_move_001_moves_note_between_decks(world):

--- a/tests/support/fake_anki.py
+++ b/tests/support/fake_anki.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from ankiops.anki_client import AnkiConnectError
+from ankiops.tags import normalize_tags
 
 
 class MockAnki:
@@ -179,6 +180,7 @@ class MockAnki:
                         for field_name, field_value in note_data["fields"].items()
                     },
                     "cards": [card_id],
+                    "tags": list(normalize_tags(note_data.get("tags", ()))),
                 }
                 self.cards[card_id] = {
                     "cardId": card_id,
@@ -204,6 +206,33 @@ class MockAnki:
                             "value": field_value
                         }
                 return None
+
+            case "updateNote":
+                note_info = params["note"]
+                note_id = note_info["id"]
+                if note_id in self.notes:
+                    for field_name, field_value in note_info.get("fields", {}).items():
+                        self.notes[note_id]["fields"][field_name] = {
+                            "value": field_value
+                        }
+                    if "tags" in note_info:
+                        self.notes[note_id]["tags"] = list(
+                            normalize_tags(note_info["tags"])
+                        )
+                return None
+
+            case "updateNoteTags":
+                note_id = params["note"]
+                if note_id in self.notes:
+                    self.notes[note_id]["tags"] = list(
+                        normalize_tags(params.get("tags", ()))
+                    )
+                return None
+
+            case "getNoteTags":
+                note_id = params["note"]
+                note = self.notes.get(note_id)
+                return list(note.get("tags", [])) if note else []
 
             case "deleteNotes":
                 note_ids = params["notes"]
@@ -271,12 +300,23 @@ class MockAnki:
             case _:
                 return None
 
-    def add_note(self, deck_name: str, note_type: str, fields: dict):
+    def add_note(
+        self,
+        deck_name: str,
+        note_type: str,
+        fields: dict,
+        tags=(),
+    ):
         """Convenience helper for test setup."""
         if deck_name not in self.decks:
             self.invoke("createDeck", deck=deck_name)
 
         self.invoke(
             "addNote",
-            note={"deckName": deck_name, "modelName": note_type, "fields": fields},
+            note={
+                "deckName": deck_name,
+                "modelName": note_type,
+                "fields": fields,
+                "tags": list(normalize_tags(tags)),
+            },
         )

--- a/tests/support/sync_world.py
+++ b/tests/support/sync_world.py
@@ -17,6 +17,7 @@ from ankiops.db import SQLiteDbAdapter
 from ankiops.export_notes import export_collection
 from ankiops.fs import FileSystemAdapter
 from ankiops.import_notes import import_collection
+from ankiops.tags import format_tags_comment
 
 _NOTE_KEY_RE = re.compile(r"<!--\s*note_key:\s*([a-zA-Z0-9-]+)\s*-->")
 
@@ -98,19 +99,22 @@ class SyncWorld:
         safe = deck_name_to_file_stem(deck_name)
         return self.root / f"{safe}.md"
 
-    def write_qa_deck(
-        self, deck_name: str, notes: list[tuple[str, str, str | None]]
-    ) -> Path:
+    def write_qa_deck(self, deck_name: str, notes: list[tuple]) -> Path:
         path = self.deck_path(deck_name)
         if not notes:
             path.write_text("", encoding="utf-8")
             return path
 
         blocks = []
-        for question, answer, note_key in notes:
+        for note_data in notes:
+            question, answer, note_key = note_data[:3]
+            tags = note_data[3] if len(note_data) > 3 else ()
             lines = []
             if note_key:
                 lines.append(f"<!-- note_key: {note_key} -->")
+            tag_comment = format_tags_comment(tags)
+            if tag_comment:
+                lines.append(tag_comment)
             lines.append(f"Q: {question}")
             lines.append(f"A: {answer}")
             blocks.append("\n".join(lines))
@@ -131,11 +135,12 @@ class SyncWorld:
         question: str,
         answer: str,
         note_key: str | None = None,
+        tags=(),
     ) -> int:
         fields = {"Question": question, "Answer": answer}
         if note_key is not None:
             fields["AnkiOps Key"] = note_key
-        self.mock_anki.add_note(deck_name, "AnkiOpsQA", fields)
+        self.mock_anki.add_note(deck_name, "AnkiOpsQA", fields, tags=tags)
         return max(self.mock_anki.notes.keys())
 
     def set_note_answer(self, note_id: int, answer: str) -> None:

--- a/tests/unit/adapters/test_anki_adapter.py
+++ b/tests/unit/adapters/test_anki_adapter.py
@@ -111,8 +111,7 @@ def test_apply_note_changes_preflight_reports_create_context():
 
     assert created_ids == [None]
     assert errors == [
-        "Create failed ('Duplicate Q...'): "
-        "cannot create note because it is a duplicate"
+        "Create failed ('Duplicate Q...'): cannot create note because it is a duplicate"
     ]
     assert [call.args[0] for call in mock_invoke.call_args_list] == [
         "canAddNotesWithErrorDetail"
@@ -140,9 +139,105 @@ def test_apply_note_changes_bulk_create_exception_keeps_create_context():
 
     assert created_ids == [None]
     assert errors == [
-        "Create failed ('Duplicate Q...'): "
-        "cannot create note because it is a duplicate"
+        "Create failed ('Duplicate Q...'): cannot create note because it is a duplicate"
     ]
+
+
+def test_fetch_notes_info_maps_tags():
+    adapter = AnkiAdapter()
+
+    with patch(
+        "ankiops.anki.invoke",
+        return_value=[
+            {
+                "noteId": 101,
+                "modelName": "AnkiOpsQA",
+                "fields": {
+                    "Question": {"value": "Q"},
+                    "Answer": {"value": "A"},
+                },
+                "cards": [1001],
+                "tags": ["z", "a", "z"],
+            }
+        ],
+    ):
+        notes = adapter.fetch_notes_info([101])
+
+    assert notes[101].tags == ("a", "z")
+
+
+def test_apply_note_changes_updates_fields_and_tags_with_update_note():
+    adapter = AnkiAdapter()
+    update_change = Change(
+        ChangeType.UPDATE,
+        101,
+        "note_key: update",
+        {
+            "html_fields": {"Question": "Q", "Answer": "A2"},
+            "tags": ("z", "a"),
+        },
+    )
+
+    with patch("ankiops.anki.invoke", return_value=[None]) as mock_invoke:
+        created_ids, errors = adapter.apply_note_changes(
+            deck_name="DeckY",
+            needs_create_deck=False,
+            creates=[],
+            updates=[update_change],
+            deletes=[],
+            cards_to_move=[],
+        )
+
+    assert created_ids == []
+    assert errors == []
+    action = mock_invoke.call_args.kwargs["actions"][0]
+    assert action["action"] == "updateNote"
+    assert action["params"]["note"] == {
+        "id": 101,
+        "fields": {"Question": "Q", "Answer": "A2"},
+        "tags": ["a", "z"],
+    }
+
+
+def test_apply_note_changes_bulk_create_includes_tags():
+    adapter = AnkiAdapter()
+    create_change = Change(
+        ChangeType.CREATE,
+        None,
+        "note_key: create",
+        {
+            "note": Note(
+                note_key=None,
+                note_type="AnkiOpsQA",
+                fields={},
+                tags=("z", "a"),
+            ),
+            "html_fields": {"Question": "Q", "Answer": "A"},
+            "note_key": "created-key",
+        },
+    )
+
+    with patch(
+        "ankiops.anki.invoke",
+        side_effect=[
+            [{"canAdd": True}],
+            [303],
+        ],
+    ) as mock_invoke:
+        created_ids, errors = adapter.apply_note_changes(
+            deck_name="DeckY",
+            needs_create_deck=False,
+            creates=[create_change],
+            updates=[],
+            deletes=[],
+            cards_to_move=[],
+        )
+
+    assert created_ids == [303]
+    assert errors == []
+    add_notes_call = mock_invoke.call_args_list[1]
+    note_payload = add_notes_call.kwargs["notes"][0]
+    assert note_payload["tags"] == ["a", "z"]
 
 
 def test_fetch_model_states_normalizes_dict_styling_payload():

--- a/tests/unit/domain/test_note_models.py
+++ b/tests/unit/domain/test_note_models.py
@@ -380,7 +380,10 @@ class TestParseQABlock:
         md.write_text("Q: Question only")
         with pytest.raises(
             ValueError,
-            match=r"Cannot determine note type from fields: Question \(file: broken-note\.md, line: 1\)",
+            match=(
+                r"Cannot determine note type from fields: Question "
+                r"\(file: broken-note\.md, line: 1\)"
+            ),
         ):
             fs.read_markdown_file(md)
 
@@ -393,7 +396,10 @@ class TestParseQABlock:
         md.write_text("Q: Question only")
         with pytest.raises(
             ValueError,
-            match=r"Cannot determine note type from fields: Question \(file: nested/broken-note\.md, line: 1\)",
+            match=(
+                r"Cannot determine note type from fields: Question "
+                r"\(file: nested/broken-note\.md, line: 1\)"
+            ),
         ):
             fs.read_markdown_file(md, context_root=tmp_path)
 
@@ -402,9 +408,57 @@ class TestParseQABlock:
         md.write_text("<!-- note_key: key-1 -->\nQ: Question only")
         with pytest.raises(
             ValueError,
-            match=r"Cannot determine note type from fields: Question \(file: broken-note\.md, line: 2\)",
+            match=(
+                r"Cannot determine note type from fields: Question "
+                r"\(file: broken-note\.md, line: 2\)"
+            ),
         ):
             fs.read_markdown_file(md)
+
+    def test_qa_with_tags_metadata(self, fs, tmp_path):
+        md = tmp_path / "deck.md"
+        md.write_text(
+            "<!-- note_key: key-1 -->\n"
+            "<!-- tags: z high-yield topic::subtopic z -->\n"
+            "Q: What?\n"
+            "A: Answer"
+        )
+        result = fs.read_markdown_file(md)
+        note = result.notes[0]
+        assert note.note_key == "key-1"
+        assert note.tags == ("high-yield", "topic::subtopic", "z")
+
+    def test_qa_with_tags_before_note_key(self, fs, tmp_path):
+        md = tmp_path / "deck.md"
+        md.write_text(
+            "<!-- tags: anatomy -->\n<!-- note_key: key-1 -->\nQ: What?\nA: Answer"
+        )
+        result = fs.read_markdown_file(md)
+        note = result.notes[0]
+        assert note.note_key == "key-1"
+        assert note.tags == ("anatomy",)
+
+    def test_qa_missing_or_empty_tags_are_empty(self, fs, tmp_path):
+        md = tmp_path / "deck.md"
+        md.write_text(
+            "<!-- tags: -->\n"
+            "Q: With empty tags\n"
+            "A: Answer\n\n"
+            "---\n\n"
+            "Q: Without tags\n"
+            "A: Answer"
+        )
+        result = fs.read_markdown_file(md)
+        assert result.notes[0].tags == ()
+        assert result.notes[1].tags == ()
+
+    def test_tags_comment_inside_code_block_is_field_content(self, fs, tmp_path):
+        md = tmp_path / "deck.md"
+        md.write_text("Q: What?\nA:\n```\n<!-- tags: not-metadata -->\n```")
+        result = fs.read_markdown_file(md)
+        note = result.notes[0]
+        assert note.tags == ()
+        assert "<!-- tags: not-metadata -->" in note.fields["Answer"]
 
 
 class TestMultiNoteFile:
@@ -423,7 +477,10 @@ class TestMultiNoteFile:
         md.write_text("Q: Q1\nA: A1\n\n---\n\nQ: Question only")
         with pytest.raises(
             ValueError,
-            match=r"Cannot determine note type from fields: Question \(file: deck\.md, line: 6\)",
+            match=(
+                r"Cannot determine note type from fields: Question "
+                r"\(file: deck\.md, line: 6\)"
+            ),
         ):
             fs.read_markdown_file(md)
 

--- a/tests/unit/domain/test_tags.py
+++ b/tests/unit/domain/test_tags.py
@@ -1,0 +1,40 @@
+"""Tests for note-level tag helpers."""
+
+from ankiops.tags import format_tags_comment, normalize_tags, parse_tags_comment
+
+
+def test_normalize_tags_handles_empty_input():
+    assert normalize_tags(None) == ()
+    assert normalize_tags("") == ()
+    assert normalize_tags(["", "   "]) == ()
+
+
+def test_normalize_tags_dedupes_trims_and_sorts():
+    assert normalize_tags([" z ", "a", "z", "topic::subtopic"]) == (
+        "a",
+        "topic::subtopic",
+        "z",
+    )
+
+
+def test_normalize_tags_accepts_whitespace_separated_string():
+    assert normalize_tags("z a topic::subtopic a") == (
+        "a",
+        "topic::subtopic",
+        "z",
+    )
+
+
+def test_parse_tags_comment():
+    assert parse_tags_comment("<!-- tags: z a topic::subtopic -->") == (
+        "a",
+        "topic::subtopic",
+        "z",
+    )
+    assert parse_tags_comment("<!-- tags: -->") == ()
+    assert parse_tags_comment("Q: Not a tag comment") is None
+
+
+def test_format_tags_comment_omits_empty_tags():
+    assert format_tags_comment(()) is None
+    assert format_tags_comment(["z", "a"]) == "<!-- tags: a z -->"

--- a/tests/unit/llm/test_runner_execution.py
+++ b/tests/unit/llm/test_runner_execution.py
@@ -95,6 +95,7 @@ def _context(
         {
             "note_key": "nk-1",
             "note_type": "AnkiOpsQA",
+            "tags": ["keep-me"],
             "fields": {
                 "Question": "Broken",
                 "Answer": "Existing answer",
@@ -187,6 +188,7 @@ def test_executor_persists_successful_updates(
     assert persisted["data"]["decks"][0]["notes"][0]["fields"]["Question"] == (
         "Fixed question"
     )
+    assert persisted["data"]["decks"][0]["notes"][0]["tags"] == ["keep-me"]
 
 
 def test_executor_cancels_queued_items_after_fatal_error(

--- a/tests/unit/usecases/test_sync_internals.py
+++ b/tests/unit/usecases/test_sync_internals.py
@@ -6,7 +6,11 @@ from pathlib import Path
 
 from ankiops.config import NOTE_TYPES_DIR, get_collection_dir
 from ankiops.db import SQLiteDbAdapter
-from ankiops.export_notes import _order_resolved_notes, _sync_deck
+from ankiops.export_notes import (
+    _order_resolved_notes,
+    _render_notes_to_markdown,
+    _sync_deck,
+)
 from ankiops.fs import FileSystemAdapter
 from ankiops.import_notes import _flush_writes, _PendingWrite
 from ankiops.models import AnkiNote, MarkdownFile, Note
@@ -103,6 +107,22 @@ def test_sync_deck_records_unknown_note_type_error(tmp_path):
         assert_summary(result.summary, total=0)
     finally:
         db.close()
+
+
+def test_render_notes_to_markdown_places_tags_after_note_key(fs):
+    config_by_name = {config.name: config for config in fs._note_type_configs}
+    note = Note(
+        note_key="key-1",
+        note_type="AnkiOpsQA",
+        fields={"Question": "Q", "Answer": "A"},
+        tags=("z", "a"),
+    )
+
+    rendered = _render_notes_to_markdown([note], config_by_name)
+
+    assert rendered.startswith(
+        "<!-- note_key: key-1 -->\n<!-- tags: a z -->\nQ: Q\nA: A"
+    )
 
 
 def test_order_resolved_notes_preserves_existing_and_appends_new():


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds note-level tag support to AnkiOps, syncing Anki's tag metadata bidirectionally with a new `<!-- tags: ... -->` HTML comment in Markdown files.

- **New `tags.py` module** provides `normalize_tags` (sort + deduplicate), `parse_tags_comment`, and `format_tags_comment` helpers used throughout the codebase.
- **Import and export flows** are updated to read/write the tags comment, include tags in fingerprints (cache invalidation), and pass tags to AnkiConnect's `updateNote` action (replacing the former `updateNoteFields`).
- **`fs.py` receives a correctness fix** as a side-effect: the `in_code_block` guard is now checked *before* the `note_key` and `tags` pattern matches, so metadata comments embedded inside fenced code blocks are no longer mis-parsed as note metadata.

<h3>Confidence Score: 5/5</h3>

Safe to merge — tag sync is correctly propagated through all layers with no data-loss paths found.

The tag feature is implemented end-to-end with consistent normalisation across read, write, fingerprint, and AnkiConnect paths. The switch from `updateNoteFields` to `updateNote` is the right AnkiConnect action for joint field+tag updates. The `in_code_block` guard fix in `fs.py` is a correct improvement. Test coverage spans unit, integration, and serialisation round-trip scenarios. No logic gaps or data-corruption paths were found in the new code.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| ankiops/tags.py | New module: clean helpers for parsing, formatting, and normalising Anki tags. Regex is correctly anchored; normalize_tags is idempotent and handles all input shapes. |
| ankiops/fs.py | Adds tags comment parsing during note block reading; also fixes the pre-existing bug where `in_code_block` was checked after the note_key pattern, now correctly guarding all metadata patterns. |
| ankiops/import_notes.py | Adds code-block-aware `_find_tags_comment_index` to correctly place new note_key comments before existing tags comments; tags are propagated into update/create change contexts. |
| ankiops/export_notes.py | Tags are included in fingerprints and the skip/update comparison; tags comment is rendered after the note_key comment during Markdown export. |
| ankiops/anki.py | Switches update action from `updateNoteFields` to `updateNote` to include tags; note creation payload also includes tags; local variable renamed to avoid shadowing Anki's concept of tags. |
| ankiops/models.py | Adds `tags` field to both `Note` and `AnkiNote` dataclasses; `__post_init__` normalises on construction so consumers always receive a sorted, deduped tuple. |
| ankiops/fingerprints.py | Tags added to the fingerprint payload; schema change silently invalidates all existing cached hashes on first sync after upgrade (noted in prior review comments). |
| tests/support/fake_anki.py | MockAnki gains handlers for `updateNote`, `updateNoteTags`, and `getNoteTags`; note creation and `add_note` helper now propagate tags correctly. |
| tests/integration/sync/test_sync_matrix_import.py | New integration tests cover: fresh create with tags, tag-only update triggering Anki update, and clearing tags when Markdown comment is removed. |
| tests/integration/sync/test_sync_matrix_export.py | New export integration tests: writing Anki tags to Markdown on fresh export, and tag-only Anki edits triggering a Markdown update with idempotent third sync. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant MD as Markdown File
    participant FS as FileSystemAdapter
    participant N as Note domain object
    participant FP as Fingerprints
    participant DB as ankiops.db
    participant AC as AnkiConnect

    rect rgb(230,240,255)
        Note over MD,AC: Import flow (MD to Anki)
        MD->>FS: read_markdown_file
        FS->>FS: parse note_key and tags comments
        FS->>N: Note with normalized tags tuple
        N->>FP: note_fingerprint(type, fields, tags)
        FP-->>DB: store md_hash
        N->>AC: updateNote with fields and tags list
    end

    rect rgb(240,255,230)
        Note over MD,AC: Export flow (Anki to MD)
        AC-->>N: AnkiNote with normalized tags
        N->>FP: note_fingerprint(type, fields, tags)
        FP-->>DB: compare cached md_hash and anki_hash
        N->>MD: render note_key comment then tags comment
    end
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `ankiops/fingerprints.py`, line 270-276 ([link](https://github.com/visserle/ankiops/blob/d543acc38a5d0e20d3a8d97215f0fcfe71ae0dfb/ankiops/fingerprints.py#L270-L276)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Fingerprint schema change silently invalidates all cached hashes on upgrade**

   Adding `tags` to the fingerprint payload changes every note's stored hash without any migration or version bump in the fingerprint scheme. On the first sync after upgrading, every note whose cached `(md_hash, anki_hash)` pair is in `.ankiops.db` will miss the cache and be re-evaluated against Anki — triggering an unnecessary full-collection comparison pass. While this self-corrects, users with large collections may see unexpected "updated" counts on first run. A version tag in the payload (or a one-time cache flush on schema change) would make this more predictable.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["add function to find tags comment index ..."](https://github.com/visserle/ankiops/commit/7e8df083e6d3a5846b797520903f1d5a87dde9a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34026989)</sub>

<!-- /greptile_comment -->