### PR TITLE
update tasks

### DIFF
--- a/ankiops/llm/resources/artifacts.yaml
+++ b/ankiops/llm/resources/artifacts.yaml
@@ -12,6 +12,8 @@ fields:
   read_only:
     "AnkiOpsChoice": ["Answer"]
 
+tags: hidden
+
 request:
   max_notes_per_request: 3
   reasoning: low

--- a/ankiops/llm/resources/autotag.yaml
+++ b/ankiops/llm/resources/autotag.yaml
@@ -1,9 +1,10 @@
-model: gpt-5.4-mini
+model: gpt-5.4-nano
 system_prompt: !file _system_prompt.md
 user_prompt: |
   Add or update Anki tags based only on the readable note text.
   Preserve useful existing tags and existing tag namespace style.
   Return the complete replacement tag list only when tags should change.
+# alternatively, the prompt could define a list of tags from which to choose
 
 fields:
   default_access: hidden

--- a/ankiops/llm/resources/translate.yaml
+++ b/ankiops/llm/resources/translate.yaml
@@ -12,5 +12,7 @@ fields:
   read_only:
     "AnkiOpsChoice": ["Answer"]
 
+tags: editable
+
 request:
   max_notes_per_request: 3


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires up `tags` access for three built-in task configs and renames/downgrades the autotagger task. The semantic intent is clear: artifact-fixing should never touch tags (`hidden`), while translation and auto-tagging should be able to update them (`editable`).

- `artifacts.yaml` gains `tags: hidden`; `translate.yaml` gains `tags: editable` — both are valid `FieldAccess` values parsed by `_parse_tag_access`.
- `autotagger.yaml` is renamed to `autotag.yaml` (changing the ejected task name from `autotagger` to `autotag`) and the model is downgraded from `gpt-5.4-mini` to `gpt-5.4-nano`, which is already present in `_models.yaml`. A YAML comment is also added after the `user_prompt` block — the comment is at indentation 0 and correctly terminates the block scalar without affecting the parsed prompt value.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all three YAML files parse correctly with valid field access values and registered models.

The only finding is a missing trailing newline in `artifacts.yaml` that was already present before this PR. All functional changes (`tags: hidden`, `tags: editable`, model downgrade, file rename) are valid and consistent with the config loader and model registry.

No files require special attention; `artifacts.yaml` has a cosmetic trailing-newline issue.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ankiops/llm/resources/artifacts.yaml | Adds `tags: hidden` to suppress tag editing for the artifact-fixing task; file still lacks a trailing newline. |
| ankiops/llm/resources/autotag.yaml | Renames from `autotagger.yaml` to `autotag.yaml`, downgrades model to `gpt-5.4-nano`, and adds a YAML comment after the `user_prompt` block — all changes are valid. |
| ankiops/llm/resources/translate.yaml | Adds `tags: editable` so the translation task can update tags alongside note content — straightforward and correct. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ankiops init] -->|eject resource YAMLs| B[llm/ directory]

    B --> C[artifacts.yaml\ntags: hidden\nmodel: gpt-5.4-nano]
    B --> D[autotag.yaml\ntags: editable\nmodel: gpt-5.4-nano]
    B --> E[translate.yaml\ntags: editable\nmodel: gpt-5.4-mini]

    C --> F{tag_access}
    D --> F
    E --> F

    F -->|hidden| G[Tags not sent to LLM\nnot updated]
    F -->|editable| H[Tags sent as editable\nLLM may update them]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["update tasks"](https://github.com/visserle/ankiops/commit/c54ed1463ad12dc5ad7a81445d92ca16c3ec730b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34611320)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->