### PR TITLE
add tag access for llm tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Q: How fast do actions potentials propagate in the human body?
 ![](img_hash.png){width=700}
 ```
 
-With the first import, AnkiOps adds a stable `note_key` comment above each note for tracking. -->
+With the first import, AnkiOps adds a stable `note_key` comment above each note for tracking.
+
+same for note type:Inference is only for fresh notes that do not yet have metadata. -->
 
 ## Installation
 

--- a/ankiops/llm/commands.py
+++ b/ankiops/llm/commands.py
@@ -425,11 +425,12 @@ def _show_plan(
     logger.info("Field surface:")
     if plan.field_surface:
         _log_table(
-            ["Type", "Candidates", "Editable", "Read-only", "Hidden"],
+            ["Type", "Candidates", "Tags", "Editable", "Read-only", "Hidden"],
             [
                 [
                     surface.note_type,
                     str(surface.candidate_notes),
+                    surface.tag_access.value,
                     _format_field_list(surface.editable_fields),
                     _format_field_list(surface.read_only_fields),
                     _format_field_list(surface.hidden_fields),

--- a/ankiops/llm/config_loader.py
+++ b/ankiops/llm/config_loader.py
@@ -33,6 +33,7 @@ _SUPPORTED_TASK_KEYS = (
     "user_prompt",
     "request",
     "fields",
+    "tags",
 )
 _SUPPORTED_REQUEST_KEYS = (
     "max_notes_per_request",
@@ -172,6 +173,7 @@ def _parse_task(
         note_type_configs=note_type_configs,
         path=path,
     )
+    tag_access = _parse_tag_access(mapping.get("tags"), path=path)
     request = _parse_request_options(mapping.get("request"), path=path)
 
     return TaskConfig(
@@ -183,6 +185,7 @@ def _parse_task(
         user_prompt_path=user_prompt_path,
         default_field_access=default_field_access,
         field_rules=field_rules,
+        tag_access=tag_access,
         request=request,
     )
 
@@ -282,7 +285,12 @@ def _parse_field_rules(
             f"{path}: unknown fields config key(s): {', '.join(unknown_fields)}"
         )
 
-    default_access = _parse_field_access_value(value.get("default_access"), path=path)
+    default_access = _parse_access_value(
+        value.get("default_access"),
+        path=path,
+        key="fields.default_access",
+        default=FieldAccess.EDITABLE,
+    )
     note_type_names = [config.name for config in note_type_configs]
     field_names = {
         config.name: {field.name for field in config.fields}
@@ -304,21 +312,36 @@ def _parse_field_rules(
     return default_access, rules
 
 
-def _parse_field_access_value(value: Any, *, path: Path) -> FieldAccess:
+def _parse_tag_access(value: Any, *, path: Path) -> FieldAccess:
+    return _parse_access_value(
+        value,
+        path=path,
+        key="tags",
+        default=FieldAccess.HIDDEN,
+    )
+
+
+def _parse_access_value(
+    value: Any,
+    *,
+    path: Path,
+    key: str,
+    default: FieldAccess,
+) -> FieldAccess:
     if value is None:
-        return FieldAccess.EDITABLE
+        return default
     if not isinstance(value, str):
-        return _raise_invalid_field_access(path)
+        return _raise_invalid_access(path, key=key)
     normalized = value.strip()
     for access in FieldAccess:
         if normalized == access.value:
             return access
-    return _raise_invalid_field_access(path)
+    return _raise_invalid_access(path, key=key)
 
 
-def _raise_invalid_field_access(path: Path) -> FieldAccess:
+def _raise_invalid_access(path: Path, *, key: str) -> FieldAccess:
     supported = ", ".join(access.value for access in FieldAccess)
-    raise LlmConfigError(f"{path}: 'fields.default_access' must be one of: {supported}")
+    raise LlmConfigError(f"{path}: '{key}' must be one of: {supported}")
 
 
 def _parse_access_rules_by_note_type(

--- a/ankiops/llm/resources/_system_prompt.md
+++ b/ankiops/llm/resources/_system_prompt.md
@@ -1,10 +1,14 @@
 You are editing serialized Anki notes.
 Return structured output that matches the provided schema exactly.
 Only return entries in updates for fields that should be overwritten.
+Only return entries in tag_updates for tags that should be overwritten.
 Use the exact input note_key and exact editable field names.
 Never modify read_only_fields.
+Never modify read_only_tags.
 Never invent field names or change field names.
 Preserve Markdown structure, math, code fences, links, cloze syntax, and meaning.
 Each update value must contain the full replacement field content, not a diff.
-If no changes are needed, return an empty updates list.
+Each tag update must contain the full replacement tag list, not a diff.
+If no changes are needed, return empty update lists for the keys in the schema.
 Use an empty string only when you intentionally want to clear a field.
+Use an empty tag list only when you intentionally want to clear tags.

--- a/ankiops/llm/resources/autotagger.yaml
+++ b/ankiops/llm/resources/autotagger.yaml
@@ -1,0 +1,17 @@
+model: gpt-5.4-mini
+system_prompt: !file _system_prompt.md
+user_prompt: |
+  Add or update Anki tags based only on the readable note text.
+  Preserve useful existing tags and existing tag namespace style.
+  Return the complete replacement tag list only when tags should change.
+
+fields:
+  default_access: hidden
+  read_only:
+    "*": ["Text", "Question", "Answer"]
+
+tags: editable
+
+request:
+  max_notes_per_request: 3
+  reasoning: low

--- a/ankiops/llm/runner.py
+++ b/ankiops/llm/runner.py
@@ -29,7 +29,12 @@ from ankiops.tags import normalize_tags
 from .config_loader import is_task_config_file, load_llm_task_catalog
 from .llm_db import LlmDb, LlmJobDetail, LlmJobListItem
 from .model_registry import parse_model
-from .schemas import build_response_model, parsed_response_json, parsed_updates
+from .schemas import (
+    build_response_model,
+    parsed_response_json,
+    parsed_tag_updates,
+    parsed_updates,
+)
 from .types import (
     DeckScope,
     DiscoveryCounts,
@@ -454,7 +459,7 @@ class LlmTaskExecutor:
                 _log_note_error(item.candidate, item.error_message)
             elif item.changed_fields:
                 logger.debug(
-                    "  Updated %s in '%s' (%s): fields=%s",
+                    "  Updated %s in '%s' (%s): changed=%s",
                     item.candidate.payload.note_key,
                     item.candidate.deck_name,
                     item.candidate.payload.note_type,
@@ -759,14 +764,26 @@ def _discover_note(
         else:
             editable_fields[field.name] = raw_value
 
-    if not editable_fields:
+    tags = normalize_tags(note.get("tags", ()))
+    editable_tags = tags if task.tag_access is FieldAccess.EDITABLE else None
+    read_only_tags = tags if task.tag_access is FieldAccess.READ_ONLY else None
+    has_editable_surface = bool(editable_fields) or editable_tags is not None
+    has_visible_field_surface = bool(editable_fields) or bool(read_only_fields)
+    if not has_editable_surface or (
+        editable_tags is not None
+        and not editable_fields
+        and not has_visible_field_surface
+    ):
+        skip_reason = (
+            "no readable fields" if has_editable_surface else "no editable fields"
+        )
         return DiscoveryItem(
             ordinal=ordinal,
             deck_name=deck_name,
             note_key=note_key,
             note_type=note_type_name,
             item_status=LlmItemStatus.SKIPPED_NO_EDITABLE_FIELDS,
-            skip_reason="no editable fields",
+            skip_reason=skip_reason,
             error_message=None,
             payload=None,
             note_type_config=note_type_config,
@@ -786,6 +803,8 @@ def _discover_note(
             note_type=note_type_name,
             editable_fields=editable_fields,
             read_only_fields=read_only_fields,
+            editable_tags=editable_tags,
+            read_only_tags=read_only_tags,
         ),
         note_type_config=note_type_config,
         serialized_note=note,
@@ -1046,25 +1065,32 @@ def _build_request_content(
     task: TaskConfig,
     batch: EligibleBatch,
 ) -> tuple[str, str]:
-    notes: list[dict[str, object]] = []
-    for candidate in batch.candidates:
-        note_payload: dict[str, object] = {
-            "note_key": candidate.payload.note_key,
-            "editable_fields": candidate.payload.editable_fields,
-        }
-        if candidate.payload.read_only_fields:
-            note_payload["read_only_fields"] = candidate.payload.read_only_fields
-        notes.append(note_payload)
-
     payload = {
         "user_prompt": task.user_prompt,
         "note_type": batch.note_type,
-        "notes": notes,
+        "notes": [
+            _build_note_request_payload(candidate.payload)
+            for candidate in batch.candidates
+        ],
     }
     return (
         task.system_prompt.strip(),
         json.dumps(payload, ensure_ascii=False),
     )
+
+
+def _build_note_request_payload(payload: NotePayload) -> dict[str, object]:
+    note_payload: dict[str, object] = {
+        "note_key": payload.note_key,
+        "editable_fields": payload.editable_fields,
+    }
+    if payload.read_only_fields:
+        note_payload["read_only_fields"] = payload.read_only_fields
+    if payload.editable_tags is not None:
+        note_payload["editable_tags"] = list(payload.editable_tags)
+    if payload.read_only_tags is not None:
+        note_payload["read_only_tags"] = list(payload.read_only_tags)
+    return note_payload
 
 
 def _openai_error_result(
@@ -1095,6 +1121,7 @@ def _apply_batch_parsed_response(
     batch: EligibleBatch,
 ) -> list[_CandidateApplyResult]:
     updates = parsed_updates(parsed_response)
+    tag_updates = parsed_tag_updates(parsed_response)
     candidates_by_note_key = {
         candidate.payload.note_key: candidate for candidate in batch.candidates
     }
@@ -1102,6 +1129,11 @@ def _apply_batch_parsed_response(
         {
             note_key
             for note_key, _field_name, _value in updates
+            if note_key not in candidates_by_note_key
+        }
+        | {
+            note_key
+            for note_key, _tags in tag_updates
             if note_key not in candidates_by_note_key
         }
     )
@@ -1113,8 +1145,13 @@ def _apply_batch_parsed_response(
     updates_by_note_key: dict[str, list[tuple[str, str, str]]] = {
         note_key: [] for note_key in candidates_by_note_key
     }
+    tag_updates_by_note_key: dict[str, list[tuple[str, list[str]]]] = {
+        note_key: [] for note_key in candidates_by_note_key
+    }
     for update in updates:
         updates_by_note_key[update[0]].append(update)
+    for tag_update in tag_updates:
+        tag_updates_by_note_key[tag_update[0]].append(tag_update)
 
     results: list[_CandidateApplyResult] = []
     for candidate in batch.candidates:
@@ -1122,6 +1159,7 @@ def _apply_batch_parsed_response(
             changed_fields = _apply_candidate_updates(
                 candidate=candidate,
                 updates=updates_by_note_key[candidate.payload.note_key],
+                tag_updates=tag_updates_by_note_key[candidate.payload.note_key],
             )
         except ValueError as error:
             results.append(
@@ -1151,6 +1189,7 @@ def _apply_candidate_updates(
     *,
     candidate: EligibleCandidate,
     updates: list[tuple[str, str, str]],
+    tag_updates: list[tuple[str, list[str]]] | None = None,
 ) -> list[str]:
     seen_fields: set[str] = set()
     edits: dict[str, str] = {}
@@ -1168,16 +1207,31 @@ def _apply_candidate_updates(
             )
         edits[field_name] = value
 
+    tag_edit: tuple[str, ...] | None = None
+    if tag_updates:
+        if len(tag_updates) > 1:
+            raise ValueError("Model returned duplicate update for 'tags'")
+        if candidate.payload.editable_tags is None:
+            if candidate.payload.read_only_tags is not None:
+                raise ValueError("Model attempted to update read-only tags")
+            raise ValueError("Model attempted to update hidden tags")
+        _note_key, raw_tags = tag_updates[0]
+        tag_edit = normalize_tags(raw_tags)
+
     raw_fields = candidate.serialized_note.get("fields")
     if not isinstance(raw_fields, dict):
         raise ValueError("Serialized note fields must be a mapping")
 
     next_fields = dict(raw_fields)
+    next_tags = normalize_tags(candidate.serialized_note.get("tags", ()))
     changed_fields: list[str] = []
     for field_name, value in edits.items():
         if next_fields.get(field_name, "") != value:
             next_fields[field_name] = value
             changed_fields.append(field_name)
+    if tag_edit is not None and next_tags != tag_edit:
+        next_tags = tag_edit
+        changed_fields.append("tags")
 
     if not changed_fields:
         return []
@@ -1186,7 +1240,7 @@ def _apply_candidate_updates(
         note_key=candidate.payload.note_key,
         note_type=candidate.payload.note_type,
         fields=next_fields,
-        tags=normalize_tags(candidate.serialized_note.get("tags", ())),
+        tags=next_tags,
     )
     errors = [*_validate_cloze_text_fields(note, candidate.note_type_config)]
     errors.extend(note.validate(candidate.note_type_config))
@@ -1194,6 +1248,7 @@ def _apply_candidate_updates(
         raise ValueError("; ".join(errors))
 
     candidate.serialized_note["fields"] = next_fields
+    candidate.serialized_note["tags"] = list(next_tags)
     return changed_fields
 
 
@@ -1386,6 +1441,7 @@ def _build_plan_field_surface(
                 editable_fields=editable_fields,
                 read_only_fields=read_only_fields,
                 hidden_fields=hidden_fields,
+                tag_access=task.tag_access,
             )
         )
     return surface
@@ -1394,20 +1450,10 @@ def _build_plan_field_surface(
 def _estimate_batch_input_tokens(task: TaskConfig, payloads: list[NotePayload]) -> int:
     if not payloads:
         return 0
-    notes: list[dict[str, object]] = []
-    for payload in payloads:
-        note_payload: dict[str, object] = {
-            "note_key": payload.note_key,
-            "editable_fields": payload.editable_fields,
-        }
-        if payload.read_only_fields:
-            note_payload["read_only_fields"] = payload.read_only_fields
-        notes.append(note_payload)
-
     request_payload = {
         "user_prompt": task.user_prompt,
         "note_type": payloads[0].note_type,
-        "notes": notes,
+        "notes": [_build_note_request_payload(payload) for payload in payloads],
     }
     return _estimate_tokens(
         "\n".join(

--- a/ankiops/llm/runner.py
+++ b/ankiops/llm/runner.py
@@ -769,11 +769,10 @@ def _discover_note(
     read_only_tags = tags if task.tag_access is FieldAccess.READ_ONLY else None
     has_editable_surface = bool(editable_fields) or editable_tags is not None
     has_visible_field_surface = bool(editable_fields) or bool(read_only_fields)
-    if not has_editable_surface or (
-        editable_tags is not None
-        and not editable_fields
-        and not has_visible_field_surface
-    ):
+    tag_only_without_fields = (
+        editable_tags is not None and not has_visible_field_surface
+    )
+    if not has_editable_surface or tag_only_without_fields:
         skip_reason = (
             "no readable fields" if has_editable_surface else "no editable fields"
         )

--- a/ankiops/llm/schemas.py
+++ b/ankiops/llm/schemas.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from pydantic import ConfigDict, create_model
 
@@ -25,27 +25,46 @@ def build_response_model(
     editable_fields = sorted(
         {field_name for payload in payloads for field_name in payload.editable_fields}
     )
-    if not editable_fields:
-        raise ValueError("response model requires at least one editable field")
+    has_editable_tags = any(payload.editable_tags is not None for payload in payloads)
+    if not editable_fields and not has_editable_tags:
+        raise ValueError(
+            "response model requires at least one editable field or editable tags"
+        )
 
     suffix = _safe_type_name(note_type)
-    update_model = create_model(
-        f"{suffix}Update",
-        __config__=ConfigDict(extra="forbid"),
-        note_key=(_literal(note_keys), ...),
-        field=(_literal(editable_fields), ...),
-        value=(str, ...),
-    )
-    return create_model(
-        f"{suffix}Response",
-        __config__=ConfigDict(extra="forbid"),
-        updates=(list[update_model], ...),
+    response_fields: dict[str, Any] = {}
+    if editable_fields:
+        update_model = create_model(
+            f"{suffix}Update",
+            __config__=ConfigDict(extra="forbid"),
+            note_key=(_literal(note_keys), ...),
+            field=(_literal(editable_fields), ...),
+            value=(str, ...),
+        )
+        update_model_type: Any = update_model
+        response_fields["updates"] = (list[update_model_type], ...)
+    if has_editable_tags:
+        tag_update_model = create_model(
+            f"{suffix}TagUpdate",
+            __config__=ConfigDict(extra="forbid"),
+            note_key=(_literal(note_keys), ...),
+            tags=(list[str], ...),
+        )
+        tag_update_model_type: Any = tag_update_model
+        response_fields["tag_updates"] = (list[tag_update_model_type], ...)
+    return cast(
+        type[Any],
+        create_model(
+            f"{suffix}Response",
+            __config__=ConfigDict(extra="forbid"),
+            **response_fields,
+        ),
     )
 
 
 def parsed_updates(parsed_response: object) -> list[tuple[str, str, str]]:
     """Return ``(note_key, field, value)`` tuples from a parsed Pydantic object."""
-    raw_updates = getattr(parsed_response, "updates", None)
+    raw_updates = getattr(parsed_response, "updates", [])
     if not isinstance(raw_updates, list):
         raise ValueError("Parsed response is missing updates list")
 
@@ -61,6 +80,26 @@ def parsed_updates(parsed_response: object) -> list[tuple[str, str, str]]:
         if not isinstance(value, str):
             raise ValueError("Parsed update value must be a string")
         updates.append((note_key, field, value))
+    return updates
+
+
+def parsed_tag_updates(parsed_response: object) -> list[tuple[str, list[str]]]:
+    """Return ``(note_key, tags)`` tuples from a parsed Pydantic object."""
+    raw_updates = getattr(parsed_response, "tag_updates", [])
+    if not isinstance(raw_updates, list):
+        raise ValueError("Parsed response is missing tag_updates list")
+
+    updates: list[tuple[str, list[str]]] = []
+    for raw_update in raw_updates:
+        note_key = getattr(raw_update, "note_key", None)
+        tags = getattr(raw_update, "tags", None)
+        if not isinstance(note_key, str):
+            raise ValueError("Parsed tag update note_key must be a string")
+        if not isinstance(tags, list) or not all(
+            isinstance(tag, str) for tag in tags
+        ):
+            raise ValueError("Parsed tag update tags must be a list of strings")
+        updates.append((note_key, tags))
     return updates
 
 

--- a/ankiops/llm/types.py
+++ b/ankiops/llm/types.py
@@ -87,6 +87,7 @@ class TaskConfig:
     decks: DeckScope = field(default_factory=DeckScope)
     default_field_access: FieldAccess = FieldAccess.EDITABLE
     field_rules: list[FieldAccessRule] = field(default_factory=list)
+    tag_access: FieldAccess = FieldAccess.HIDDEN
     request: TaskRequestOptions = field(default_factory=TaskRequestOptions)
 
     def field_access(self, note_type: str, field_name: str) -> FieldAccess:
@@ -115,6 +116,8 @@ class NotePayload:
     note_type: str
     editable_fields: dict[str, str]
     read_only_fields: dict[str, str] = field(default_factory=dict)
+    editable_tags: tuple[str, ...] | None = None
+    read_only_tags: tuple[str, ...] | None = None
 
 
 @dataclass(frozen=True)
@@ -231,6 +234,7 @@ class PlanFieldSurface:
     editable_fields: list[str]
     read_only_fields: list[str]
     hidden_fields: list[str]
+    tag_access: FieldAccess
 
 
 @dataclass(frozen=True)

--- a/tests/unit/llm/test_config_loader.py
+++ b/tests/unit/llm/test_config_loader.py
@@ -32,6 +32,7 @@ def test_load_llm_task_catalog_loads_files_fields_and_request(
             "*": ["AI Notes"]
           hidden:
             "AnkiOpsChoice": ["Answer"]
+        tags: editable
         """,
     )
 
@@ -57,6 +58,32 @@ def test_load_llm_task_catalog_loads_files_fields_and_request(
     assert task.field_access("AnkiOpsQA", "Question") is FieldAccess.READ_ONLY
     assert task.field_access("AnkiOpsQA", "AI Notes") is FieldAccess.EDITABLE
     assert task.field_access("AnkiOpsChoice", "Answer") is FieldAccess.HIDDEN
+    assert task.tag_access is FieldAccess.EDITABLE
+
+
+def test_load_llm_task_catalog_defaults_tags_hidden(
+    llm_collection,
+    write_file,
+    llm_qa_config,
+):
+    write_file(
+        llm_collection / "llm/grammar.yaml",
+        """
+        model: test
+        system_prompt: system
+        user_prompt: user
+        request:
+          max_notes_per_request: 1
+        """,
+    )
+
+    catalog = load_llm_task_catalog(
+        llm_collection,
+        note_type_configs=[llm_qa_config],
+    )
+
+    assert not catalog.errors
+    assert catalog.tasks_by_name["grammar"].tag_access is FieldAccess.HIDDEN
 
 
 @pytest.mark.parametrize(
@@ -119,6 +146,17 @@ def test_load_llm_task_catalog_loads_files_fields_and_request(
               reasoning: extreme
             """,
             "request.reasoning' must be one of",
+        ),
+        (
+            """
+            model: test
+            system_prompt: system
+            user_prompt: user
+            tags: read-only
+            request:
+              max_notes_per_request: 1
+            """,
+            "'tags' must be one of",
         ),
     ],
 )

--- a/tests/unit/llm/test_runner_execution.py
+++ b/tests/unit/llm/test_runner_execution.py
@@ -17,6 +17,7 @@ from ankiops.llm.types import (
     DiscoveryCounts,
     DiscoveryItem,
     DiscoverySnapshot,
+    FieldAccess,
     LlmItemStatus,
     NotePayload,
     TaskConfig,
@@ -33,11 +34,15 @@ class _FakeAsyncOpenAI:
         pass
 
 
-def _parsed_response(*updates):
+def _parsed_response(*updates, tag_updates=()):
     return SimpleNamespace(
         updates=[
             SimpleNamespace(note_key=note_key, field=field, value=value)
             for note_key, field, value in updates
+        ],
+        tag_updates=[
+            SimpleNamespace(note_key=note_key, tags=tags)
+            for note_key, tags in tag_updates
         ],
         model_dump=lambda mode: {"updates": []},
     )
@@ -189,6 +194,93 @@ def test_executor_persists_successful_updates(
         "Fixed question"
     )
     assert persisted["data"]["decks"][0]["notes"][0]["tags"] == ["keep-me"]
+
+
+def test_executor_persists_successful_tag_updates(
+    tmp_path,
+    monkeypatch,
+    llm_qa_config,
+):
+    task = TaskConfig(
+        name="autotagger",
+        model=ModelSpec(
+            model="test",
+            model_id="gpt-test",
+            base_url="https://api.openai.com/v1",
+            api_key="$OPENAI_API_KEY",
+            concurrency=1,
+        ),
+        system_prompt="system",
+        user_prompt="user",
+        tag_access=FieldAccess.EDITABLE,
+        request=TaskRequestOptions(max_notes_per_request=1),
+    )
+    note = {
+        "note_key": "nk-1",
+        "note_type": "AnkiOpsQA",
+        "tags": ["old"],
+        "fields": {
+            "Question": "Question",
+            "Answer": "Answer",
+        },
+    }
+    item = DiscoveryItem(
+        ordinal=1,
+        deck_name="Deck",
+        note_key="nk-1",
+        note_type="AnkiOpsQA",
+        item_status=LlmItemStatus.QUEUED,
+        skip_reason=None,
+        error_message=None,
+        payload=NotePayload(
+            note_key="nk-1",
+            note_type="AnkiOpsQA",
+            editable_fields={},
+            read_only_fields={"Question": "Question", "Answer": "Answer"},
+            editable_tags=("old",),
+        ),
+        note_type_config=llm_qa_config,
+        serialized_note=note,
+    )
+    context = MaterializedTaskContext(
+        task=task,
+        note_type_configs={"AnkiOpsQA": llm_qa_config},
+        serialized_data={"decks": [{"name": "Deck", "notes": [note]}]},
+        discovery_snapshot=DiscoverySnapshot(
+            counts=DiscoveryCounts(decks_seen=1, decks_matched=1, notes_seen=1),
+            items=[item],
+        ),
+    )
+    persisted = {}
+
+    async def fake_call_openai(*, batch, **_kwargs):
+        assert batch.candidates[0].payload.editable_tags == ("old",)
+        return _success(
+            _parsed_response(tag_updates=[("nk-1", ["new", "old", "new"])]),
+            input_tokens=7,
+            output_tokens=4,
+        )
+
+    def fake_deserialize(data, **_kwargs):
+        persisted["data"] = data
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr("ankiops.llm.runner.AsyncOpenAI", _FakeAsyncOpenAI)
+    monkeypatch.setattr("ankiops.llm.runner._call_openai", fake_call_openai)
+    monkeypatch.setattr("ankiops.llm.runner.deserialize", fake_deserialize)
+
+    result = asyncio.run(
+        LlmTaskExecutor(
+            collection_dir=tmp_path,
+            materialized_context=context,
+            no_auto_commit=True,
+        ).execute()
+    )
+
+    assert not result.failed
+    assert result.persisted
+    assert result.summary.updated == 1
+    assert persisted["data"]["decks"][0]["notes"][0]["tags"] == ["new", "old"]
 
 
 def test_executor_cancels_queued_items_after_fatal_error(

--- a/tests/unit/llm/test_runner_plan.py
+++ b/tests/unit/llm/test_runner_plan.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from ankiops.config import LLM_DB_FILENAME
 from ankiops.fs import FileSystemAdapter
 from ankiops.llm.runner import plan_task
+from ankiops.llm.types import FieldAccess
 
 
 def test_plan_task_summarizes_scope_surface_and_does_not_persist(
@@ -111,4 +112,83 @@ def test_plan_task_summarizes_scope_surface_and_does_not_persist(
     surface_by_type = {surface.note_type: surface for surface in plan.field_surface}
     assert "AI Notes" in surface_by_type["AnkiOpsQA"].hidden_fields
     assert "Answer" in surface_by_type["AnkiOpsChoice"].read_only_fields
+    assert surface_by_type["AnkiOpsQA"].tag_access is FieldAccess.HIDDEN
     assert not (llm_collection / "llm" / LLM_DB_FILENAME).exists()
+
+
+def test_plan_task_summarizes_autotagger_tag_surface_and_skips_contextless_notes(
+    llm_collection,
+    write_file,
+    monkeypatch,
+):
+    FileSystemAdapter().eject_builtin_note_types(llm_collection / "note_types")
+    write_file(
+        llm_collection / "llm/autotagger.yaml",
+        """
+        model: test
+        system_prompt: system
+        user_prompt: Tag the note.
+        fields:
+          default_access: hidden
+          read_only:
+            "*": ["Text", "Question", "Answer"]
+        tags: editable
+        request:
+          max_notes_per_request: 4
+        """,
+    )
+
+    def fake_serialize(collection_dir, *, deck=None, no_subdecks=False, note_types_dir):
+        return {
+            "decks": [
+                {
+                    "name": "Deck",
+                    "notes": [
+                        {
+                            "note_key": "qa-1",
+                            "note_type": "AnkiOpsQA",
+                            "tags": ["old"],
+                            "fields": {
+                                "Question": "What?",
+                                "Answer": "That.",
+                                "Source": "book",
+                            },
+                        },
+                        {
+                            "note_key": "cloze-1",
+                            "note_type": "AnkiOpsCloze",
+                            "tags": [],
+                            "fields": {
+                                "Text": "{{c1::Cloze}} text",
+                                "Source": "article",
+                            },
+                        },
+                        {
+                            "note_key": "rev-1",
+                            "note_type": "AnkiOpsReversed",
+                            "tags": ["old"],
+                            "fields": {
+                                "Front": "front",
+                                "Back": "back",
+                            },
+                        },
+                    ],
+                }
+            ]
+        }
+
+    monkeypatch.setattr("ankiops.llm.runner.serialize", fake_serialize)
+
+    plan = plan_task(collection_dir=llm_collection, task_name="autotagger")
+
+    assert plan.summary.notes_seen == 3
+    assert plan.summary.eligible == 2
+    assert plan.summary.skipped == 1
+    assert plan.requests_estimate == 2
+    surface_by_type = {surface.note_type: surface for surface in plan.field_surface}
+    assert surface_by_type["AnkiOpsQA"].tag_access is FieldAccess.EDITABLE
+    assert surface_by_type["AnkiOpsCloze"].tag_access is FieldAccess.EDITABLE
+    assert surface_by_type["AnkiOpsReversed"].tag_access is FieldAccess.EDITABLE
+    assert surface_by_type["AnkiOpsQA"].read_only_fields == ["Question", "Answer"]
+    assert surface_by_type["AnkiOpsCloze"].read_only_fields == ["Text"]
+    assert surface_by_type["AnkiOpsReversed"].candidate_notes == 0

--- a/tests/unit/llm/test_schemas.py
+++ b/tests/unit/llm/test_schemas.py
@@ -12,12 +12,16 @@ from ankiops.llm.schemas import build_response_model
 from ankiops.llm.types import EligibleCandidate, LlmItemStatus, NotePayload
 
 
-def _parsed_response(*updates):
+def _parsed_response(*updates, tag_updates=()):
     return SimpleNamespace(
         updates=[
             SimpleNamespace(note_key=note_key, field=field, value=value)
             for note_key, field, value in updates
-        ]
+        ],
+        tag_updates=[
+            SimpleNamespace(note_key=note_key, tags=tags)
+            for note_key, tags in tag_updates
+        ],
     )
 
 
@@ -40,6 +44,38 @@ def _candidate(llm_qa_config) -> EligibleCandidate:
                 "Answer": "Existing answer",
                 "Source": "Book",
                 "AI Notes": "Private",
+            },
+        },
+    )
+
+
+def _tag_candidate(
+    llm_qa_config,
+    *,
+    editable: bool = True,
+    read_only: bool = False,
+    tags: list[str] | None = None,
+) -> EligibleCandidate:
+    current_tags = ["old"] if tags is None else tags
+    return EligibleCandidate(
+        item_id=1,
+        deck_name="Deck",
+        payload=NotePayload(
+            note_key="nk-1",
+            note_type="AnkiOpsQA",
+            editable_fields={},
+            read_only_fields={"Question": "Question", "Answer": "Answer"},
+            editable_tags=tuple(current_tags) if editable else None,
+            read_only_tags=tuple(current_tags) if read_only else None,
+        ),
+        note_type_config=llm_qa_config,
+        serialized_note={
+            "note_key": "nk-1",
+            "note_type": "AnkiOpsQA",
+            "tags": current_tags,
+            "fields": {
+                "Question": "Question",
+                "Answer": "Answer",
             },
         },
     )
@@ -78,6 +114,60 @@ def test_response_model_accepts_only_known_note_keys_and_editable_fields():
         )
 
 
+def test_response_model_accepts_tag_only_updates():
+    response_model = build_response_model(
+        note_type="AnkiOpsQA",
+        payloads=[
+            NotePayload(
+                note_key="nk-1",
+                note_type="AnkiOpsQA",
+                editable_fields={},
+                read_only_fields={"Question": "Question"},
+                editable_tags=(),
+            )
+        ],
+    )
+
+    response_model.model_validate(
+        {"tag_updates": [{"note_key": "nk-1", "tags": ["a", "z"]}]}
+    )
+    with pytest.raises(ValidationError):
+        response_model.model_validate(
+            {"updates": [{"note_key": "nk-1", "field": "tags", "value": "a z"}]}
+        )
+    with pytest.raises(ValidationError):
+        response_model.model_validate(
+            {"tag_updates": [{"note_key": "nk-2", "tags": ["a"]}]}
+        )
+
+
+def test_response_model_accepts_mixed_field_and_tag_updates():
+    response_model = build_response_model(
+        note_type="AnkiOpsQA",
+        payloads=[
+            NotePayload(
+                note_key="nk-1",
+                note_type="AnkiOpsQA",
+                editable_fields={"Question": "Broken"},
+                editable_tags=("old",),
+            )
+        ],
+    )
+
+    response_model.model_validate(
+        {
+            "updates": [
+                {"note_key": "nk-1", "field": "Question", "value": "Fixed"}
+            ],
+            "tag_updates": [{"note_key": "nk-1", "tags": ["new"]}],
+        }
+    )
+    with pytest.raises(ValidationError):
+        response_model.model_validate(
+            {"updates": [{"note_key": "nk-1", "field": "Question", "value": "Fixed"}]}
+        )
+
+
 def test_apply_batch_parsed_response_updates_editable_fields(llm_qa_config):
     candidate = _candidate(llm_qa_config)
 
@@ -96,6 +186,46 @@ def test_apply_batch_parsed_response_updates_editable_fields(llm_qa_config):
         "Source": "Book",
         "AI Notes": "Private",
     }
+
+
+def test_apply_batch_parsed_response_updates_editable_tags(llm_qa_config):
+    candidate = _tag_candidate(llm_qa_config, tags=["old"])
+
+    results = _apply_batch_parsed_response(
+        parsed_response=_parsed_response(tag_updates=[("nk-1", ["z", "a", "z"])]),
+        batch=_batch(candidate),
+    )
+
+    assert len(results) == 1
+    assert results[0].status is LlmItemStatus.SUCCEEDED_UPDATED
+    assert results[0].changed_fields == ["tags"]
+    assert candidate.serialized_note["tags"] == ["a", "z"]
+
+
+def test_apply_batch_parsed_response_can_clear_tags(llm_qa_config):
+    candidate = _tag_candidate(llm_qa_config, tags=["old"])
+
+    results = _apply_batch_parsed_response(
+        parsed_response=_parsed_response(tag_updates=[("nk-1", [])]),
+        batch=_batch(candidate),
+    )
+
+    assert results[0].status is LlmItemStatus.SUCCEEDED_UPDATED
+    assert results[0].changed_fields == ["tags"]
+    assert candidate.serialized_note["tags"] == []
+
+
+def test_apply_batch_parsed_response_normalizes_unchanged_tags(llm_qa_config):
+    candidate = _tag_candidate(llm_qa_config, tags=["a", "z"])
+
+    results = _apply_batch_parsed_response(
+        parsed_response=_parsed_response(tag_updates=[("nk-1", ["z", "a", "z"])]),
+        batch=_batch(candidate),
+    )
+
+    assert results[0].status is LlmItemStatus.SUCCEEDED_UNCHANGED
+    assert results[0].changed_fields == []
+    assert candidate.serialized_note["tags"] == ["a", "z"]
 
 
 def test_apply_batch_parsed_response_rejects_unexpected_note_key(llm_qa_config):
@@ -134,6 +264,30 @@ def test_apply_batch_parsed_response_marks_unsafe_candidate_updates(
     results = _apply_batch_parsed_response(
         parsed_response=_parsed_response(*updates),
         batch=_batch(_candidate(llm_qa_config)),
+    )
+
+    assert len(results) == 1
+    assert results[0].status is LlmItemStatus.NOTE_ERROR
+    assert results[0].changed_fields == []
+    assert results[0].error_message is not None
+    assert expected_error in results[0].error_message
+
+
+@pytest.mark.parametrize(
+    ("candidate_kwargs", "expected_error"),
+    [
+        ({"editable": False, "read_only": True}, "read-only tags"),
+        ({"editable": False, "read_only": False}, "hidden tags"),
+    ],
+)
+def test_apply_batch_parsed_response_marks_unsafe_tag_updates(
+    llm_qa_config,
+    candidate_kwargs,
+    expected_error,
+):
+    results = _apply_batch_parsed_response(
+        parsed_response=_parsed_response(tag_updates=[("nk-1", ["new"])]),
+        batch=_batch(_tag_candidate(llm_qa_config, **candidate_kwargs)),
     )
 
     assert len(results) == 1


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces tag access for LLM tasks, allowing tasks to be configured with `tags: editable`, `tags: read_only`, or `tags: hidden` (default). Tags are now exposed in the LLM request payload and the LLM can return `tag_updates` alongside field `updates` in structured responses.

- Adds `tag_access: FieldAccess` to `TaskConfig` and `NotePayload`, wires tag normalization through discovery, request building, and response application, and updates the Pydantic response schema generation to conditionally include a `tag_updates` field.
- Introduces an `autotagger.yaml` example task, updates the system prompt with tag-specific instructions, and adds comprehensive unit tests covering editable/read-only/hidden tag scenarios, deduplication, and skip logic for notes without visible field context.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changed paths are well-guarded and backed by targeted unit tests.

The tag-access feature is implemented end-to-end with consistent defaults (tags hidden unless explicitly enabled), correct mutual-exclusivity between editable/read-only/hidden states, schema enforcement via extra=forbid, and normalization applied at every tag boundary. Test coverage spans config parsing, schema generation, response application, deduplication, and the skip logic for context-less notes. No unauthorized tag mutations, data-loss paths, or broken contracts were found.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| ankiops/llm/runner.py | Tag discovery, request-payload building, and response application are all updated correctly; the `tag_only_without_fields` skip guard and `_apply_candidate_updates` validation paths look correct. |
| ankiops/llm/schemas.py | Response model generation now conditionally adds `tag_updates`; `parsed_updates` correctly defaults to `[]` (instead of `None`) so field-only models don't raise on missing `updates`. |
| ankiops/llm/config_loader.py | Refactors `_parse_field_access_value` into a generic `_parse_access_value` and adds `_parse_tag_access`; all three `FieldAccess` values are accepted for tags and the default is `HIDDEN`. |
| ankiops/llm/types.py | Adds `tag_access` to `TaskConfig`, `editable_tags`/`read_only_tags` to `NotePayload`, and `tag_access` to `PlanFieldSurface` — all with correct defaults. |
| ankiops/llm/resources/autotagger.yaml | New example task file using `tags: editable` and `fields: default_access: hidden`; demonstrates the intended autotagger workflow. |
| tests/unit/llm/test_schemas.py | Good coverage of tag-only, mixed field+tag, deduplication/normalization, and rejection of unauthorized tag updates. |
| tests/unit/llm/test_runner_execution.py | New `test_executor_persists_successful_tag_updates` exercises the full execution path; deduplication assertion is correct. |
| tests/unit/llm/test_runner_plan.py | New autotagger plan test verifies skip logic (notes with no readable fields are skipped) and correct surface tag_access values. |
| tests/unit/llm/test_config_loader.py | Covers default-hidden behaviour, explicit editable parsing, and invalid value rejection for the new `tags` config key. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Config as config_loader
    participant Runner as runner._discover_note
    participant Builder as _build_note_request_payload
    participant Schema as schemas.build_response_model
    participant LLM as OpenAI Structured Output
    participant Apply as _apply_candidate_updates

    Config->>Runner: "TaskConfig(tag_access=EDITABLE|READ_ONLY|HIDDEN)"
    Runner->>Runner: normalize_tags(note["tags"])
    Runner->>Runner: editable_tags / read_only_tags based on tag_access
    Runner->>Runner: skip if no editable surface OR tag-only without visible fields
    Runner->>Builder: NotePayload(editable_tags, read_only_tags)
    Builder->>LLM: payload with editable_tags / read_only_tags keys
    Schema->>LLM: response schema with optional tag_updates field
    LLM-->>Apply: parsed_response with updates[] + tag_updates[]
    Apply->>Apply: validate tag edits (editable? read-only? hidden?)
    Apply->>Apply: normalize_tags(raw_tags)
    Apply->>Apply: write serialized_note["fields"] + ["tags"]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `GITHUB_DECK_SYNC_NOTE_TYPES.md`, line 1 ([link](https://github.com/visserle/ankiops/blob/7464f4984a830b9a1e52fecaacaca9f4b5d14f39/GITHUB_DECK_SYNC_NOTE_TYPES.md#L1)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Empty file — likely an accidental commit**

   `GITHUB_DECK_SYNC_NOTE_TYPES.md` is completely empty and appears unrelated to the tag-access feature. Was this meant to be included in this PR?
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix condition"](https://github.com/visserle/ankiops/commit/1a7d731b417e95358c31c2558fb8395d6329251a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34585070)</sub>

<!-- /greptile_comment -->