### PR TITLE
add collaboration

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Create a new Markdown file in your initialized AnkiOps folder. For the first imp
 
 ```markdown
 <!-- note_key: 123487556abc -->
+<!-- note_type: AnkiOpsQA -->
 <!-- tags: AnkiOps -->
 Q: Question text here
 A: Answer text here
@@ -82,6 +83,7 @@ M: Content behind a "more" button (optional)
 ---
 
 <!-- note_key: 123474567def -->
+<!-- note_type: AnkiOpsCloze -->
 T: Text with the {{c1::first}} cloze.
 Text with the {{c1::second}} cloze.
 E: Some *formatted* extra info.
@@ -116,7 +118,7 @@ For the last option specifically, the recommended workflow is:
 
 ### How does it work?
 
-AnkiOps assigns a stable `note_key` to each managed note. It is represented by a single-line HTML tag (e.g., `<!-- note_key: a1b2c3d4e5f6 -->`) above a note in the Markdown. AnkiOps note keys are profile-independent, in contrast to Anki's note IDs. The `.ankiops.db`database stores the mapping between Anki's note IDs and AnkiOps note keys, along with other metadata. When syncing, AnkiOps uses these note keys to determine which notes to create, update, or delete in either Anki or Markdown. Media files are stored in a `media/` folder with hashed file names to avoid conflicts.
+AnkiOps assigns a stable `note_key` to each managed note. It is represented by a single-line HTML tag (e.g., `<!-- note_key: a1b2c3d4e5f6 -->`) above a note in the Markdown. AnkiOps also manages a derived `note_type` tag (e.g., `<!-- note_type: AnkiOpsQA -->`) so the resolved type is visible in the file. AnkiOps note keys are profile-independent, in contrast to Anki's note IDs. The `.ankiops.db`database stores the mapping between Anki's note IDs and AnkiOps note keys, along with other metadata. When syncing, AnkiOps uses these note keys to determine which notes to create, update, or delete in either Anki or Markdown. Media files are stored in a `media/` folder with hashed file names to avoid conflicts.
 
 ### What is the recommended workflow?
 

--- a/anki_addon/__init__.py
+++ b/anki_addon/__init__.py
@@ -1,152 +1,33 @@
-"""AnkiOps Anki add-on: Import / Export buttons in the top toolbar.
+"""AnkiOps Anki add-on.
 
-Adds two links to Anki's main toolbar that shell out to the `ankiops`
-CLI (installed separately via `pipx install ankiops`).
+Adds toolbar commands and hosts the local AnkiOps bridge.
 """
 
 from __future__ import annotations
 
-import shutil
-import subprocess
-from pathlib import Path
-from typing import Any
-
 from aqt import gui_hooks, mw
-from aqt.qt import (
-    QDialog,
-    QDialogButtonBox,
-    QFontDatabase,
-    QPlainTextEdit,
-    QVBoxLayout,
-)
 from aqt.toolbar import Toolbar
-from aqt.utils import showCritical, tooltip
 
-ADDON_NAME = "AnkiOps"
+from .bridge_host import AnkiOpsBridgeHost
+from .command_runner import AnkiOpsCommandRunner, add_toolbar_links
 
-
-def _config() -> dict[str, Any]:
-    return mw.addonManager.getConfig(__name__) or {}
-
-
-def _resolve_ankiops_binary() -> str | None:
-    configured = (_config().get("ankiops_path") or "").strip()
-    if configured:
-        path = Path(configured).expanduser()
-        if path.exists():
-            return str(path)
-
-    candidates = [
-        shutil.which("ankiops"),
-        str(Path.home() / ".local" / "bin" / "ankiops"),
-        "/opt/homebrew/bin/ankiops",
-        "/usr/local/bin/ankiops",
-    ]
-    for candidate in candidates:
-        if candidate and Path(candidate).exists():
-            return candidate
-    return None
-
-
-def _collection_dir() -> Path | None:
-    configured = (_config().get("collection_dir") or "").strip()
-    if not configured:
-        return None
-    path = Path(configured).expanduser()
-    return path if path.is_dir() else None
-
-
-def _run_ankiops(command: str) -> None:
-    binary = _resolve_ankiops_binary()
-    if binary is None:
-        showCritical(
-            "Could not find the AnkiOps CLI. Install it with "
-            "`pipx install ankiops`, or set `ankiops_path` in "
-            "Tools → Add-ons → AnkiOps → Config."
-        )
-        return
-
-    cwd = _collection_dir()
-    if cwd is None:
-        showCritical(
-            "Set `collection_dir` in Tools → Add-ons → AnkiOps "
-            "→ Config to point to your AnkiOps collection."
-        )
-        return
-
-    tooltip(f"Running ankiops {command}…")
-
-    def task() -> subprocess.CompletedProcess:
-        return subprocess.run(
-            [binary, command],
-            cwd=str(cwd),
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-
-    def on_done(future) -> None:
-        try:
-            result = future.result()
-        except Exception as error:
-            showCritical(f"Failed to run ankiops: {error}")
-            return
-
-        output = ((result.stdout or "") + (result.stderr or "")).strip()
-        if result.returncode == 0:
-            _show_output(f"ankiops {command} — done", output)
-            if command == "ma":
-                mw.reset()
-        else:
-            _show_output(
-                f"ankiops {command} — failed (exit {result.returncode})", output
-            )
-
-    mw.taskman.run_in_background(task, on_done)
-
-
-def _show_output(title: str, body: str) -> None:
-    dialog = QDialog(mw)
-    dialog.setWindowTitle(title)
-    dialog.resize(600, 400)
-
-    layout = QVBoxLayout(dialog)
-
-    view = QPlainTextEdit(dialog)
-    view.setReadOnly(True)
-    view.setPlainText(body or "(no output)")
-    view.setFont(QFontDatabase.systemFont(QFontDatabase.SystemFont.FixedFont))
-    view.setLineWrapMode(QPlainTextEdit.LineWrapMode.NoWrap)
-    layout.addWidget(view)
-
-    buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok, dialog)
-    buttons.accepted.connect(dialog.accept)
-    layout.addWidget(buttons)
-
-    dialog.exec()
+_command_runner = AnkiOpsCommandRunner(mw=mw, addon_module_name=__name__)
+_bridge_host = AnkiOpsBridgeHost(
+    get_collection=lambda: mw.col,
+    run_on_main=mw.taskman.run_on_main,
+)
 
 
 def _on_toolbar_init(links: list[str], toolbar: Toolbar) -> None:
-    links.insert(
-        -2,
-        toolbar.create_link(
-            cmd="ankiops_anki_to_markdown",
-            label="am",
-            func=lambda: _run_ankiops("am"),
-            tip="ankiops anki-to-markdown",
-            id="ankiops-anki-to-markdown",
-        ),
-    )
-    links.insert(
-        -2,
-        toolbar.create_link(
-            cmd="ankiops_markdown_to_anki",
-            label="ma",
-            func=lambda: _run_ankiops("ma"),
-            tip="ankiops markdown-to-anki",
-            id="ankiops-markdown-to-anki",
-        ),
-    )
+    add_toolbar_links(links, toolbar, _command_runner)
+
+
+def _start_bridge() -> None:
+    _bridge_host.start()
 
 
 gui_hooks.top_toolbar_did_init_links.append(_on_toolbar_init)
+if hasattr(gui_hooks, "profile_did_open"):
+    gui_hooks.profile_did_open.append(_start_bridge)
+else:
+    _start_bridge()

--- a/anki_addon/bridge_actions.py
+++ b/anki_addon/bridge_actions.py
@@ -1,0 +1,226 @@
+"""AnkiOps bridge actions.
+
+This module stays importable without ``aqt`` so bridge behaviour can be tested
+outside Anki.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+BRIDGE_VERSION = 1
+ANKIOPS_KEY_FIELD_NAME = "AnkiOps Key"
+CARD_SNAPSHOT_COLUMNS = (
+    "id",
+    "nid",
+    "ord",
+    "did",
+    "queue",
+    "type",
+    "due",
+    "ivl",
+    "factor",
+    "reps",
+    "lapses",
+    "left",
+    "odue",
+    "odid",
+)
+
+BridgeAction = Callable[[object, dict], object]
+
+
+class BridgeActionError(Exception):
+    """Raised when a bridge action cannot be completed safely."""
+
+
+def dispatch_bridge_action(col, action: str, params: dict):
+    try:
+        handler = BRIDGE_ACTIONS[action]
+    except KeyError as error:
+        raise BridgeActionError(f"Unknown AnkiOps bridge action: {action}") from error
+    return handler(col, params)
+
+
+def version_action(_col, _params: dict) -> dict:
+    return {"version": BRIDGE_VERSION}
+
+
+def change_notes_notetype_action(col, params: dict) -> dict:
+    return change_notes_notetype(
+        col=col,
+        note_ids=params.get("noteIds") or [],
+        old_model=params.get("oldModel") or "",
+        new_model=params.get("newModel") or "",
+    )
+
+
+BRIDGE_ACTIONS: dict[str, BridgeAction] = {
+    "version": version_action,
+    "changeNotesNotetype": change_notes_notetype_action,
+}
+
+
+def change_notes_notetype(col, note_ids, old_model: str, new_model: str) -> dict:
+    note_ids = [int(note_id) for note_id in note_ids]
+    if not note_ids:
+        return {"changed": 0}
+    if not old_model or not new_model:
+        raise BridgeActionError("oldModel and newModel are required.")
+
+    old_notetype = _model_by_name(col.models, old_model)
+    new_notetype = _model_by_name(col.models, new_model)
+    if old_notetype is None:
+        raise BridgeActionError(f"Old note type not found: {old_model}")
+    if new_notetype is None:
+        raise BridgeActionError(f"New note type not found: {new_model}")
+
+    old_fields = _field_names(old_notetype)
+    new_fields = _field_names(new_notetype)
+    if ANKIOPS_KEY_FIELD_NAME not in old_fields:
+        raise BridgeActionError(f"Old note type lacks {ANKIOPS_KEY_FIELD_NAME}.")
+    if ANKIOPS_KEY_FIELD_NAME not in new_fields:
+        raise BridgeActionError(f"New note type lacks {ANKIOPS_KEY_FIELD_NAME}.")
+    field_map = _exact_name_map(old_fields, new_fields, "field")
+    template_map = _exact_name_map(
+        _template_names(old_notetype),
+        _template_names(new_notetype),
+        "template",
+    )
+
+    notes = _load_notes(col, note_ids)
+    for note_id, note in notes.items():
+        actual_model = _note_model_name(note)
+        if actual_model != old_model:
+            raise BridgeActionError(
+                f"Note {note_id} uses '{actual_model}', expected '{old_model}'."
+            )
+
+    before_notes = {
+        note_id: _note_field_values(note, old_notetype)
+        for note_id, note in notes.items()
+    }
+    before_cards = _card_snapshot(col, note_ids)
+
+    info = col.models.change_notetype_info(
+        old_notetype_id=_model_id(old_notetype),
+        new_notetype_id=_model_id(new_notetype),
+    )
+    request = info.input
+    _replace_repeated(request.note_ids, note_ids)
+    _replace_repeated(request.new_fields, field_map)
+    _replace_repeated(request.new_templates, template_map)
+    col.models.change_notetype_of_notes(request)
+
+    after_notes = _load_notes(col, note_ids)
+    after_cards = _card_snapshot(col, note_ids)
+    failures = []
+    for note_id, note in after_notes.items():
+        actual_model = _note_model_name(note)
+        if actual_model != new_model:
+            failures.append(f"note {note_id} still uses '{actual_model}'")
+            continue
+        after_fields = _note_field_values(note, new_notetype)
+        if after_fields != before_notes[note_id]:
+            failures.append(f"note {note_id} fields changed")
+
+    if set(after_notes) != set(notes):
+        failures.append("converted note set changed")
+    if after_cards != before_cards:
+        failures.append("card scheduling or identity changed")
+
+    if failures:
+        raise BridgeActionError(
+            "Post-conversion verification failed: " + "; ".join(failures)
+        )
+
+    return {"changed": len(note_ids)}
+
+
+def _model_by_name(models, name: str):
+    return models.by_name(name)
+
+
+def _model_id(model) -> int:
+    try:
+        return int(model["id"])
+    except Exception as error:
+        raise BridgeActionError("Note type is missing an id.") from error
+
+
+def _field_names(model) -> list[str]:
+    return [_item_name(field) for field in model.get("flds", [])]
+
+
+def _template_names(model) -> list[str]:
+    return [_item_name(template) for template in model.get("tmpls", [])]
+
+
+def _item_name(item) -> str:
+    return item.get("name") or ""
+
+
+def _exact_name_map(old_names: list[str], new_names: list[str], kind: str) -> list[int]:
+    if len(set(old_names)) != len(old_names) or len(set(new_names)) != len(new_names):
+        raise BridgeActionError(f"Duplicate {kind} names are not supported.")
+    if set(old_names) != set(new_names):
+        raise BridgeActionError(
+            f"Cannot convert note type: {kind} names differ "
+            f"({old_names!r} -> {new_names!r})."
+        )
+    return [old_names.index(name) for name in new_names]
+
+
+def _load_notes(col, note_ids: list[int]) -> dict[int, object]:
+    notes = {}
+    for note_id in note_ids:
+        try:
+            note = col.get_note(note_id)
+        except Exception as error:
+            raise BridgeActionError(f"Note not found: {note_id}") from error
+        if note is None:
+            raise BridgeActionError(f"Note not found: {note_id}")
+        notes[note_id] = note
+    return notes
+
+
+def _note_model_name(note) -> str:
+    notetype = note.note_type()
+    if notetype:
+        return notetype.get("name", "")
+    return ""
+
+
+def _note_field_values(note, model) -> dict[str, str]:
+    field_names = _field_names(model)
+    raw_fields = getattr(note, "fields", None)
+    if isinstance(raw_fields, dict):
+        return {name: raw_fields.get(name, "") for name in field_names}
+    if raw_fields is not None:
+        return {
+            name: raw_fields[index] if index < len(raw_fields) else ""
+            for index, name in enumerate(field_names)
+        }
+    return {}
+
+
+def _card_snapshot(col, note_ids: list[int]) -> dict[int, tuple]:
+    if hasattr(col, "ankiops_bridge_cards_snapshot"):
+        return col.ankiops_bridge_cards_snapshot(note_ids)
+
+    placeholders = ",".join("?" for _ in note_ids)
+    columns = ", ".join(CARD_SNAPSHOT_COLUMNS)
+    rows = col.db.all(
+        f"select {columns} from cards where nid in ({placeholders})",
+        *note_ids,
+    )
+    snapshot = {}
+    for row in rows:
+        values = tuple(row)
+        snapshot[int(values[0])] = values
+    return snapshot
+
+
+def _replace_repeated(target, values: list[int]) -> None:
+    del target[:]
+    target.extend(values)

--- a/anki_addon/bridge_host.py
+++ b/anki_addon/bridge_host.py
@@ -80,7 +80,10 @@ class AnkiOpsBridgeHost:
         raw_length = handler.headers.get("Content-Length")
         if raw_length is None:
             raise ValueError("Missing Content-Length.")
-        length = int(raw_length)
+        try:
+            length = int(raw_length)
+        except ValueError as error:
+            raise ValueError("Invalid Content-Length header.") from error
         if length > self._body_limit:
             raise ValueError("Bridge request body is too large.")
         raw = handler.rfile.read(length)

--- a/anki_addon/bridge_host.py
+++ b/anki_addon/bridge_host.py
@@ -1,0 +1,137 @@
+"""HTTP host for the AnkiOps bridge."""
+
+from __future__ import annotations
+
+import json
+import threading
+from collections.abc import Callable
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+from .bridge_actions import dispatch_bridge_action
+
+BRIDGE_HOST = "127.0.0.1"
+BRIDGE_PORT = 8766
+BRIDGE_BODY_LIMIT = 1024 * 1024
+BRIDGE_MAIN_THREAD_TIMEOUT_SECONDS = 30
+
+
+class _BridgeServer(ThreadingHTTPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+
+class AnkiOpsBridgeHost:
+    def __init__(
+        self,
+        *,
+        get_collection: Callable[[], object | None],
+        run_on_main: Callable[[Callable[[], None]], None],
+        dispatch_action: Callable[[object, str, dict], object] = dispatch_bridge_action,
+        host: str = BRIDGE_HOST,
+        port: int = BRIDGE_PORT,
+        body_limit: int = BRIDGE_BODY_LIMIT,
+        timeout_seconds: int = BRIDGE_MAIN_THREAD_TIMEOUT_SECONDS,
+    ) -> None:
+        self._get_collection = get_collection
+        self._run_on_main = run_on_main
+        self._dispatch_action = dispatch_action
+        self._host = host
+        self._port = port
+        self._body_limit = body_limit
+        self._timeout_seconds = timeout_seconds
+        self._server: ThreadingHTTPServer | None = None
+
+    def start(self) -> bool:
+        if self._server is not None:
+            return True
+        try:
+            server = _BridgeServer((self._host, self._port), self._handler_class())
+        except OSError as error:
+            print(f"AnkiOps bridge could not start: {error}")
+            return False
+        thread = threading.Thread(
+            target=server.serve_forever,
+            name="AnkiOpsBridge",
+            daemon=True,
+        )
+        thread.start()
+        self._server = server
+        return True
+
+    def handle_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
+        try:
+            result = self.dispatch_payload(payload)
+            return {"result": result, "error": None}
+        except Exception as error:
+            return {"result": None, "error": str(error)}
+
+    def dispatch_payload(self, payload: dict[str, Any]):
+        action = payload.get("action")
+        params = payload.get("params", {})
+        if not isinstance(action, str) or not isinstance(params, dict):
+            raise ValueError("Bridge requests require action and params.")
+        return self._run_action_on_main(action, params)
+
+    def read_payload(self, handler: BaseHTTPRequestHandler) -> dict[str, Any]:
+        content_type = handler.headers.get("Content-Type", "").split(";")[0]
+        if content_type != "application/json":
+            raise ValueError("Bridge requests must use application/json.")
+        raw_length = handler.headers.get("Content-Length")
+        if raw_length is None:
+            raise ValueError("Missing Content-Length.")
+        length = int(raw_length)
+        if length > self._body_limit:
+            raise ValueError("Bridge request body is too large.")
+        raw = handler.rfile.read(length)
+        payload = json.loads(raw.decode("utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError("Bridge request body must be a JSON object.")
+        return payload
+
+    def _run_action_on_main(self, action: str, params: dict[str, Any]):
+        done = threading.Event()
+        box: dict[str, Any] = {}
+
+        def work() -> None:
+            try:
+                collection = self._get_collection()
+                if collection is None:
+                    raise RuntimeError("No Anki collection is open.")
+                box["result"] = self._dispatch_action(collection, action, params)
+            except Exception as error:
+                box["error"] = str(error)
+            finally:
+                done.set()
+
+        self._run_on_main(work)
+        if not done.wait(timeout=self._timeout_seconds):
+            raise RuntimeError("Timed out waiting for Anki main thread.")
+        if "error" in box:
+            raise RuntimeError(box["error"])
+        return box.get("result")
+
+    def _handler_class(self):
+        bridge_host = self
+
+        class _BridgeHandler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:
+                try:
+                    payload = bridge_host.read_payload(self)
+                    response = bridge_host.handle_payload(payload)
+                except Exception as error:
+                    response = {"result": None, "error": str(error)}
+                self._send_json(response)
+
+            def log_message(self, _format: str, *_args) -> None:
+                return
+
+            def _send_json(self, payload: dict[str, Any]) -> None:
+                body = json.dumps(payload).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+        return _BridgeHandler

--- a/anki_addon/command_runner.py
+++ b/anki_addon/command_runner.py
@@ -1,0 +1,142 @@
+"""Toolbar command runner for the AnkiOps add-on."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from aqt.qt import (
+    QDialog,
+    QDialogButtonBox,
+    QFontDatabase,
+    QPlainTextEdit,
+    QVBoxLayout,
+)
+from aqt.utils import showCritical, tooltip
+
+
+class AnkiOpsCommandRunner:
+    def __init__(self, *, mw, addon_module_name: str) -> None:
+        self._mw = mw
+        self._addon_module_name = addon_module_name
+
+    def run(self, command: str) -> None:
+        binary = self._resolve_ankiops_binary()
+        if binary is None:
+            showCritical(
+                "Could not find the AnkiOps CLI. Install it with "
+                "`pipx install ankiops`, or set `ankiops_path` in "
+                "Tools → Add-ons → AnkiOps → Config."
+            )
+            return
+
+        cwd = self._collection_dir()
+        if cwd is None:
+            showCritical(
+                "Set `collection_dir` in Tools → Add-ons → AnkiOps "
+                "→ Config to point to your AnkiOps collection."
+            )
+            return
+
+        tooltip(f"Running ankiops {command}…")
+
+        def task() -> subprocess.CompletedProcess:
+            return subprocess.run(
+                [binary, command],
+                cwd=str(cwd),
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        def on_done(future) -> None:
+            try:
+                result = future.result()
+            except Exception as error:
+                showCritical(f"Failed to run ankiops: {error}")
+                return
+
+            output = ((result.stdout or "") + (result.stderr or "")).strip()
+            if result.returncode == 0:
+                self._show_output(f"ankiops {command} — done", output)
+                if command == "ma":
+                    self._mw.reset()
+            else:
+                self._show_output(
+                    f"ankiops {command} — failed (exit {result.returncode})", output
+                )
+
+        self._mw.taskman.run_in_background(task, on_done)
+
+    def _config(self) -> dict[str, Any]:
+        return self._mw.addonManager.getConfig(self._addon_module_name) or {}
+
+    def _resolve_ankiops_binary(self) -> str | None:
+        configured = (self._config().get("ankiops_path") or "").strip()
+        if configured:
+            path = Path(configured).expanduser()
+            if path.exists():
+                return str(path)
+
+        candidates = [
+            shutil.which("ankiops"),
+            str(Path.home() / ".local" / "bin" / "ankiops"),
+            "/opt/homebrew/bin/ankiops",
+            "/usr/local/bin/ankiops",
+        ]
+        for candidate in candidates:
+            if candidate and Path(candidate).exists():
+                return candidate
+        return None
+
+    def _collection_dir(self) -> Path | None:
+        configured = (self._config().get("collection_dir") or "").strip()
+        if not configured:
+            return None
+        path = Path(configured).expanduser()
+        return path if path.is_dir() else None
+
+    def _show_output(self, title: str, body: str) -> None:
+        dialog = QDialog(self._mw)
+        dialog.setWindowTitle(title)
+        dialog.resize(600, 400)
+
+        layout = QVBoxLayout(dialog)
+
+        view = QPlainTextEdit(dialog)
+        view.setReadOnly(True)
+        view.setPlainText(body or "(no output)")
+        view.setFont(QFontDatabase.systemFont(QFontDatabase.SystemFont.FixedFont))
+        view.setLineWrapMode(QPlainTextEdit.LineWrapMode.NoWrap)
+        layout.addWidget(view)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok, dialog)
+        buttons.accepted.connect(dialog.accept)
+        layout.addWidget(buttons)
+
+        dialog.exec()
+
+
+def add_toolbar_links(links: list[str], toolbar, runner: AnkiOpsCommandRunner) -> None:
+    links.insert(
+        -2,
+        toolbar.create_link(
+            cmd="ankiops_anki_to_markdown",
+            label="am",
+            func=lambda: runner.run("am"),
+            tip="ankiops anki-to-markdown",
+            id="ankiops-anki-to-markdown",
+        ),
+    )
+    links.insert(
+        -2,
+        toolbar.create_link(
+            cmd="ankiops_markdown_to_anki",
+            label="ma",
+            func=lambda: runner.run("ma"),
+            tip="ankiops markdown-to-anki",
+            id="ankiops-markdown-to-anki",
+        ),
+    )

--- a/ankiops/anki.py
+++ b/ankiops/anki.py
@@ -5,6 +5,7 @@ import shutil
 from pathlib import Path
 
 from ankiops.anki_client import AnkiConnectError, invoke
+from ankiops.ankiops_bridge import change_notes_notetype
 from ankiops.models import (
     ANKIOPS_KEY_FIELD,
     AnkiNote,
@@ -29,6 +30,17 @@ FIELD_DESCRIPTIONS = {
 
 def _action(action_str: str, **params) -> dict:
     return {"action": action_str, "params": params}
+
+
+def _quote_search_value(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def _quote_field_exact_search(field_name: str, value: str) -> str:
+    escaped_field = field_name.replace("\\", "\\\\").replace('"', '\\"')
+    escaped_value = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped_field}:{escaped_value}"'
 
 
 def _normalize_model_styling_payload(styling: object, *, model_name: str) -> str:
@@ -63,14 +75,45 @@ class AnkiAdapter:
         """Get the currently active Anki profile name."""
         return invoke("getActiveProfile")
 
+    def change_notes_notetype(
+        self,
+        note_ids: list[int],
+        old_model: str,
+        new_model: str,
+    ) -> None:
+        change_notes_notetype(note_ids, old_model, new_model)
+
     def fetch_deck_names_and_ids(self) -> dict[str, int]:
         return invoke("deckNamesAndIds")
 
     def fetch_all_note_ids(self, required_types: list[str]) -> list[int]:
         if not required_types:
             return []
-        query = " OR ".join(f"note:{model_name}" for model_name in required_types)
+        query = " OR ".join(
+            f"note:{_quote_search_value(model_name)}" for model_name in required_types
+        )
         return invoke("findNotes", query=query)
+
+    def fetch_note_ids_by_note_keys(self, note_keys: set[str]) -> dict[str, list[int]]:
+        if not note_keys:
+            return {}
+        keys = sorted(note_keys)
+        actions = [
+            _action(
+                "findNotes",
+                query=_quote_field_exact_search(ANKIOPS_KEY_FIELD.name, note_key),
+            )
+            for note_key in keys
+        ]
+        results = invoke("multi", actions=actions)
+        note_ids_by_key = {}
+        for note_key, result in zip(keys, results):
+            if isinstance(result, str):
+                raise AnkiConnectError(
+                    f"Failed to search notes by AnkiOps Key '{note_key}': {result}"
+                )
+            note_ids_by_key[note_key] = list(result or [])
+        return note_ids_by_key
 
     def fetch_cards_info(self, card_ids: list[int]) -> dict[int, dict]:
         if not card_ids:

--- a/ankiops/ankiops_bridge.py
+++ b/ankiops/ankiops_bridge.py
@@ -1,0 +1,83 @@
+"""Client for the AnkiOps add-on bridge."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+
+ANKIOPS_BRIDGE_URL = "http://127.0.0.1:8766"
+CHANGE_NOTETYPE_ACTION = "changeNotesNotetype"
+
+DEFAULT_TIMEOUT_SECONDS = 10
+
+
+class AnkiOpsBridgeError(Exception):
+    """Raised when the AnkiOps add-on bridge is unavailable or returns an error."""
+
+
+class AnkiOpsBridgeClient:
+    def __init__(
+        self,
+        *,
+        url: str = ANKIOPS_BRIDGE_URL,
+        session: requests.Session | None = None,
+        timeout: int = DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        self._url = url
+        self._session = session or requests.Session()
+        self._timeout = timeout
+
+    def version(self) -> dict[str, Any]:
+        return self._invoke("version", {})
+
+    def change_notes_notetype(
+        self,
+        note_ids: list[int],
+        old_model: str,
+        new_model: str,
+    ) -> dict[str, Any]:
+        return self._invoke(
+            CHANGE_NOTETYPE_ACTION,
+            {
+                "noteIds": note_ids,
+                "oldModel": old_model,
+                "newModel": new_model,
+            },
+        )
+
+    def _invoke(self, action: str, params: dict[str, Any]) -> Any:
+        try:
+            response = self._session.post(
+                self._url,
+                json={"action": action, "params": params},
+                timeout=self._timeout,
+            )
+        except requests.RequestException as error:
+            raise AnkiOpsBridgeError(
+                f"Unable to reach AnkiOps bridge at {self._url}: {error}"
+            ) from error
+
+        try:
+            payload = response.json()
+        except ValueError as error:
+            raise AnkiOpsBridgeError(
+                "AnkiOps bridge returned a non-JSON response."
+            ) from error
+
+        if payload.get("error"):
+            raise AnkiOpsBridgeError(str(payload["error"]))
+        if "result" not in payload:
+            raise AnkiOpsBridgeError("AnkiOps bridge response missing 'result' field.")
+        return payload["result"]
+
+
+_default_client = AnkiOpsBridgeClient()
+
+
+def change_notes_notetype(
+    note_ids: list[int],
+    old_model: str,
+    new_model: str,
+) -> dict[str, Any]:
+    return _default_client.change_notes_notetype(note_ids, old_model, new_model)

--- a/ankiops/cli.py
+++ b/ankiops/cli.py
@@ -300,9 +300,17 @@ def run_deserialize(args):
         logger.error(f"Serialized file not found: {serialized_file}")
         raise SystemExit(1)
 
+    collection_dir = require_collection_dir()
+    if not args.no_auto_commit:
+        logger.debug("Creating pre-deserialize git snapshot")
+        git_snapshot(collection_dir, "deserialize")
+    else:
+        logger.debug("Auto-commit disabled (--no-auto-commit)")
+
     deserialize_from_file(
         serialized_file,
         overwrite=args.overwrite,
+        collection_dir=collection_dir,
     )
 
 
@@ -345,7 +353,7 @@ def run_fix_image_widths(args):
         f"{result.images_changed} images changed"
     )
     if result.changed:
-        logger.info("Only local Markdown files were edited. Run 'ankiops ma' to sync.")
+        logger.info("Only Markdown files were edited. Run 'ankiops ma' to sync.")
 
 
 def run_llm(args):
@@ -354,9 +362,16 @@ def run_llm(args):
         args,
         require_collection_dir_fn=require_collection_dir,
         load_note_type_configs_fn=(
-            lambda note_types_dir: FileSystemAdapter().load_note_type_configs(
-                note_types_dir
-            )
+            lambda note_types_dir: [
+                config
+                for source_config in load_configs_for_sources(
+                    discover_sync_sources(
+                        note_types_dir.parent,
+                        note_types_dir=note_types_dir,
+                    )
+                )
+                for config in source_config.configs
+            ]
         ),
         load_llm_task_catalog_fn=load_llm_task_catalog,
         plan_task_fn=plan_task,
@@ -474,7 +489,7 @@ def main():
     # Deserialize parser
     deserialize_parser = subparsers.add_parser(
         "deserialize",
-        help="Import markdown from JSON (run 'init' after to set up)",
+        help="Import markdown from JSON into an initialized collection",
     )
     deserialize_parser.add_argument(
         "--input",
@@ -485,6 +500,12 @@ def main():
         "--overwrite",
         action="store_true",
         help="Overwrite existing markdown files",
+    )
+    deserialize_parser.add_argument(
+        "--no-auto-commit",
+        "-n",
+        action="store_true",
+        help="Skip the automatic git commit for this operation",
     )
     deserialize_parser.set_defaults(handler=run_deserialize)
 

--- a/ankiops/cli.py
+++ b/ankiops/cli.py
@@ -1,12 +1,15 @@
 import argparse
 import logging
+import subprocess
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
+from types import SimpleNamespace
 
 from rich.markup import escape as rich_escape
 
 from ankiops.anki_client import AnkiConnectError
 from ankiops.cli_anki import connect_or_exit
+from ankiops.collab import run as run_collab_impl
 from ankiops.config import (
     NOTE_TYPES_DIR,
     deck_name_to_file_stem,
@@ -31,14 +34,28 @@ from ankiops.serializer import (
     deserialize_from_file,
     serialize_to_file,
 )
+from ankiops.sources import discover_sync_sources, load_configs_for_sources
 from ankiops.sync_media import (
     format_media_status,
-    sync_media_from_anki,
-    sync_media_to_anki,
+    sync_all_media_from_anki,
+    sync_all_media_to_anki,
 )
-from ankiops.sync_note_types import sync_note_types
+from ankiops.sync_note_types import sync_note_type_configs
 
 logger = logging.getLogger(__name__)
+
+sync_media_from_anki = sync_all_media_from_anki
+sync_media_to_anki = sync_all_media_to_anki
+
+
+def sync_note_types(anki_port, fs_port, collection_dir, note_types_dir, db_port):
+    sources = discover_sync_sources(collection_dir, note_types_dir=note_types_dir)
+    configs = [
+        config
+        for source_config in load_configs_for_sources(sources)
+        for config in source_config.configs
+    ]
+    return sync_note_type_configs(anki_port, configs, db_port=db_port)
 
 
 def _positive_int(value: str) -> int:
@@ -183,7 +200,7 @@ def run_ma(args):
         logger.warning(f"Media sync failed: {error}")
 
     logger.debug("Starting note type sync")
-    nt_summary = sync_note_types(anki, fs, note_types_dir, db)
+    nt_summary = sync_note_types(anki, fs, collection_dir, note_types_dir, db)
     if nt_summary:
         logger.info(f"Note types: {nt_summary}")
 
@@ -349,6 +366,22 @@ def run_llm(args):
     )
 
 
+def run_collab(args):
+    try:
+        if getattr(args, "collab_command", None) == "contribute" and args.from_anki:
+            run_am(SimpleNamespace(no_auto_commit=False))
+        run_collab_impl(args)
+        if getattr(args, "collab_command", None) == "pull" and args.to_anki:
+            run_ma(SimpleNamespace(no_auto_commit=False))
+    except ValueError as error:
+        logger.error(str(error))
+        raise SystemExit(1) from error
+    except subprocess.CalledProcessError as error:
+        output = ((error.stdout or "") + (error.stderr or "")).strip()
+        logger.error(output or f"git command failed with exit {error.returncode}")
+        raise SystemExit(1) from error
+
+
 def _get_cli_version() -> str:
     try:
         return version("ankiops")
@@ -489,6 +522,86 @@ def main():
     fix_widths_parser.set_defaults(handler=run_fix_image_widths)
 
     configure_llm_parser(subparsers, handler=run_llm)
+
+    collab_parser = subparsers.add_parser(
+        "collab",
+        help="Publish, subscribe to, update, and contribute GitHub collab decks",
+    )
+    collab_subparsers = collab_parser.add_subparsers(
+        dest="collab_command",
+        required=True,
+    )
+
+    collab_publish = collab_subparsers.add_parser(
+        "publish",
+        help="Publish a local deck tree to a GitHub collab source",
+    )
+    collab_publish.add_argument("deck", help="Deck to publish (includes subdecks)")
+    collab_publish.add_argument(
+        "repo",
+        help="GitHub repo as owner/repo (letters, digits, hyphens)",
+    )
+    publish_visibility = collab_publish.add_mutually_exclusive_group()
+    publish_visibility.add_argument(
+        "--public",
+        action="store_true",
+        help="Create the GitHub repo as public when it does not exist",
+    )
+    publish_visibility.add_argument(
+        "--private",
+        action="store_false",
+        dest="public",
+        help="Create the GitHub repo as private when it does not exist (default)",
+    )
+    collab_publish.set_defaults(public=False)
+    collab_publish.set_defaults(handler=run_collab)
+
+    collab_subscribe = collab_subparsers.add_parser(
+        "subscribe",
+        help="Add a GitHub collab source to this collection",
+    )
+    collab_subscribe.add_argument(
+        "repo",
+        help="GitHub repo as owner/repo (letters, digits, hyphens)",
+    )
+    collab_subscribe.set_defaults(handler=run_collab)
+
+    collab_pull = collab_subparsers.add_parser(
+        "pull",
+        help="Pull one or all collab sources from GitHub",
+    )
+    collab_pull.add_argument(
+        "repo",
+        nargs="?",
+        help="GitHub repo as owner/repo (letters, digits, hyphens)",
+    )
+    collab_pull.add_argument(
+        "--to-anki",
+        action="store_true",
+        help="Run Markdown -> Anki after pulling files",
+    )
+    collab_pull.set_defaults(handler=run_collab)
+
+    collab_contribute = collab_subparsers.add_parser(
+        "contribute",
+        help="Prepare a GitHub PR from local collab source edits",
+    )
+    collab_contribute.add_argument(
+        "repo",
+        help="GitHub repo as owner/repo (letters, digits, hyphens)",
+    )
+    collab_contribute.add_argument(
+        "--from-anki",
+        action="store_true",
+        help="Run Anki -> Markdown before preparing the contribution",
+    )
+    collab_contribute.set_defaults(handler=run_collab)
+
+    collab_status = collab_subparsers.add_parser(
+        "status",
+        help="Show known collab sources",
+    )
+    collab_status.set_defaults(handler=run_collab)
 
     note_types_parser = subparsers.add_parser(
         "note-types",

--- a/ankiops/collab.py
+++ b/ankiops/collab.py
@@ -1,0 +1,758 @@
+"""GitHub-native collaboration source commands."""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+import subprocess
+import uuid
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+import yaml
+
+from ankiops.ankiops_bridge import AnkiOpsBridgeError
+from ankiops.cli_anki import connect_or_exit
+from ankiops.config import (
+    LOCAL_MEDIA_DIR,
+    NOTE_TYPES_DIR,
+    file_stem_to_deck_name,
+    require_collection_dir,
+)
+from ankiops.export_notes import _render_notes_to_markdown
+from ankiops.fs import FileSystemAdapter
+from ankiops.log import clickable_path
+from ankiops.models import ANKIOPS_KEY_FIELD, MarkdownFile, NoteTypeConfig
+from ankiops.sources import (
+    COLLAB_BRANCH,
+    SyncSource,
+    discover_sync_sources,
+    load_configs_for_source,
+    markdown_files_for_source,
+)
+from ankiops.sync_media import _extract_media_references
+from ankiops.sync_note_types import sync_note_type_configs
+
+logger = logging.getLogger(__name__)
+
+_SAFE_SLUG_PART_RE = re.compile(
+    r"^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$"
+)
+_GITHUB_OWNER_MAX_LENGTH = 39
+_GITHUB_REPO_MAX_LENGTH = 100
+
+
+@dataclass(frozen=True)
+class _RenderedPublishFile:
+    source_path: Path
+    target_path: Path
+    content: str
+
+
+@dataclass(frozen=True)
+class _PublishPlan:
+    source: SyncSource
+    deck_name: str
+    deck_names: set[str]
+    files: list[_RenderedPublishFile]
+    scoped_configs: list[NoteTypeConfig]
+    note_types_used: set[str]
+    note_type_by_key: dict[str, str]
+    media_used: set[str]
+    note_keys: set[str]
+
+
+def _parse_slug(slug: str) -> tuple[str, str]:
+    parts = slug.strip().removesuffix(".git").split("/")
+    if len(parts) != 2 or not all(parts):
+        raise ValueError("Expected GitHub repo as owner/repo")
+    owner, repo = parts
+    _validate_slug_part(
+        slug=slug,
+        label="owner",
+        value=owner,
+        max_length=_GITHUB_OWNER_MAX_LENGTH,
+    )
+    _validate_slug_part(
+        slug=slug,
+        label="repo",
+        value=repo,
+        max_length=_GITHUB_REPO_MAX_LENGTH,
+    )
+    return owner, repo
+
+
+def _validate_slug_part(
+    *,
+    slug: str,
+    label: str,
+    value: str,
+    max_length: int,
+) -> None:
+    if len(value) > max_length or not _SAFE_SLUG_PART_RE.fullmatch(value):
+        raise ValueError(
+            f"Invalid GitHub repo slug '{slug}'. AnkiOps collab {label} names "
+            "must use only ASCII letters, digits, and hyphens, must start and "
+            "end with a letter or digit, and must be "
+            f"{max_length} characters or fewer."
+        )
+
+
+def _source_for_slug(collection_dir: Path, slug: str) -> SyncSource:
+    owner, repo = _parse_slug(slug)
+    return SyncSource.collab(collection_dir, owner, repo)
+
+
+def _source_prefix(collection_dir: Path, source: SyncSource) -> str:
+    return str(source.root.relative_to(collection_dir))
+
+
+def _run_git(collection_dir: Path, args: list[str]) -> subprocess.CompletedProcess:
+    logger.debug("git %s", " ".join(args))
+    return subprocess.run(
+        ["git", *args],
+        cwd=collection_dir,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+
+def _ensure_git_repo(collection_dir: Path) -> None:
+    try:
+        _run_git(collection_dir, ["rev-parse", "--git-dir"])
+    except subprocess.CalledProcessError as error:
+        raise ValueError("Collab commands require a git-backed collection.") from error
+
+
+def _is_git_tracked(collection_dir: Path, rel_path: str) -> bool:
+    result = subprocess.run(
+        ["git", "ls-files", "--error-unmatch", "--", rel_path],
+        cwd=collection_dir,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def _git_commit_paths(collection_dir: Path, paths: list[Path], message: str) -> None:
+    if not paths:
+        return
+    rel_paths = []
+    seen = set()
+    for path in paths:
+        rel_path = str(path.relative_to(collection_dir))
+        if rel_path in seen:
+            continue
+        if path.exists() or _is_git_tracked(collection_dir, rel_path):
+            rel_paths.append(rel_path)
+            seen.add(rel_path)
+    if not rel_paths:
+        return
+    _run_git(collection_dir, ["add", "-A", "--", *rel_paths])
+    diff = subprocess.run(
+        ["git", "diff", "--cached", "--quiet", "--", *rel_paths],
+        cwd=collection_dir,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if diff.returncode == 0:
+        return
+    _run_git(collection_dir, ["commit", "-m", message, "--", *rel_paths])
+
+
+def _subtree_add(collection_dir: Path, source: SyncSource) -> None:
+    if source.github_url is None:
+        raise ValueError(f"Cannot derive GitHub URL for {source.display_name}")
+    _run_git(
+        collection_dir,
+        [
+            "subtree",
+            "add",
+            "--prefix",
+            _source_prefix(collection_dir, source),
+            source.github_url,
+            COLLAB_BRANCH,
+        ],
+    )
+
+
+def _subtree_pull(collection_dir: Path, source: SyncSource) -> None:
+    if source.github_url is None:
+        raise ValueError(f"Cannot derive GitHub URL for {source.display_name}")
+    _run_git(
+        collection_dir,
+        [
+            "subtree",
+            "pull",
+            "--prefix",
+            _source_prefix(collection_dir, source),
+            source.github_url,
+            COLLAB_BRANCH,
+        ],
+    )
+
+
+def _subtree_split(collection_dir: Path, source: SyncSource) -> str:
+    branch = f"ankiops-{source.source_id.replace('/', '-')}-{uuid.uuid4().hex[:8]}"
+    _run_git(
+        collection_dir,
+        [
+            "subtree",
+            "split",
+            "--prefix",
+            _source_prefix(collection_dir, source),
+            "-b",
+            branch,
+        ],
+    )
+    return branch
+
+
+def _visibility_flag(public: bool) -> str:
+    return "--public" if public else "--private"
+
+
+def _manual_repo_create_command(source: SyncSource, *, public: bool) -> str:
+    slug = source.github_slug or source.source_id
+    return f"gh repo create {slug} {_visibility_flag(public)}"
+
+
+def _github_repo_exists(collection_dir: Path, source: SyncSource) -> bool:
+    slug = source.github_slug
+    if slug is None or source.github_url is None:
+        raise ValueError(f"Cannot derive GitHub repo for {source.display_name}")
+
+    gh_path = shutil.which("gh")
+    if gh_path:
+        result = subprocess.run(
+            [gh_path, "repo", "view", slug],
+            cwd=collection_dir,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        return result.returncode == 0
+
+    result = subprocess.run(
+        ["git", "ls-remote", source.github_url],
+        cwd=collection_dir,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def _create_github_repo(
+    collection_dir: Path,
+    source: SyncSource,
+    *,
+    public: bool,
+) -> None:
+    slug = source.github_slug
+    gh_path = shutil.which("gh")
+    if slug is None or gh_path is None:
+        raise ValueError(
+            "GitHub repository does not exist or is not accessible. "
+            "Create it first with: "
+            f"{_manual_repo_create_command(source, public=public)}"
+        )
+
+    logger.info("Creating GitHub repository %s", slug)
+    result = subprocess.run(
+        [gh_path, "repo", "create", slug, _visibility_flag(public)],
+        cwd=collection_dir,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "unknown error"
+        raise ValueError(
+            f"GitHub repository {slug} does not exist and AnkiOps could not "
+            f"create it with gh: {detail}. Create it first with: "
+            f"{_manual_repo_create_command(source, public=public)}"
+        )
+
+
+def _ensure_publish_repo(
+    collection_dir: Path,
+    source: SyncSource,
+    *,
+    public: bool,
+) -> None:
+    if _github_repo_exists(collection_dir, source):
+        return
+    if shutil.which("gh") is None:
+        raise ValueError(
+            "GitHub repository does not exist or is not accessible: "
+            f"{source.github_slug}. Create it first with: "
+            f"{_manual_repo_create_command(source, public=public)}"
+        )
+    _create_github_repo(collection_dir, source, public=public)
+
+
+def _selected_deck_files(collection_dir: Path, deck: str) -> list[Path]:
+    deck_filter = deck.strip()
+    subdeck_scope = f"{deck_filter}::"
+    files = []
+    for md_file in sorted(collection_dir.glob("*.md")):
+        deck_name = file_stem_to_deck_name(md_file.stem)
+        if deck_name == deck_filter or deck_name.startswith(subdeck_scope):
+            files.append(md_file)
+    if not files:
+        raise ValueError(f"No local deck files found for '{deck}'")
+    return files
+
+
+def _deck_names_for_files(files: list[Path]) -> set[str]:
+    return {file_stem_to_deck_name(md_file.stem) for md_file in files}
+
+
+def _scoped_configs(
+    source: SyncSource,
+    configs: list[NoteTypeConfig],
+) -> list[NoteTypeConfig]:
+    return [
+        replace(config, name=source.scope_note_type_name(config.name))
+        for config in configs
+    ]
+
+
+def _prepare_publish_plan(
+    collection_dir: Path,
+    deck: str,
+    source: SyncSource,
+) -> _PublishPlan:
+    fs = FileSystemAdapter()
+    root_configs = fs.load_note_type_configs(collection_dir / NOTE_TYPES_DIR)
+    root_config_by_name = {config.name: config for config in root_configs}
+    parser = FileSystemAdapter()
+    parser.set_configs(root_configs)
+
+    selected_files = _selected_deck_files(collection_dir, deck)
+    deck_names = _deck_names_for_files(selected_files)
+    parsed_files: list[tuple[Path, MarkdownFile]] = []
+    note_types_used: set[str] = set()
+    note_type_by_key: dict[str, str] = {}
+    media_used: set[str] = set()
+    note_keys: set[str] = set()
+
+    for md_file in selected_files:
+        parsed = parser.read_markdown_file(md_file, context_root=collection_dir)
+        parsed_files.append((md_file, parsed))
+        for note in parsed.notes:
+            if note.note_key:
+                if note.note_key in note_keys:
+                    raise ValueError(
+                        f"Duplicate note_key in publish set: {note.note_key}"
+                    )
+                note_keys.add(note.note_key)
+                note_type_by_key[note.note_key] = note.note_type
+            note_types_used.add(note.note_type)
+            for field_value in note.fields.values():
+                media_used.update(_extract_media_references(field_value))
+
+    unknown_note_types = sorted(note_types_used - set(root_config_by_name))
+    if unknown_note_types:
+        raise ValueError(
+            "Unknown note type(s) while publishing: "
+            + ", ".join(unknown_note_types)
+        )
+
+    missing_media = sorted(
+        media_name
+        for media_name in media_used
+        if not (collection_dir / LOCAL_MEDIA_DIR / media_name).exists()
+    )
+    if missing_media:
+        raise ValueError(
+            "Cannot publish: referenced media file(s) missing: "
+            + ", ".join(missing_media)
+        )
+
+    used_configs = [
+        root_config_by_name[name]
+        for name in sorted(note_types_used)
+    ]
+    scoped_configs = _scoped_configs(source, used_configs)
+    scoped_config_by_name = {config.name: config for config in scoped_configs}
+    rendered_files: list[_RenderedPublishFile] = []
+    for md_file, parsed in parsed_files:
+        for note in parsed.notes:
+            note.note_type = source.scope_note_type_name(note.note_type)
+        rendered_files.append(
+            _RenderedPublishFile(
+                source_path=md_file,
+                target_path=source.root / md_file.name,
+                content=_render_notes_to_markdown(parsed.notes, scoped_config_by_name),
+            )
+        )
+
+    return _PublishPlan(
+        source=source,
+        deck_name=deck,
+        deck_names=deck_names,
+        files=rendered_files,
+        scoped_configs=scoped_configs,
+        note_types_used=note_types_used,
+        note_type_by_key=note_type_by_key,
+        media_used=media_used,
+        note_keys=note_keys,
+    )
+
+
+def _collect_notes_to_convert(anki, plan: _PublishPlan) -> dict[str, list[int]]:
+    note_ids = anki.fetch_all_note_ids(sorted(anki.fetch_model_names()))
+    notes = anki.fetch_notes_info(note_ids)
+    card_ids = [
+        card_id
+        for note in notes.values()
+        for card_id in note.card_ids
+    ]
+    cards = anki.fetch_cards_info(card_ids)
+    notes_to_convert: dict[str, list[int]] = {}
+
+    for note in notes.values():
+        deck_names = {
+            card["deckName"]
+            for card_id in note.card_ids
+            if (card := cards.get(card_id)) and card.get("deckName")
+        }
+        if not deck_names.intersection(plan.deck_names):
+            continue
+        outside_decks = deck_names - plan.deck_names
+        if outside_decks:
+            raise ValueError(
+                f"Cannot publish note {note.note_id}: it has cards both inside "
+                f"the published deck tree and outside it ({', '.join(outside_decks)})."
+            )
+        note_key = note.fields.get(ANKIOPS_KEY_FIELD.name, "").strip()
+        if not note_key:
+            raise ValueError(
+                f"Cannot publish note {note.note_id}: it has no AnkiOps Key. "
+                "Run 'ankiops am' first so the note can be tracked."
+            )
+        if note_key not in plan.note_keys:
+            raise ValueError(
+                f"Cannot publish note {note.note_id}: its AnkiOps Key "
+                f"'{note_key}' is not present in the local Markdown files. "
+                "Run 'ankiops am' before publishing."
+            )
+        markdown_note_type = plan.note_type_by_key[note_key]
+        target_note_type = plan.source.scope_note_type_name(markdown_note_type)
+        if note.note_type == target_note_type:
+            continue
+        if note.note_type != markdown_note_type:
+            raise ValueError(
+                f"Cannot publish note {note.note_id}: Markdown would publish "
+                f"note_key '{note_key}' as '{target_note_type}', but Anki "
+                f"already has '{note.note_type}'. Use the same owner/repo slug "
+                "as the existing collab source, or intentionally convert the "
+                "Anki note type first."
+            )
+        notes_to_convert.setdefault(markdown_note_type, []).append(note.note_id)
+
+    return notes_to_convert
+
+
+def _convert_publish_notes(anki, plan: _PublishPlan) -> None:
+    notes_to_convert = _collect_notes_to_convert(anki, plan)
+    if not notes_to_convert:
+        return
+
+    sync_note_type_configs(anki, plan.scoped_configs, db_port=None)
+    try:
+        for old_model, note_ids in sorted(notes_to_convert.items()):
+            anki.change_notes_notetype(
+                sorted(note_ids),
+                old_model,
+                plan.source.scope_note_type_name(old_model),
+            )
+    except AnkiOpsBridgeError as error:
+        raise ValueError(str(error)) from error
+
+
+def _styling_refs(note_type_dir: Path) -> list[str]:
+    with open(note_type_dir / "note_type.yaml", encoding="utf-8") as file:
+        info = yaml.safe_load(file) or {}
+    styling = info.get("styling")
+    if isinstance(styling, str):
+        return [styling]
+    if isinstance(styling, list):
+        styling_refs: list[str] = []
+        for css_file in styling:
+            if not isinstance(css_file, str) or not css_file.strip():
+                raise ValueError(
+                    f"Note type '{note_type_dir.name}' has invalid styling entry "
+                    f"'{css_file}'. Expected non-empty file names."
+                )
+            styling_refs.append(css_file.strip())
+        if styling_refs:
+            return styling_refs
+    raise ValueError(
+        f"Note type '{note_type_dir.name}' must reference at least one styling file."
+    )
+
+
+def _relative_note_type_asset_path(
+    note_types_dir: Path,
+    note_type: str,
+    asset_path: Path,
+    asset_ref: str,
+) -> Path:
+    try:
+        return asset_path.resolve().relative_to(note_types_dir.resolve())
+    except ValueError as error:
+        raise ValueError(
+            f"Note type '{note_type}' references styling file '{asset_ref}' "
+            "outside the note_types directory."
+        ) from error
+
+
+def _copy_note_type_styling_assets(
+    source_note_types_dir: Path,
+    target_note_types_dir: Path,
+    note_type: str,
+) -> list[Path]:
+    source_note_type_dir = source_note_types_dir / note_type
+    touched: list[Path] = []
+
+    for asset_ref in _styling_refs(source_note_type_dir):
+        source_asset = source_note_type_dir / asset_ref
+        if not source_asset.exists():
+            raise ValueError(
+                f"Note type '{note_type}' references missing styling file "
+                f"'{asset_ref}'."
+            )
+        relative_asset = _relative_note_type_asset_path(
+            source_note_types_dir,
+            note_type,
+            source_asset,
+            asset_ref,
+        )
+        target_asset = target_note_types_dir / relative_asset
+        target_asset.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_asset, target_asset)
+        touched.append(target_asset)
+
+    return touched
+
+
+def _write_publish_files(collection_dir: Path, plan: _PublishPlan) -> list[Path]:
+    source = plan.source
+    source.root.mkdir(parents=True, exist_ok=False)
+    (source.root / LOCAL_MEDIA_DIR).mkdir(parents=True, exist_ok=True)
+    source.note_types_dir.mkdir(parents=True, exist_ok=True)
+
+    touched: list[Path] = [source.root]
+    for rendered in plan.files:
+        rendered.target_path.write_text(rendered.content, encoding="utf-8")
+        rendered.source_path.unlink()
+        touched.extend([rendered.target_path, rendered.source_path])
+
+    for note_type in sorted(plan.note_types_used):
+        src = collection_dir / NOTE_TYPES_DIR / note_type
+        dst = source.note_types_dir / note_type
+        shutil.copytree(src, dst, dirs_exist_ok=True)
+        touched.append(dst)
+        touched.extend(
+            _copy_note_type_styling_assets(
+                collection_dir / NOTE_TYPES_DIR,
+                source.note_types_dir,
+                note_type,
+            )
+        )
+
+    root_media = collection_dir / LOCAL_MEDIA_DIR
+    collab_media = source.root / LOCAL_MEDIA_DIR
+    for media_name in sorted(plan.media_used):
+        src = root_media / media_name
+        dst = collab_media / media_name
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst)
+        touched.append(dst)
+
+    return touched
+
+
+def _ensure_contributable_note_keys(source: SyncSource) -> None:
+    configs = load_configs_for_source(source)
+    parser = FileSystemAdapter()
+    parser.set_configs(configs)
+    missing: list[str] = []
+
+    for md_file in markdown_files_for_source(source):
+        parsed = parser.read_markdown_file(md_file, context_root=source.root)
+        for index, note in enumerate(parsed.notes, start=1):
+            if not note.note_key:
+                missing.append(f"{md_file.relative_to(source.root)} note {index}")
+
+    if missing:
+        raise ValueError(
+            "Cannot contribute: notes are missing note_key metadata: "
+            + ", ".join(missing)
+            + ". Run 'ankiops ma' first or add explicit note_key comments."
+        )
+
+
+def _open_pr_if_possible(collection_dir: Path, source: SyncSource, branch: str) -> None:
+    if source.github_url is None:
+        logger.info("Prepared branch %s. Push it and open a PR manually.", branch)
+        return
+    if shutil.which("gh") is None:
+        logger.info(
+            "Prepared branch %s. Push it to %s and open a PR manually.",
+            branch,
+            source.github_url,
+        )
+        return
+    push = subprocess.run(
+        ["git", "push", source.github_url, f"{branch}:{branch}"],
+        cwd=collection_dir,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if push.returncode != 0:
+        logger.info(
+            "Prepared branch %s. Push it to %s and open a PR manually.",
+            branch,
+            source.github_url,
+        )
+        logger.debug(push.stderr)
+        return
+    slug = source.github_slug
+    gh = subprocess.run(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--repo",
+            slug or "",
+            "--head",
+            branch,
+            "--base",
+            COLLAB_BRANCH,
+            "--fill",
+        ],
+        cwd=collection_dir,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if gh.returncode == 0:
+        logger.info(gh.stdout.strip())
+    else:
+        logger.info("Pushed branch %s. Open the PR manually.", branch)
+        logger.debug(gh.stderr)
+
+
+def run_publish(args) -> None:
+    collection_dir = require_collection_dir()
+    source = _source_for_slug(collection_dir, args.repo)
+    _ensure_git_repo(collection_dir)
+    if source.root.exists():
+        raise ValueError(f"Collab source already exists: {source.source_id}")
+
+    plan = _prepare_publish_plan(collection_dir, args.deck, source)
+    _ensure_publish_repo(
+        collection_dir,
+        source,
+        public=bool(getattr(args, "public", False)),
+    )
+    anki = connect_or_exit()
+    _convert_publish_notes(anki, plan)
+    touched = _write_publish_files(collection_dir, plan)
+    _git_commit_paths(
+        collection_dir,
+        touched,
+        f"AnkiOps: publish {args.deck} to {source.source_id}",
+    )
+    branch = _subtree_split(collection_dir, source)
+    if source.github_url:
+        _run_git(
+            collection_dir,
+            ["push", source.github_url, f"{branch}:{COLLAB_BRANCH}"],
+        )
+    logger.info("Published %s to %s", args.deck, source.source_id)
+
+
+def run_subscribe(args) -> None:
+    collection_dir = require_collection_dir()
+    source = _source_for_slug(collection_dir, args.repo)
+    _ensure_git_repo(collection_dir)
+    if source.root.exists():
+        raise ValueError(f"Collab source already exists: {source.source_id}")
+    _subtree_add(collection_dir, source)
+    logger.info("Subscribed to %s at %s", args.repo, clickable_path(source.root))
+
+
+def run_pull(args) -> None:
+    collection_dir = require_collection_dir()
+    if args.repo:
+        source = _source_for_slug(collection_dir, args.repo)
+    _ensure_git_repo(collection_dir)
+    sources = discover_sync_sources(collection_dir)
+    if args.repo:
+        if not source.root.exists():
+            raise ValueError(f"Unknown collab source: {source.source_id}")
+        targets = [source]
+    else:
+        targets = [source for source in sources if source.is_collab]
+    if not targets:
+        logger.info("No collab sources found.")
+        return
+    for source in targets:
+        _subtree_pull(collection_dir, source)
+        logger.info("Pulled %s", source.source_id)
+
+
+def run_contribute(args) -> None:
+    collection_dir = require_collection_dir()
+    source = _source_for_slug(collection_dir, args.repo)
+    _ensure_git_repo(collection_dir)
+    if not source.root.exists():
+        raise ValueError(f"Unknown collab source: {source.source_id}")
+    _ensure_contributable_note_keys(source)
+    _git_commit_paths(
+        collection_dir,
+        [source.root],
+        f"AnkiOps: contribute {source.source_id}",
+    )
+    branch = _subtree_split(collection_dir, source)
+    _open_pr_if_possible(collection_dir, source, branch)
+
+
+def run_status(args) -> None:
+    collection_dir = require_collection_dir()
+    sources = [
+        source
+        for source in discover_sync_sources(collection_dir)
+        if source.is_collab
+    ]
+    if not sources:
+        logger.info("No collab sources found.")
+        return
+    for source in sources:
+        logger.info("%s  %s", source.source_id, clickable_path(source.root))
+
+
+def run(args) -> None:
+    match args.collab_command:
+        case "publish":
+            run_publish(args)
+        case "subscribe":
+            run_subscribe(args)
+        case "pull":
+            run_pull(args)
+        case "contribute":
+            run_contribute(args)
+        case "status":
+            run_status(args)
+        case _:
+            raise SystemExit(2)

--- a/ankiops/collab.py
+++ b/ankiops/collab.py
@@ -190,7 +190,6 @@ def _git_commit_publish(
     paths: list[Path],
     message: str,
 ) -> None:
-    _ensure_clean_git_index(collection_dir)
     add_paths = [
         str(path.relative_to(collection_dir))
         for path in paths
@@ -222,8 +221,15 @@ def _git_commit_publish(
 
 
 def _cleanup_failed_publish(collection_dir: Path, plan: _PublishPlan) -> None:
+    publish_paths = [
+        _source_prefix(collection_dir, plan.source),
+        *[
+            str(rendered.source_path.relative_to(collection_dir))
+            for rendered in plan.files
+        ],
+    ]
     if _git_head(collection_dir) is not None:
-        _run_git(collection_dir, ["reset", "--mixed", "HEAD"])
+        _run_git(collection_dir, ["reset", "HEAD", "--", *publish_paths])
     else:
         _run_git(
             collection_dir,
@@ -233,7 +239,7 @@ def _cleanup_failed_publish(collection_dir: Path, plan: _PublishPlan) -> None:
                 "--cached",
                 "--ignore-unmatch",
                 "--",
-                _source_prefix(collection_dir, plan.source),
+                *publish_paths,
             ],
         )
     _remove_publish_source_root(plan)
@@ -674,6 +680,7 @@ def run_publish(args) -> None:
         raise ValueError(f"Collab source already exists: {source.source_id}")
 
     plan = _prepare_publish_plan(collection_dir, args.deck, source)
+    _ensure_clean_git_index(collection_dir)
     _ensure_publish_repo(
         collection_dir,
         source,

--- a/ankiops/collab.py
+++ b/ankiops/collab.py
@@ -164,6 +164,58 @@ def _git_commit_paths(collection_dir: Path, paths: list[Path], message: str) -> 
     _run_git(collection_dir, ["commit", "-m", message, "--", *rel_paths])
 
 
+def _ensure_clean_git_index(collection_dir: Path) -> None:
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--quiet"],
+        cwd=collection_dir,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise ValueError(
+            "Collab publish requires a clean git index. Commit or unstage "
+            "existing changes before publishing."
+        )
+
+
+def _git_commit_publish(
+    collection_dir: Path,
+    plan: _PublishPlan,
+    paths: list[Path],
+    message: str,
+) -> None:
+    _ensure_clean_git_index(collection_dir)
+    add_paths = [
+        str(path.relative_to(collection_dir))
+        for path in paths
+        if path.exists() and path not in {file.source_path for file in plan.files}
+    ]
+    if add_paths:
+        _run_git(collection_dir, ["add", "-A", "--", *add_paths])
+
+    source_paths = [
+        str(rendered.source_path.relative_to(collection_dir))
+        for rendered in plan.files
+    ]
+    if source_paths:
+        _run_git(
+            collection_dir,
+            ["rm", "--cached", "-f", "--ignore-unmatch", "--", *source_paths],
+        )
+
+    diff = subprocess.run(
+        ["git", "diff", "--cached", "--quiet"],
+        cwd=collection_dir,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if diff.returncode == 0:
+        return
+    _run_git(collection_dir, ["commit", "-m", message])
+
+
 def _subtree_add(collection_dir: Path, source: SyncSource) -> None:
     if source.github_url is None:
         raise ValueError(f"Cannot derive GitHub URL for {source.display_name}")
@@ -407,7 +459,8 @@ def _prepare_publish_plan(
 
 
 def _collect_notes_to_convert(anki, plan: _PublishPlan) -> dict[str, list[int]]:
-    note_ids = anki.fetch_all_note_ids(sorted(anki.fetch_model_names()))
+    model_names = _publish_model_names_to_query(anki, plan)
+    note_ids = anki.fetch_all_note_ids(model_names)
     notes = anki.fetch_notes_info(note_ids)
     card_ids = [
         card_id
@@ -458,6 +511,28 @@ def _collect_notes_to_convert(anki, plan: _PublishPlan) -> dict[str, list[int]]:
         notes_to_convert.setdefault(markdown_note_type, []).append(note.note_id)
 
     return notes_to_convert
+
+
+def _publish_model_names_to_query(anki, plan: _PublishPlan) -> list[str]:
+    used = set(plan.note_types_used)
+    existing = set(anki.fetch_model_names())
+    target_scoped = {
+        plan.source.scope_note_type_name(note_type)
+        for note_type in used
+    }
+    relevant = {
+        model_name
+        for model_name in existing
+        if model_name in used
+        or model_name in target_scoped
+        or _is_collab_model_for_note_type(model_name, used)
+    }
+    return sorted(relevant)
+
+
+def _is_collab_model_for_note_type(model_name: str, note_types: set[str]) -> bool:
+    parts = model_name.split("/")
+    return len(parts) == 4 and parts[0] == "collab" and parts[-1] in note_types
 
 
 def _convert_publish_notes(anki, plan: _PublishPlan) -> None:
@@ -552,7 +627,6 @@ def _write_publish_files(collection_dir: Path, plan: _PublishPlan) -> list[Path]
     touched: list[Path] = [source.root]
     for rendered in plan.files:
         rendered.target_path.write_text(rendered.content, encoding="utf-8")
-        rendered.source_path.unlink()
         touched.extend([rendered.target_path, rendered.source_path])
 
     for note_type in sorted(plan.note_types_used):
@@ -578,6 +652,11 @@ def _write_publish_files(collection_dir: Path, plan: _PublishPlan) -> list[Path]
         touched.append(dst)
 
     return touched
+
+
+def _unlink_published_source_files(plan: _PublishPlan) -> None:
+    for rendered in plan.files:
+        rendered.source_path.unlink()
 
 
 def _ensure_contributable_note_keys(source: SyncSource) -> None:
@@ -668,11 +747,13 @@ def run_publish(args) -> None:
     anki = connect_or_exit()
     _convert_publish_notes(anki, plan)
     touched = _write_publish_files(collection_dir, plan)
-    _git_commit_paths(
+    _git_commit_publish(
         collection_dir,
+        plan,
         touched,
         f"AnkiOps: publish {args.deck} to {source.source_id}",
     )
+    _unlink_published_source_files(plan)
     branch = _subtree_split(collection_dir, source)
     if source.github_url:
         _run_git(
@@ -694,14 +775,15 @@ def run_subscribe(args) -> None:
 
 def run_pull(args) -> None:
     collection_dir = require_collection_dir()
+    requested_source = None
     if args.repo:
-        source = _source_for_slug(collection_dir, args.repo)
+        requested_source = _source_for_slug(collection_dir, args.repo)
     _ensure_git_repo(collection_dir)
     sources = discover_sync_sources(collection_dir)
-    if args.repo:
-        if not source.root.exists():
-            raise ValueError(f"Unknown collab source: {source.source_id}")
-        targets = [source]
+    if requested_source is not None:
+        if not requested_source.root.exists():
+            raise ValueError(f"Unknown collab source: {requested_source.source_id}")
+        targets = [requested_source]
     else:
         targets = [source for source in sources if source.is_collab]
     if not targets:

--- a/ankiops/collab.py
+++ b/ankiops/collab.py
@@ -690,13 +690,13 @@ def run_publish(args) -> None:
     except Exception:
         _cleanup_failed_publish(collection_dir, plan)
         raise
-    _unlink_published_source_files(plan)
     branch = _subtree_split(collection_dir, source)
     if source.github_url:
         _run_git(
             collection_dir,
             ["push", source.github_url, f"{branch}:{COLLAB_BRANCH}"],
         )
+    _unlink_published_source_files(plan)
     logger.info(
         "Published %s to %s. Run 'ankiops ma' to apply scoped note types to Anki.",
         args.deck,

--- a/ankiops/collab.py
+++ b/ankiops/collab.py
@@ -220,7 +220,41 @@ def _git_commit_publish(
     _run_git(collection_dir, ["commit", "-m", message])
 
 
-def _cleanup_failed_publish(collection_dir: Path, plan: _PublishPlan) -> None:
+def _rollback_publish_commit(
+    collection_dir: Path,
+    *,
+    initial_head: str | None,
+) -> None:
+    current_head = _git_head(collection_dir)
+    if current_head == initial_head or current_head is None:
+        return
+    if initial_head is None:
+        _run_git(collection_dir, ["update-ref", "-d", "HEAD"])
+    else:
+        _run_git(collection_dir, ["reset", "--mixed", initial_head])
+
+
+def _delete_branch_if_exists(collection_dir: Path, branch: str | None) -> None:
+    if branch is None:
+        return
+    subprocess.run(
+        ["git", "branch", "-D", branch],
+        cwd=collection_dir,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _cleanup_failed_publish(
+    collection_dir: Path,
+    plan: _PublishPlan,
+    *,
+    initial_head: str | None = None,
+    branch: str | None = None,
+) -> None:
+    _rollback_publish_commit(collection_dir, initial_head=initial_head)
+    _delete_branch_if_exists(collection_dir, branch)
     publish_paths = [
         _source_prefix(collection_dir, plan.source),
         *[
@@ -686,6 +720,8 @@ def run_publish(args) -> None:
         source,
         public=bool(getattr(args, "public", False)),
     )
+    initial_head = _git_head(collection_dir)
+    branch: str | None = None
     try:
         touched = _write_publish_files(collection_dir, plan)
         _git_commit_publish(
@@ -694,15 +730,20 @@ def run_publish(args) -> None:
             touched,
             f"AnkiOps: publish {args.deck} to {source.source_id}",
         )
+        branch = _subtree_split(collection_dir, source)
+        if source.github_url:
+            _run_git(
+                collection_dir,
+                ["push", source.github_url, f"{branch}:{COLLAB_BRANCH}"],
+            )
     except Exception:
-        _cleanup_failed_publish(collection_dir, plan)
-        raise
-    branch = _subtree_split(collection_dir, source)
-    if source.github_url:
-        _run_git(
+        _cleanup_failed_publish(
             collection_dir,
-            ["push", source.github_url, f"{branch}:{COLLAB_BRANCH}"],
+            plan,
+            initial_head=initial_head,
+            branch=branch,
         )
+        raise
     _unlink_published_source_files(plan)
     logger.info(
         "Published %s to %s. Run 'ankiops ma' to apply scoped note types to Anki.",

--- a/ankiops/collab.py
+++ b/ankiops/collab.py
@@ -12,8 +12,6 @@ from pathlib import Path
 
 import yaml
 
-from ankiops.ankiops_bridge import AnkiOpsBridgeError
-from ankiops.cli_anki import connect_or_exit
 from ankiops.config import (
     LOCAL_MEDIA_DIR,
     NOTE_TYPES_DIR,
@@ -23,7 +21,7 @@ from ankiops.config import (
 from ankiops.export_notes import _render_notes_to_markdown
 from ankiops.fs import FileSystemAdapter
 from ankiops.log import clickable_path
-from ankiops.models import ANKIOPS_KEY_FIELD, MarkdownFile, NoteTypeConfig
+from ankiops.models import MarkdownFile, NoteTypeConfig
 from ankiops.sources import (
     COLLAB_BRANCH,
     SyncSource,
@@ -32,7 +30,6 @@ from ankiops.sources import (
     markdown_files_for_source,
 )
 from ankiops.sync_media import _extract_media_references
-from ankiops.sync_note_types import sync_note_type_configs
 
 logger = logging.getLogger(__name__)
 
@@ -53,14 +50,9 @@ class _RenderedPublishFile:
 @dataclass(frozen=True)
 class _PublishPlan:
     source: SyncSource
-    deck_name: str
-    deck_names: set[str]
     files: list[_RenderedPublishFile]
-    scoped_configs: list[NoteTypeConfig]
     note_types_used: set[str]
-    note_type_by_key: dict[str, str]
     media_used: set[str]
-    note_keys: set[str]
 
 
 def _parse_slug(slug: str) -> tuple[str, str]:
@@ -164,6 +156,19 @@ def _git_commit_paths(collection_dir: Path, paths: list[Path], message: str) -> 
     _run_git(collection_dir, ["commit", "-m", message, "--", *rel_paths])
 
 
+def _git_head(collection_dir: Path) -> str | None:
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", "HEAD"],
+        cwd=collection_dir,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
 def _ensure_clean_git_index(collection_dir: Path) -> None:
     result = subprocess.run(
         ["git", "diff", "--cached", "--quiet"],
@@ -214,6 +219,34 @@ def _git_commit_publish(
     if diff.returncode == 0:
         return
     _run_git(collection_dir, ["commit", "-m", message])
+
+
+def _cleanup_failed_publish(collection_dir: Path, plan: _PublishPlan) -> None:
+    if _git_head(collection_dir) is not None:
+        _run_git(collection_dir, ["reset", "--mixed", "HEAD"])
+    else:
+        _run_git(
+            collection_dir,
+            [
+                "rm",
+                "-r",
+                "--cached",
+                "--ignore-unmatch",
+                "--",
+                _source_prefix(collection_dir, plan.source),
+            ],
+        )
+    _remove_publish_source_root(plan)
+
+
+def _remove_publish_source_root(plan: _PublishPlan) -> None:
+    if plan.source.root.exists():
+        shutil.rmtree(plan.source.root)
+    for parent in (plan.source.root.parent, plan.source.root.parent.parent):
+        try:
+            parent.rmdir()
+        except OSError:
+            pass
 
 
 def _subtree_add(collection_dir: Path, source: SyncSource) -> None:
@@ -361,10 +394,6 @@ def _selected_deck_files(collection_dir: Path, deck: str) -> list[Path]:
     return files
 
 
-def _deck_names_for_files(files: list[Path]) -> set[str]:
-    return {file_stem_to_deck_name(md_file.stem) for md_file in files}
-
-
 def _scoped_configs(
     source: SyncSource,
     configs: list[NoteTypeConfig],
@@ -387,27 +416,32 @@ def _prepare_publish_plan(
     parser.set_configs(root_configs)
 
     selected_files = _selected_deck_files(collection_dir, deck)
-    deck_names = _deck_names_for_files(selected_files)
     parsed_files: list[tuple[Path, MarkdownFile]] = []
     note_types_used: set[str] = set()
-    note_type_by_key: dict[str, str] = {}
     media_used: set[str] = set()
     note_keys: set[str] = set()
+    missing_note_keys: list[str] = []
 
     for md_file in selected_files:
         parsed = parser.read_markdown_file(md_file, context_root=collection_dir)
         parsed_files.append((md_file, parsed))
-        for note in parsed.notes:
-            if note.note_key:
-                if note.note_key in note_keys:
-                    raise ValueError(
-                        f"Duplicate note_key in publish set: {note.note_key}"
-                    )
+        for index, note in enumerate(parsed.notes, start=1):
+            if not note.note_key:
+                missing_note_keys.append(f"{md_file.name} note {index}")
+            elif note.note_key in note_keys:
+                raise ValueError(f"Duplicate note_key in publish set: {note.note_key}")
+            else:
                 note_keys.add(note.note_key)
-                note_type_by_key[note.note_key] = note.note_type
             note_types_used.add(note.note_type)
             for field_value in note.fields.values():
                 media_used.update(_extract_media_references(field_value))
+
+    if missing_note_keys:
+        raise ValueError(
+            "Cannot publish: notes are missing note_key metadata: "
+            + ", ".join(missing_note_keys)
+            + ". Run 'ankiops ma' first or add explicit note_key comments."
+        )
 
     unknown_note_types = sorted(note_types_used - set(root_config_by_name))
     if unknown_note_types:
@@ -447,109 +481,10 @@ def _prepare_publish_plan(
 
     return _PublishPlan(
         source=source,
-        deck_name=deck,
-        deck_names=deck_names,
         files=rendered_files,
-        scoped_configs=scoped_configs,
         note_types_used=note_types_used,
-        note_type_by_key=note_type_by_key,
         media_used=media_used,
-        note_keys=note_keys,
     )
-
-
-def _collect_notes_to_convert(anki, plan: _PublishPlan) -> dict[str, list[int]]:
-    model_names = _publish_model_names_to_query(anki, plan)
-    note_ids = anki.fetch_all_note_ids(model_names)
-    notes = anki.fetch_notes_info(note_ids)
-    card_ids = [
-        card_id
-        for note in notes.values()
-        for card_id in note.card_ids
-    ]
-    cards = anki.fetch_cards_info(card_ids)
-    notes_to_convert: dict[str, list[int]] = {}
-
-    for note in notes.values():
-        deck_names = {
-            card["deckName"]
-            for card_id in note.card_ids
-            if (card := cards.get(card_id)) and card.get("deckName")
-        }
-        if not deck_names.intersection(plan.deck_names):
-            continue
-        outside_decks = deck_names - plan.deck_names
-        if outside_decks:
-            raise ValueError(
-                f"Cannot publish note {note.note_id}: it has cards both inside "
-                f"the published deck tree and outside it ({', '.join(outside_decks)})."
-            )
-        note_key = note.fields.get(ANKIOPS_KEY_FIELD.name, "").strip()
-        if not note_key:
-            raise ValueError(
-                f"Cannot publish note {note.note_id}: it has no AnkiOps Key. "
-                "Run 'ankiops am' first so the note can be tracked."
-            )
-        if note_key not in plan.note_keys:
-            raise ValueError(
-                f"Cannot publish note {note.note_id}: its AnkiOps Key "
-                f"'{note_key}' is not present in the local Markdown files. "
-                "Run 'ankiops am' before publishing."
-            )
-        markdown_note_type = plan.note_type_by_key[note_key]
-        target_note_type = plan.source.scope_note_type_name(markdown_note_type)
-        if note.note_type == target_note_type:
-            continue
-        if note.note_type != markdown_note_type:
-            raise ValueError(
-                f"Cannot publish note {note.note_id}: Markdown would publish "
-                f"note_key '{note_key}' as '{target_note_type}', but Anki "
-                f"already has '{note.note_type}'. Use the same owner/repo slug "
-                "as the existing collab source, or intentionally convert the "
-                "Anki note type first."
-            )
-        notes_to_convert.setdefault(markdown_note_type, []).append(note.note_id)
-
-    return notes_to_convert
-
-
-def _publish_model_names_to_query(anki, plan: _PublishPlan) -> list[str]:
-    used = set(plan.note_types_used)
-    existing = set(anki.fetch_model_names())
-    target_scoped = {
-        plan.source.scope_note_type_name(note_type)
-        for note_type in used
-    }
-    relevant = {
-        model_name
-        for model_name in existing
-        if model_name in used
-        or model_name in target_scoped
-        or _is_collab_model_for_note_type(model_name, used)
-    }
-    return sorted(relevant)
-
-
-def _is_collab_model_for_note_type(model_name: str, note_types: set[str]) -> bool:
-    parts = model_name.split("/")
-    return len(parts) == 4 and parts[0] == "collab" and parts[-1] in note_types
-
-
-def _convert_publish_notes(anki, plan: _PublishPlan) -> None:
-    notes_to_convert = _collect_notes_to_convert(anki, plan)
-    if not notes_to_convert:
-        return
-
-    sync_note_type_configs(anki, plan.scoped_configs, db_port=None)
-    try:
-        for old_model, note_ids in sorted(notes_to_convert.items()):
-            anki.change_notes_notetype(
-                sorted(note_ids),
-                old_model,
-                plan.source.scope_note_type_name(old_model),
-            )
-    except AnkiOpsBridgeError as error:
-        raise ValueError(str(error)) from error
 
 
 def _styling_refs(note_type_dir: Path) -> list[str]:
@@ -744,15 +679,17 @@ def run_publish(args) -> None:
         source,
         public=bool(getattr(args, "public", False)),
     )
-    anki = connect_or_exit()
-    _convert_publish_notes(anki, plan)
-    touched = _write_publish_files(collection_dir, plan)
-    _git_commit_publish(
-        collection_dir,
-        plan,
-        touched,
-        f"AnkiOps: publish {args.deck} to {source.source_id}",
-    )
+    try:
+        touched = _write_publish_files(collection_dir, plan)
+        _git_commit_publish(
+            collection_dir,
+            plan,
+            touched,
+            f"AnkiOps: publish {args.deck} to {source.source_id}",
+        )
+    except Exception:
+        _cleanup_failed_publish(collection_dir, plan)
+        raise
     _unlink_published_source_files(plan)
     branch = _subtree_split(collection_dir, source)
     if source.github_url:
@@ -760,7 +697,11 @@ def run_publish(args) -> None:
             collection_dir,
             ["push", source.github_url, f"{branch}:{COLLAB_BRANCH}"],
         )
-    logger.info("Published %s to %s", args.deck, source.source_id)
+    logger.info(
+        "Published %s to %s. Run 'ankiops ma' to apply scoped note types to Anki.",
+        args.deck,
+        source.source_id,
+    )
 
 
 def run_subscribe(args) -> None:

--- a/ankiops/export_notes.py
+++ b/ankiops/export_notes.py
@@ -48,10 +48,21 @@ _ResolvedDeckNote = tuple[str, int, Note]
 _SYNC_ORDER = (
     ChangeType.DELETE,
     ChangeType.CREATE,
+    ChangeType.CONVERT,
     ChangeType.UPDATE,
     ChangeType.SKIP,
     ChangeType.MOVE,
 )
+
+
+def _format_pending_note_type_conversion_error(
+    *, note_key: str, markdown_note_type: str, anki_note_type: str
+) -> str:
+    return (
+        f"Pending note type conversion for note_key {note_key}: Markdown uses "
+        f"'{markdown_note_type}' but Anki has '{anki_note_type}'. Run "
+        "'ankiops ma' before exporting with 'ankiops am'."
+    )
 
 
 def _from_html(
@@ -157,6 +168,15 @@ def _resolve_deck_notes(
 
         local_match = local_notes_by_note_key.get(note_key) if note_key else None
         if note_key and local_match:
+            if local_match.note_type != anki_note.note_type:
+                errors.append(
+                    _format_pending_note_type_conversion_error(
+                        note_key=note_key,
+                        markdown_note_type=local_match.note_type,
+                        anki_note_type=anki_note.note_type,
+                    )
+                )
+                continue
             local_md_hash = note_fingerprint(
                 local_match.note_type,
                 local_match.fields,
@@ -460,6 +480,9 @@ def _sync_deck(
         local_notes_by_content=local_notes_by_content,
     )
     result.errors.extend(resolve_errors)
+    if resolve_errors:
+        result.order_changes(order=_SYNC_ORDER)
+        return result
 
     final_notes, protected_keyless_count = _order_resolved_notes(
         resolved_notes=resolved_notes,

--- a/ankiops/export_notes.py
+++ b/ankiops/export_notes.py
@@ -30,6 +30,13 @@ from ankiops.models import (
     ProtectedNoteGroup,
     SyncResult,
 )
+from ankiops.note_identity import assert_unique_export_note_keys
+from ankiops.sources import (
+    SyncSource,
+    discover_sync_sources,
+    load_configs_for_sources,
+    markdown_files_for_source,
+)
 from ankiops.tags import format_tags_comment
 
 logger = logging.getLogger(__name__)
@@ -529,14 +536,26 @@ def export_collection(
     collection_dir: Path,
     note_types_dir: Path,
 ) -> CollectionResult:
-    configs = fs_port.load_note_type_configs(note_types_dir)
+    sources = discover_sync_sources(collection_dir, note_types_dir=note_types_dir)
+    local_source = sources[0]
+    source_configs = load_configs_for_sources(sources)
+    configs = [
+        config
+        for source_config in source_configs
+        for config in source_config.configs
+    ]
     config_by_name = {config.name: config for config in configs}
+    fs_port.set_configs(configs)
     with db_port.write_tx():
         deck_ids_by_name = anki_port.fetch_deck_names_and_ids()
 
         all_note_ids = anki_port.fetch_all_note_ids([config.name for config in configs])
         anki_notes = anki_port.fetch_notes_info(all_note_ids)
         note_keys_by_id = db_port.resolve_note_keys(all_note_ids)
+        assert_unique_export_note_keys(
+            anki_notes=anki_notes,
+            note_keys_by_id=note_keys_by_id,
+        )
         pending_note_mappings: list[tuple[str, int]] = []
         note_key_candidates = set(note_keys_by_id.values())
         for anki_note in anki_notes.values():
@@ -566,10 +585,29 @@ def export_collection(
             deck_name = primary_card_info.get("deckName")
             notes_by_deck.setdefault(deck_name, []).append(anki_note)
 
-        md_files = fs_port.find_markdown_files(collection_dir)
-        file_map_by_name = {}
-        for md_file in md_files:
-            file_map_by_name[md_file.stem] = md_file
+        md_files: list[Path] = []
+        source_by_file: dict[Path, SyncSource] = {}
+        file_map_by_deck_name: dict[str, tuple[SyncSource, Path]] = {}
+        deck_conflicts: list[str] = []
+        for source in sources:
+            for md_file in markdown_files_for_source(source):
+                md_files.append(md_file)
+                source_by_file[md_file] = source
+                deck_name = file_stem_to_deck_name(md_file.stem)
+                previous = file_map_by_deck_name.get(deck_name)
+                if previous is not None:
+                    deck_conflicts.append(
+                        f"Deck '{deck_name}' is defined by both "
+                        f"{previous[0].display_name}:{previous[1].name} and "
+                        f"{source.display_name}:{md_file.name}"
+                    )
+                    continue
+                file_map_by_deck_name[deck_name] = (source, md_file)
+        if deck_conflicts:
+            raise ValueError(
+                "Aborting export: deck ownership conflicts found: "
+                + "; ".join(deck_conflicts)
+            )
 
         results = []
         protected_note_groups: list[ProtectedNoteGroup] = []
@@ -584,23 +622,28 @@ def export_collection(
             old_name = db_port.resolve_deck_name(deck_id)
             safe_name = deck_name_to_file_stem(deck_name)
             if old_name and old_name != deck_name:
-                old_safe = deck_name_to_file_stem(old_name)
-                if old_safe in file_map_by_name:
-                    old_path = file_map_by_name[old_safe]
+                old_entry = file_map_by_deck_name.get(old_name)
+                if old_entry is not None:
+                    old_source, old_path = old_entry
                     new_path = old_path.parent / f"{safe_name}.md"
                     old_path.rename(new_path)
-                    file_map_by_name[safe_name] = new_path
-                    del file_map_by_name[old_safe]
+                    source_by_file.pop(old_path, None)
+                    source_by_file[new_path] = old_source
+                    file_map_by_deck_name[deck_name] = (old_source, new_path)
+                    del file_map_by_deck_name[old_name]
                     logger.info(f"Deck renamed: '{old_name}' → '{deck_name}'")
 
-            target_file = file_map_by_name.get(safe_name)
+            target_source, target_file = file_map_by_deck_name.get(
+                deck_name,
+                (local_source, None),
+            )
 
             sync_result = _sync_deck(
                 deck_name,
                 notes,
                 config_by_name,
                 target_file,
-                collection_dir,
+                target_source.root,
                 fs_port,
                 db_port,
                 note_keys_by_id,
@@ -636,9 +679,10 @@ def export_collection(
                 continue
             if md_file not in active_files:
                 deck_name = file_stem_to_deck_name(md_file.stem)
+                source = source_by_file.get(md_file, local_source)
                 orphan_split = _split_orphan_file_notes(
                     md_file=md_file,
-                    collection_dir=collection_dir,
+                    collection_dir=source.root,
                     fs_port=fs_port,
                 )
                 if orphan_split is None:

--- a/ankiops/fs.py
+++ b/ankiops/fs.py
@@ -14,11 +14,11 @@ from ankiops.config import LOCAL_MEDIA_DIR
 from ankiops.html_converter import HTMLToMarkdown
 from ankiops.markdown_converter import MarkdownToHTML
 from ankiops.markdown_format import (
-    NOTE_SEPARATOR,
     FIELD_LABEL_CANDIDATE_RE,
+    NOTE_SEPARATOR,
     is_code_fence_line,
-    is_note_type_comment,
     parse_note_key_comment,
+    parse_note_type_comment,
 )
 from ankiops.models import (
     ANKIOPS_KEY_FIELD,
@@ -112,6 +112,7 @@ class FileSystemAdapter:
 
             lines = stripped_block.split("\n")
             note_key: str | None = None
+            explicit_note_type: str | None = None
             tags: tuple[str, ...] = ()
             fields: dict[str, str] = {}
             current_field: str | None = None
@@ -140,7 +141,9 @@ class FileSystemAdapter:
                     note_key = parsed_note_key
                     continue
 
-                if is_note_type_comment(line):
+                parsed_note_type = parse_note_type_comment(line)
+                if parsed_note_type is not None:
+                    explicit_note_type = parsed_note_type
                     continue
 
                 tag_values = parse_tags_comment(line)
@@ -211,17 +214,27 @@ class FileSystemAdapter:
                     )
                 )
 
-            # Infer Note Type
-            try:
-                note_type = self._infer_note_type(fields, labels=seen_labels)
-            except ValueError as error:
-                raise ValueError(
-                    self._with_parse_error_context(
-                        str(error),
-                        display_path=display_path,
-                        line_number=first_field_line or note_start_line,
+            if explicit_note_type is not None:
+                note_type = explicit_note_type
+                if note_type not in config_by_name:
+                    raise ValueError(
+                        self._with_parse_error_context(
+                            f"Unknown note type '{note_type}'.",
+                            display_path=display_path,
+                            line_number=first_field_line or note_start_line,
+                        )
                     )
-                ) from error
+            else:
+                try:
+                    note_type = self._infer_note_type(fields, labels=seen_labels)
+                except ValueError as error:
+                    raise ValueError(
+                        self._with_parse_error_context(
+                            str(error),
+                            display_path=display_path,
+                            line_number=first_field_line or note_start_line,
+                        )
+                    ) from error
             note = Note(
                 note_key=note_key,
                 note_type=note_type,

--- a/ankiops/import_notes.py
+++ b/ankiops/import_notes.py
@@ -54,15 +54,32 @@ class _SourceMarkdownFile:
     file_state: MarkdownFile
 
 
-def _format_note_type_mismatch_error(
+@dataclass(frozen=True)
+class _NoteTypeConversion:
+    note_id: int
+    note_key: str
+    old_model: str
+    new_model: str
+    entity_repr: str
+    md_hash: str
+    import_anki_hash: str
+
+
+def _collab_scope(note_type: str) -> str | None:
+    parts = note_type.split("/")
+    if len(parts) == 4 and parts[0] == "collab":
+        return "/".join(parts[:3])
+    return None
+
+
+def _format_cross_collab_conversion_error(
     *, note_key: str, markdown_note_type: str, anki_note_type: str
 ) -> str:
     return (
-        f"Note type mismatch for note_key: {note_key}: markdown uses "
-        f"'{markdown_note_type}' but Anki has '{anki_note_type}'. "
-        "AnkiOps will not create a duplicate note to resolve this. "
-        "Fix the Markdown note_type metadata or intentionally convert the "
-        "existing Anki note type, then re-run import."
+        f"Cannot convert note_key {note_key} from '{anki_note_type}' to "
+        f"'{markdown_note_type}': the Anki note already belongs to a different "
+        "collab source. Use the matching collab source or resolve the note "
+        "ownership manually."
     )
 
 
@@ -314,6 +331,7 @@ def _sync_keyed_note(
     result: SyncResult,
     cards_to_move: list[int],
     moved_from_decks: set[str],
+    note_type_conversions: list[_NoteTypeConversion],
     queue_note_mapping,
     clear_note_mapping,
     queue_import_fingerprint,
@@ -388,23 +406,14 @@ def _sync_keyed_note(
         )
         cards_to_move.extend(cards_to_move_for_note)
 
-    if anki_note.note_type != parsed_note.note_type:
-        result.errors.append(
-            _format_note_type_mismatch_error(
-                note_key=note_key,
-                markdown_note_type=parsed_note.note_type,
-                anki_note_type=anki_note.note_type,
-            )
-        )
-        return
-
+    needs_note_type_conversion = anki_note.note_type != parsed_note.note_type
     current_anki_hash = note_fingerprint(
         anki_note.note_type,
         anki_note.fields,
         tags=anki_note.tags,
     )
     cached = note_import_fingerprints_by_note_key.get(note_key)
-    if cached == (md_hash, current_anki_hash):
+    if not needs_note_type_conversion and cached == (md_hash, current_anki_hash):
         result.add_change(Change(ChangeType.SKIP, note_id, parsed_note.identifier))
         queue_import_fingerprint(note_key, md_hash, current_anki_hash)
         return
@@ -412,17 +421,63 @@ def _sync_keyed_note(
     html_fields = _to_html(parsed_note, cfg, fs_port)
     if anki_note.fields.get(ANKIOPS_KEY_FIELD.name, "") != note_key:
         html_fields[ANKIOPS_KEY_FIELD.name] = note_key
-
-    if _anki_note_match(html_fields, parsed_note.tags, anki_note):
-        result.add_change(Change(ChangeType.SKIP, note_id, parsed_note.identifier))
-        queue_import_fingerprint(note_key, md_hash, current_anki_hash)
-        return
-
     target_anki_hash = note_fingerprint(
         parsed_note.note_type,
         html_fields,
         tags=parsed_note.tags,
     )
+
+    if needs_note_type_conversion:
+        anki_scope = _collab_scope(anki_note.note_type)
+        markdown_scope = _collab_scope(parsed_note.note_type)
+        if anki_scope is not None and anki_scope != markdown_scope:
+            result.errors.append(
+                _format_cross_collab_conversion_error(
+                    note_key=note_key,
+                    markdown_note_type=parsed_note.note_type,
+                    anki_note_type=anki_note.note_type,
+                )
+            )
+            return
+        result.add_change(
+            Change(
+                ChangeType.CONVERT,
+                note_id,
+                parsed_note.identifier,
+                {
+                    "note_key": note_key,
+                    "old_model": anki_note.note_type,
+                    "new_model": parsed_note.note_type,
+                    "md_hash": md_hash,
+                    "import_anki_hash": target_anki_hash,
+                },
+            )
+        )
+        note_type_conversions.append(
+            _NoteTypeConversion(
+                note_id=note_id,
+                note_key=note_key,
+                old_model=anki_note.note_type,
+                new_model=parsed_note.note_type,
+                entity_repr=parsed_note.identifier,
+                md_hash=md_hash,
+                import_anki_hash=target_anki_hash,
+            )
+        )
+
+    if (
+        not needs_note_type_conversion
+        and _anki_note_match(html_fields, parsed_note.tags, anki_note)
+    ):
+        result.add_change(Change(ChangeType.SKIP, note_id, parsed_note.identifier))
+        queue_import_fingerprint(note_key, md_hash, current_anki_hash)
+        return
+
+    if needs_note_type_conversion and _anki_note_match(
+        html_fields, parsed_note.tags, anki_note
+    ):
+        return
+
     result.add_change(
         Change(
             ChangeType.UPDATE,
@@ -553,6 +608,42 @@ def _collect_orphan_deletes(
                 )
 
 
+def _apply_note_type_conversions(
+    *,
+    anki_port: AnkiAdapter,
+    conversions: list[_NoteTypeConversion],
+    queue_import_fingerprint,
+) -> list[str]:
+    if not conversions:
+        return []
+
+    by_model_pair: dict[tuple[str, str], list[_NoteTypeConversion]] = {}
+    for conversion in conversions:
+        by_model_pair.setdefault(
+            (conversion.old_model, conversion.new_model),
+            [],
+        ).append(conversion)
+
+    try:
+        for (old_model, new_model), grouped in sorted(by_model_pair.items()):
+            anki_port.change_notes_notetype(
+                sorted(conversion.note_id for conversion in grouped),
+                old_model,
+                new_model,
+            )
+    except Exception as error:
+        affected = ", ".join(conversion.entity_repr for conversion in conversions)
+        return [f"Failed note type conversion ({affected}): {error}"]
+
+    for conversion in conversions:
+        queue_import_fingerprint(
+            conversion.note_key,
+            conversion.md_hash,
+            conversion.import_anki_hash,
+        )
+    return []
+
+
 def _apply_changes_and_update_state(
     *,
     deck_context: _DeckContext,
@@ -560,6 +651,7 @@ def _apply_changes_and_update_state(
     db_port: SQLiteDbAdapter,
     result: SyncResult,
     cards_to_move: list[int],
+    note_type_conversions: list[_NoteTypeConversion],
     note_ids_by_note_key: dict[str, int],
     global_note_keys: set[str],
     global_mapped_note_ids: set[int],
@@ -568,6 +660,18 @@ def _apply_changes_and_update_state(
     queue_import_fingerprint,
 ) -> list[tuple[Note, str]]:
     if not deck_context.deck_name:
+        return []
+
+    if result.errors:
+        return []
+
+    conversion_errors = _apply_note_type_conversions(
+        anki_port=anki_port,
+        conversions=note_type_conversions,
+        queue_import_fingerprint=queue_import_fingerprint,
+    )
+    if conversion_errors:
+        result.errors.extend(conversion_errors)
         return []
 
     creates = result.changes_for(ChangeType.CREATE)
@@ -667,6 +771,7 @@ def _sync_file(
     result = SyncResult.for_notes(name=deck_context.deck_name, file_path=fs.file_path)
     cards_to_move: list[int] = []
     moved_from_decks: set[str] = set()
+    note_type_conversions: list[_NoteTypeConversion] = []
 
     def _queue_note_mapping(note_key: str, note_id: int) -> None:
         existing_note_id = note_ids_by_note_key.get(note_key)
@@ -717,6 +822,7 @@ def _sync_file(
                 result=result,
                 cards_to_move=cards_to_move,
                 moved_from_decks=moved_from_decks,
+                note_type_conversions=note_type_conversions,
                 queue_note_mapping=_queue_note_mapping,
                 clear_note_mapping=_clear_note_mapping,
                 queue_import_fingerprint=_queue_import_fingerprint,
@@ -747,6 +853,7 @@ def _sync_file(
         db_port=db_port,
         result=result,
         cards_to_move=cards_to_move,
+        note_type_conversions=note_type_conversions,
         note_ids_by_note_key=note_ids_by_note_key,
         global_note_keys=global_note_keys,
         global_mapped_note_ids=global_mapped_note_ids,

--- a/ankiops/import_notes.py
+++ b/ankiops/import_notes.py
@@ -30,6 +30,13 @@ from ankiops.models import (
     SyncResult,
     UntrackedDeck,
 )
+from ankiops.note_identity import resolve_import_note_identity
+from ankiops.sources import (
+    SyncSource,
+    discover_sync_sources,
+    load_configs_for_sources,
+    markdown_files_for_source,
+)
 from ankiops.tags import parse_tags_comment
 
 logger = logging.getLogger(__name__)
@@ -41,15 +48,21 @@ class _PendingWrite:
     note_key_assignments: list[tuple[Note, str]]
 
 
+@dataclass(frozen=True)
+class _SourceMarkdownFile:
+    source: SyncSource
+    file_state: MarkdownFile
+
+
 def _format_note_type_mismatch_error(
     *, note_key: str, markdown_note_type: str, anki_note_type: str
 ) -> str:
     return (
         f"Note type mismatch for note_key: {note_key}: markdown uses "
         f"'{markdown_note_type}' but Anki has '{anki_note_type}'. "
-        "AnkiConnect cannot convert existing notes between note types. "
-        f"Remove this note's key comment ({format_note_key_comment(note_key)}) "
-        "to force creating a new note with the new type on the next import."
+        "AnkiOps will not create a duplicate note to resolve this. "
+        "Fix the Markdown note_type metadata or intentionally convert the "
+        "existing Anki note type, then re-run import."
     )
 
 
@@ -320,7 +333,7 @@ def _sync_keyed_note(
 
     # Keyed sync trusts a non-empty embedded key field as source of truth.
     # If mapped note_id points to a different non-empty key, treat mapping as stale.
-    # Empty embedded keys are treated as backfill candidates.
+    # Empty embedded keys can receive the Markdown note_key during this import.
     if anki_note and note_id:
         embedded_note_key = anki_note.fields.get(ANKIOPS_KEY_FIELD.name, "").strip()
         if embedded_note_key and embedded_note_key != note_key:
@@ -500,7 +513,7 @@ def _collect_orphan_deletes(
                     ANKIOPS_KEY_FIELD.name, ""
                 ).strip()
 
-            # Protect unmanaged legacy notes from deletion on import.
+            # Protect unmanaged keyless notes from deletion on import.
             if not embedded_note_key:
                 result.protected_keyless_notes += 1
                 result.add_change(
@@ -762,14 +775,52 @@ def import_collection(
     collection_dir: Path,
     note_types_dir: Path,
 ) -> CollectionResult:
-    configs = fs_port.load_note_type_configs(note_types_dir)
+    sources = discover_sync_sources(collection_dir, note_types_dir=note_types_dir)
+    source_configs = load_configs_for_sources(sources)
+    configs = [
+        config
+        for source_config in source_configs
+        for config in source_config.configs
+    ]
     required_note_types = [config.name for config in configs]
     config_by_name = {config.name: config for config in configs}
-    md_files = fs_port.find_markdown_files(collection_dir)
-    fs_docs = [
-        fs_port.read_markdown_file(md_file, context_root=collection_dir)
-        for md_file in md_files
-    ]
+    fs_port.set_configs(configs)
+    source_docs: list[_SourceMarkdownFile] = []
+    for source_config in source_configs:
+        source_fs = FileSystemAdapter()
+        source_fs.set_configs(source_config.configs)
+        for md_file in markdown_files_for_source(source_config.source):
+            source_docs.append(
+                _SourceMarkdownFile(
+                    source=source_config.source,
+                    file_state=source_fs.read_markdown_file(
+                        md_file,
+                        context_root=source_config.source.root,
+                    ),
+                )
+            )
+    fs_docs = [source_doc.file_state for source_doc in source_docs]
+
+    deck_sources: dict[str, str] = {}
+    deck_duplicates: list[str] = []
+    for source_doc in source_docs:
+        deck_name = file_stem_to_deck_name(source_doc.file_state.file_path.stem)
+        previous = deck_sources.get(deck_name)
+        current = (
+            f"{source_doc.source.display_name}:"
+            f"{source_doc.file_state.file_path.name}"
+        )
+        if previous is not None:
+            deck_duplicates.append(
+                f"Deck '{deck_name}' is defined by both {previous} and {current}"
+            )
+            continue
+        deck_sources[deck_name] = current
+    if deck_duplicates:
+        raise ValueError(
+            "Aborting import: deck ownership conflicts found: "
+            + "; ".join(deck_duplicates)
+        )
 
     global_note_keys = set()
     note_key_sources = {}
@@ -781,16 +832,16 @@ def import_collection(
                 if note.note_key in note_key_sources:
                     duplicates.append(f"Duplicate note_key {note.note_key}")
                 else:
-                    note_key_sources[note.note_key] = markdown_file.file_path.name
+                    note_key_sources[note.note_key] = str(
+                        markdown_file.file_path.relative_to(collection_dir)
+                    )
                 global_note_keys.add(note.note_key)
 
     if duplicates:
         raise ValueError(f"Aborting import: Duplicates found: {duplicates}")
-    note_ids_by_note_key = db_port.resolve_note_ids(global_note_keys)
     note_import_fingerprints_by_note_key = db_port.resolve_import_hashes(
         global_note_keys
     )
-    pending_note_mappings: list[tuple[str, int]] = []
     pending_import_fingerprints: list[tuple[str, str, str]] = []
 
     with db_port.write_tx():
@@ -800,21 +851,15 @@ def import_collection(
             deck_id: deck_name for deck_name, deck_id in deck_ids_by_name.items()
         }
 
-        all_note_ids = anki_port.fetch_all_note_ids(required_note_types)
-        anki_notes = anki_port.fetch_notes_info(all_note_ids)
-
-        # Collaboration mode: rebuild note_key->note_id mappings from embedded
-        # key fields, so move/delete decisions do not depend on a local DB.
-        for anki_note in anki_notes.values():
-            embedded_note_key = anki_note.fields.get(
-                ANKIOPS_KEY_FIELD.name, ""
-            ).strip()
-            if not embedded_note_key or embedded_note_key not in global_note_keys:
-                continue
-            if note_ids_by_note_key.get(embedded_note_key) == anki_note.note_id:
-                continue
-            note_ids_by_note_key[embedded_note_key] = anki_note.note_id
-            pending_note_mappings.append((embedded_note_key, anki_note.note_id))
+        identity = resolve_import_note_identity(
+            anki_port=anki_port,
+            db_port=db_port,
+            note_keys=global_note_keys,
+            required_note_types=required_note_types,
+        )
+        anki_notes = identity.anki_notes
+        note_ids_by_note_key = identity.note_ids_by_note_key
+        pending_note_mappings = list(identity.pending_note_mappings)
 
         global_mapped_note_ids = {
             note_id
@@ -840,7 +885,8 @@ def import_collection(
         }
         rename_candidates: set[tuple[str, str]] = set()
 
-        for markdown_file in fs_docs:
+        for source_doc in source_docs:
+            markdown_file = source_doc.file_state
             # Determine actual anki_deck_note_ids for this specific file
             # We find what the deck name maps to...
             deck_name = file_stem_to_deck_name(markdown_file.file_path.stem)

--- a/ankiops/llm/commands.py
+++ b/ankiops/llm/commands.py
@@ -30,7 +30,7 @@ from ankiops.config import (
     file_stem_to_deck_name,
     require_collection_dir,
 )
-from ankiops.fs import FileSystemAdapter
+from ankiops.sources import discover_sync_sources, load_configs_for_sources
 
 from .config_loader import load_llm_task_catalog
 from .llm_db import LlmJobRequestNoteRef
@@ -225,6 +225,7 @@ def _show_job(
             [
                 str(item.ordinal),
                 item.note_key or "unknown",
+                item.source,
                 item.deck_name,
                 item.note_type or "unknown",
                 item.item_status.value,
@@ -237,6 +238,7 @@ def _show_job(
         [
             "#",
             "Note",
+            "Source",
             "Deck",
             "Type",
             "Final",
@@ -425,9 +427,10 @@ def _show_plan(
     logger.info("Field surface:")
     if plan.field_surface:
         _log_table(
-            ["Type", "Candidates", "Tags", "Editable", "Read-only", "Hidden"],
+            ["Source", "Type", "Candidates", "Tags", "Editable", "Read-only", "Hidden"],
             [
                 [
+                    surface.source,
                     surface.note_type,
                     str(surface.candidate_notes),
                     surface.tag_access.value,
@@ -458,7 +461,13 @@ def _show_plan(
 
 
 def _load_note_type_configs(note_types_dir: Path) -> list[Any]:
-    return FileSystemAdapter().load_note_type_configs(note_types_dir)
+    collection_dir = note_types_dir.parent
+    sources = discover_sync_sources(collection_dir, note_types_dir=note_types_dir)
+    return [
+        config
+        for source_config in load_configs_for_sources(sources)
+        for config in source_config.configs
+    ]
 
 
 def _normalize_deck_override(value: str | None) -> str | None:

--- a/ankiops/llm/llm_db.py
+++ b/ankiops/llm/llm_db.py
@@ -39,6 +39,7 @@ class LlmJobListItem:
 class LlmJobItemDetail:
     ordinal: int
     note_key: str | None
+    source: str
     deck_name: str
     note_type: str | None
     item_status: LlmItemStatus
@@ -170,6 +171,7 @@ class LlmDb:
         *,
         job_id: int,
         ordinal: int,
+        source: str,
         deck_name: str,
         note_key: str | None,
         note_type: str | None,
@@ -182,15 +184,16 @@ class LlmDb:
         cursor = self._write(
             f"""
             INSERT INTO {_ITEM_TABLE} (
-                job_id, ordinal, note_key, deck_name, note_type,
+                job_id, ordinal, note_key, source, deck_name, note_type,
                 item_status, skip_reason, error_message,
                 changed_fields_json, applied_to_markdown
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 job_id,
                 ordinal,
                 note_key,
+                source,
                 deck_name,
                 note_type,
                 item_status.value,
@@ -460,8 +463,8 @@ class LlmDb:
         aggregate = self.aggregate_job(job_id)
         item_rows = self._conn.execute(
             f"""
-            SELECT i.ordinal, i.note_key, i.deck_name, i.note_type, i.item_status,
-                   i.error_message, i.changed_fields_json,
+            SELECT i.ordinal, i.note_key, i.source, i.deck_name, i.note_type,
+                   i.item_status, i.error_message, i.changed_fields_json,
                    COUNT(ri.request_id) request_count
             FROM {_ITEM_TABLE} i
             LEFT JOIN {_REQUEST_ITEM_TABLE} ri ON ri.job_item_id = i.id
@@ -476,6 +479,7 @@ class LlmDb:
             LlmJobItemDetail(
                 ordinal=int(item["ordinal"]),
                 note_key=(str(item["note_key"]) if item["note_key"] else None),
+                source=str(item["source"]),
                 deck_name=str(item["deck_name"]),
                 note_type=(str(item["note_type"]) if item["note_type"] else None),
                 item_status=_parse_enum(LlmItemStatus, item["item_status"]),
@@ -577,6 +581,7 @@ class LlmDb:
                     job_id INTEGER NOT NULL,
                     ordinal INTEGER NOT NULL,
                     note_key TEXT,
+                    source TEXT NOT NULL,
                     deck_name TEXT NOT NULL,
                     note_type TEXT,
                     item_status TEXT NOT NULL
@@ -635,6 +640,20 @@ class LlmDb:
         self._assert_schema()
 
     def _assert_schema(self) -> None:
+        required_item_columns = {
+            "id",
+            "job_id",
+            "ordinal",
+            "note_key",
+            "source",
+            "deck_name",
+            "note_type",
+            "item_status",
+            "skip_reason",
+            "error_message",
+            "changed_fields_json",
+            "applied_to_markdown",
+        }
         required_request_columns = {
             "id",
             "job_id",
@@ -652,13 +671,18 @@ class LlmDb:
             str(row["name"])
             for row in self._conn.execute(f"PRAGMA table_info({_REQUEST_TABLE})")
         }
+        item_columns = {
+            str(row["name"])
+            for row in self._conn.execute(f"PRAGMA table_info({_ITEM_TABLE})")
+        }
         required_request_item_columns = {"request_id", "job_item_id"}
         request_item_columns = {
             str(row["name"])
             for row in self._conn.execute(f"PRAGMA table_info({_REQUEST_ITEM_TABLE})")
         }
         if (
-            required_request_columns - request_columns
+            required_item_columns - item_columns
+            or required_request_columns - request_columns
             or required_request_item_columns - request_item_columns
         ):
             raise RuntimeError(

--- a/ankiops/llm/runner.py
+++ b/ankiops/llm/runner.py
@@ -9,6 +9,7 @@ import os
 import re
 import time
 from dataclasses import dataclass, replace
+from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -20,10 +21,10 @@ from openai.types.responses import (
 )
 
 from ankiops.config import NOTE_TYPES_DIR
-from ankiops.fs import FileSystemAdapter
 from ankiops.git import git_snapshot
 from ankiops.models import ANKIOPS_KEY_FIELD, Note, NoteTypeConfig
 from ankiops.serializer import deserialize, serialize
+from ankiops.sources import discover_sync_sources, load_configs_for_sources
 from ankiops.tags import normalize_tags
 
 from .config_loader import is_task_config_file, load_llm_task_catalog
@@ -599,6 +600,7 @@ def _materialize_task_context(
         task=task,
         note_type_configs=note_type_configs,
     )
+    _validate_note_type_patterns_match_scope(task, discovery_snapshot)
     return MaterializedTaskContext(
         task=task,
         note_type_configs=note_type_configs,
@@ -612,8 +614,15 @@ def _load_task(
     collection_dir: Path,
     task_name: str,
 ) -> tuple[TaskConfig, dict[str, NoteTypeConfig]]:
-    fs = FileSystemAdapter()
-    note_type_configs = fs.load_note_type_configs(collection_dir / NOTE_TYPES_DIR)
+    sources = discover_sync_sources(
+        collection_dir,
+        note_types_dir=collection_dir / NOTE_TYPES_DIR,
+    )
+    note_type_configs = [
+        config
+        for source_config in load_configs_for_sources(sources)
+        for config in source_config.configs
+    ]
     catalog = load_llm_task_catalog(
         collection_dir,
         note_type_configs=note_type_configs,
@@ -661,10 +670,13 @@ def _discover_candidates(
     for deck in decks:
         if not isinstance(deck, dict):
             continue
+        source = deck.get("source")
         deck_name = deck.get("name")
         notes = deck.get("notes")
+        if not isinstance(source, str) or not source.strip():
+            raise ValueError("Serialized deck is missing source")
         if not isinstance(deck_name, str) or not isinstance(notes, list):
-            continue
+            raise ValueError(f"Serialized deck in source '{source}' is malformed")
         decks_seen += 1
         notes_seen += len(notes)
         if not task.decks.matches(deck_name):
@@ -678,6 +690,7 @@ def _discover_candidates(
             items.append(
                 _discover_note(
                     task=task,
+                    source=source,
                     deck_name=deck_name,
                     ordinal=ordinal,
                     note=note,
@@ -698,6 +711,7 @@ def _discover_candidates(
 def _discover_note(
     *,
     task: TaskConfig,
+    source: str,
     deck_name: str,
     ordinal: int,
     note: dict[str, Any],
@@ -711,6 +725,7 @@ def _discover_note(
 
     if not isinstance(note_key, str) or not isinstance(note_type_name, str):
         return _invalid_discovery_item(
+            source=source,
             deck_name=deck_name,
             ordinal=ordinal,
             note_key=note_key_value,
@@ -720,6 +735,7 @@ def _discover_note(
         )
     if not isinstance(fields, dict):
         return _invalid_discovery_item(
+            source=source,
             deck_name=deck_name,
             ordinal=ordinal,
             note_key=note_key,
@@ -731,6 +747,7 @@ def _discover_note(
     note_type_config = note_type_configs.get(note_type_name)
     if note_type_config is None:
         return _invalid_discovery_item(
+            source=source,
             deck_name=deck_name,
             ordinal=ordinal,
             note_key=note_key,
@@ -752,6 +769,7 @@ def _discover_note(
             raw_value = ""
         if not isinstance(raw_value, str):
             return _invalid_discovery_item(
+                source=source,
                 deck_name=deck_name,
                 ordinal=ordinal,
                 note_key=note_key,
@@ -778,6 +796,7 @@ def _discover_note(
         )
         return DiscoveryItem(
             ordinal=ordinal,
+            source=source,
             deck_name=deck_name,
             note_key=note_key,
             note_type=note_type_name,
@@ -791,6 +810,7 @@ def _discover_note(
 
     return DiscoveryItem(
         ordinal=ordinal,
+        source=source,
         deck_name=deck_name,
         note_key=note_key,
         note_type=note_type_name,
@@ -812,6 +832,7 @@ def _discover_note(
 
 def _invalid_discovery_item(
     *,
+    source: str,
     deck_name: str,
     ordinal: int,
     note_key: str | None,
@@ -821,6 +842,7 @@ def _invalid_discovery_item(
 ) -> DiscoveryItem:
     return DiscoveryItem(
         ordinal=ordinal,
+        source=source,
         deck_name=deck_name,
         note_key=note_key,
         note_type=note_type,
@@ -831,6 +853,33 @@ def _invalid_discovery_item(
         note_type_config=None,
         serialized_note=serialized_note,
     )
+
+
+def _validate_note_type_patterns_match_scope(
+    task: TaskConfig,
+    snapshot: DiscoverySnapshot,
+) -> None:
+    observed_note_types = {
+        item.note_type
+        for item in snapshot.items
+        if item.note_type is not None and item.note_type_config is not None
+    }
+    missing_patterns: list[str] = []
+    for rule in task.field_rules:
+        for pattern in rule.note_types:
+            if pattern == "*":
+                continue
+            if not any(
+                fnmatchcase(note_type, pattern) for note_type in observed_note_types
+            ):
+                missing_patterns.append(pattern)
+
+    if missing_patterns:
+        missing = ", ".join(sorted(set(missing_patterns)))
+        raise ValueError(
+            "LLM note type pattern(s) matched no notes after deck filtering: "
+            f"{missing}"
+        )
 
 
 def _record_discovery_snapshot(
@@ -864,6 +913,7 @@ def _record_discovery_item(
         db.insert_job_item(
             job_id=job_id,
             ordinal=item.ordinal,
+            source=item.source,
             deck_name=item.deck_name,
             note_key=item.note_key,
             note_type=item.note_type,
@@ -884,6 +934,7 @@ def _record_discovery_item(
         db.insert_job_item(
             job_id=job_id,
             ordinal=item.ordinal,
+            source=item.source,
             deck_name=item.deck_name,
             note_key=item.note_key,
             note_type=item.note_type,
@@ -902,6 +953,7 @@ def _record_discovery_item(
     item_id = db.insert_job_item(
         job_id=job_id,
         ordinal=item.ordinal,
+        source=item.source,
         deck_name=item.deck_name,
         note_key=item.payload.note_key,
         note_type=item.payload.note_type,
@@ -910,6 +962,7 @@ def _record_discovery_item(
     )
     return EligibleCandidate(
         item_id=item_id,
+        source=item.source,
         deck_name=item.deck_name,
         payload=item.payload,
         note_type_config=item.note_type_config,
@@ -1405,13 +1458,16 @@ def _build_plan_field_surface(
     note_type_configs: dict[str, NoteTypeConfig],
     snapshot_items: list[DiscoveryItem],
 ) -> list[PlanFieldSurface]:
-    observed_note_types = {
-        item.note_type
+    observed = {
+        (item.source, item.note_type)
         for item in snapshot_items
         if item.note_type is not None and item.note_type_config is not None
     }
     surface: list[PlanFieldSurface] = []
-    for note_type in sorted(observed_note_types):
+    for source, note_type in sorted(
+        observed,
+        key=lambda item: (0 if item[0] == "local" else 1, item[0], item[1]),
+    ):
         config = note_type_configs.get(note_type)
         if config is None:
             continue
@@ -1431,10 +1487,13 @@ def _build_plan_field_surface(
         candidate_notes = sum(
             1
             for item in snapshot_items
-            if item.item_status is LlmItemStatus.QUEUED and item.note_type == note_type
+            if item.item_status is LlmItemStatus.QUEUED
+            and item.source == source
+            and item.note_type == note_type
         )
         surface.append(
             PlanFieldSurface(
+                source=source,
                 note_type=note_type,
                 candidate_notes=candidate_notes,
                 editable_fields=editable_fields,

--- a/ankiops/llm/types.py
+++ b/ankiops/llm/types.py
@@ -130,6 +130,7 @@ class DiscoveryCounts:
 @dataclass(frozen=True)
 class DiscoveryItem:
     ordinal: int
+    source: str
     deck_name: str
     note_key: str | None
     note_type: str | None
@@ -150,6 +151,7 @@ class DiscoverySnapshot:
 @dataclass(frozen=True)
 class EligibleCandidate:
     item_id: int
+    source: str
     deck_name: str
     payload: NotePayload
     note_type_config: NoteTypeConfig
@@ -229,6 +231,7 @@ class LlmJobResult:
 
 @dataclass(frozen=True)
 class PlanFieldSurface:
+    source: str
     note_type: str
     candidate_notes: int
     editable_fields: list[str]

--- a/ankiops/markdown_format.py
+++ b/ankiops/markdown_format.py
@@ -9,7 +9,7 @@ NOTE_SEPARATOR = "\n\n---\n\n"  # changing the whitespace might lead to issues
 NOTE_KEY_COMMENT_RE = re.compile(
     r"^\s*<!--\s*note_key:\s*([a-zA-Z0-9-]+)\s*-->\s*$"
 )
-NOTE_TYPE_COMMENT_RE = re.compile(r"^\s*<!--\s*note_type:\s*.*?\s*-->\s*$")
+NOTE_TYPE_COMMENT_RE = re.compile(r"^\s*<!--\s*note_type:\s*(.*?)\s*-->\s*$")
 TAGS_COMMENT_RE = re.compile(r"^\s*<!--\s*tags:\s*(.*?)\s*-->\s*$")
 CODE_FENCE_RE = re.compile(r"^(```|~~~)")
 FIELD_LABEL_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_-]*$")
@@ -27,6 +27,14 @@ def format_note_type_comment(note_type: str) -> str:
 def parse_note_key_comment(line: str) -> str | None:
     match = NOTE_KEY_COMMENT_RE.match(line)
     return match.group(1) if match else None
+
+
+def parse_note_type_comment(line: str) -> str | None:
+    match = NOTE_TYPE_COMMENT_RE.match(line)
+    if not match:
+        return None
+    value = match.group(1).strip()
+    return value or None
 
 
 def is_note_type_comment(line: str) -> bool:

--- a/ankiops/models.py
+++ b/ankiops/models.py
@@ -295,6 +295,7 @@ class AnkiNote:
 class ChangeType(Enum):
     CREATE = ("created", True, 4, True, True, True)
     UPDATE = ("updated", True, 3, True, True, False)
+    CONVERT = ("converted", True, 3, True, False, False)
     DELETE = ("deleted", False, 6, True, True, True)
     MOVE = ("moved", True, 5, True, True, True)
     SKIP = ("skipped", True, 0, True, True, False)
@@ -344,6 +345,7 @@ _NOTE_REPORTED_CHANGE_TYPES = ChangeType.note_reported()
 _MEDIA_REPORTED_CHANGE_TYPES = ChangeType.media_reported()
 _NOTE_CHANGE_ORDER: tuple[ChangeType, ...] = (
     ChangeType.CREATE,
+    ChangeType.CONVERT,
     ChangeType.UPDATE,
     ChangeType.DELETE,
     ChangeType.SKIP,
@@ -434,6 +436,7 @@ class SyncSummary:
     total: int = 0
     created: int = 0
     updated: int = 0
+    converted: int = 0
     deleted: int = 0
     moved: int = 0
     skipped: int = 0
@@ -443,6 +446,7 @@ class SyncSummary:
     _FORMAT_ORDER = (
         "created",
         "updated",
+        "converted",
         "deleted",
         "moved",
         "errors",

--- a/ankiops/note_identity.py
+++ b/ankiops/note_identity.py
@@ -1,0 +1,252 @@
+"""Resolve managed note identity before sync planning."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from ankiops.models import ANKIOPS_KEY_FIELD, AnkiNote
+
+
+class AnkiIdentityPort(Protocol):
+    def fetch_all_note_ids(self, required_types: list[str]) -> list[int]: ...
+
+    def fetch_note_ids_by_note_keys(
+        self,
+        note_keys: set[str],
+    ) -> dict[str, list[int]]: ...
+
+    def fetch_notes_info(self, note_ids: list[int]) -> dict[int, AnkiNote]: ...
+
+
+class DbIdentityPort(Protocol):
+    def resolve_note_ids(self, note_keys: set[str]) -> dict[str, int]: ...
+
+
+@dataclass(frozen=True)
+class ImportNoteIdentity:
+    anki_notes: dict[int, AnkiNote]
+    note_ids_by_note_key: dict[str, int]
+    pending_note_mappings: list[tuple[str, int]]
+
+
+def _embedded_note_key(note: AnkiNote) -> str:
+    return note.fields.get(ANKIOPS_KEY_FIELD.name, "").strip()
+
+
+def _merge_notes(
+    target: dict[int, AnkiNote],
+    new_notes: dict[int, AnkiNote],
+) -> None:
+    for note_id, note in new_notes.items():
+        target[note_id] = note
+
+
+def _embedded_note_ids_by_key(
+    anki_notes: dict[int, AnkiNote],
+    note_keys: set[str],
+) -> dict[str, set[int]]:
+    note_ids_by_key: dict[str, set[int]] = {}
+    for note in anki_notes.values():
+        embedded_note_key = _embedded_note_key(note)
+        if embedded_note_key and embedded_note_key in note_keys:
+            note_ids_by_key.setdefault(embedded_note_key, set()).add(note.note_id)
+    return note_ids_by_key
+
+
+def _candidate_note_ids(
+    *,
+    note_key: str,
+    mapped_note_id: int | None,
+    anki_notes: dict[int, AnkiNote],
+    embedded_note_ids_by_key: dict[str, set[int]],
+) -> set[int]:
+    candidates = set(embedded_note_ids_by_key.get(note_key, set()))
+    if mapped_note_id is None:
+        return candidates
+
+    mapped_note = anki_notes.get(mapped_note_id)
+    if mapped_note is None:
+        return candidates
+
+    embedded_note_key = _embedded_note_key(mapped_note)
+    if not embedded_note_key or embedded_note_key == note_key:
+        candidates.add(mapped_note_id)
+    return candidates
+
+
+def _needs_key_field_lookup(
+    *,
+    note_key: str,
+    mapped_note_id: int | None,
+    anki_notes: dict[int, AnkiNote],
+    candidates: set[int],
+) -> bool:
+    if not candidates:
+        return True
+    if mapped_note_id is None:
+        return False
+    mapped_note = anki_notes.get(mapped_note_id)
+    if mapped_note is None:
+        return True
+    return not _embedded_note_key(mapped_note)
+
+
+def _duplicate_errors(
+    *,
+    note_keys: set[str],
+    db_mappings: dict[str, int],
+    anki_notes: dict[int, AnkiNote],
+    embedded_note_ids_by_key: dict[str, set[int]],
+) -> list[str]:
+    note_ids_by_key: dict[str, set[int]] = {}
+    for note_key in sorted(note_keys):
+        candidates = _candidate_note_ids(
+            note_key=note_key,
+            mapped_note_id=db_mappings.get(note_key),
+            anki_notes=anki_notes,
+            embedded_note_ids_by_key=embedded_note_ids_by_key,
+        )
+        note_ids_by_key[note_key] = candidates
+    return _duplicate_key_errors(note_ids_by_key)
+
+
+def _duplicate_key_errors(note_ids_by_key: dict[str, set[int]]) -> list[str]:
+    return [
+        f"Duplicate AnkiOps Key '{note_key}' found on Anki note IDs "
+        f"{sorted(note_ids)}"
+        for note_key, note_ids in sorted(note_ids_by_key.items())
+        if len(note_ids) > 1
+    ]
+
+
+def _resolve_note_ids_by_key(
+    *,
+    note_keys: set[str],
+    db_mappings: dict[str, int],
+    anki_notes: dict[int, AnkiNote],
+    embedded_note_ids_by_key: dict[str, set[int]],
+) -> dict[str, int]:
+    note_ids_by_key: dict[str, int] = {}
+    for note_key in sorted(note_keys):
+        candidates = _candidate_note_ids(
+            note_key=note_key,
+            mapped_note_id=db_mappings.get(note_key),
+            anki_notes=anki_notes,
+            embedded_note_ids_by_key=embedded_note_ids_by_key,
+        )
+        if candidates:
+            note_ids_by_key[note_key] = min(candidates)
+    return note_ids_by_key
+
+
+def resolve_import_note_identity(
+    *,
+    anki_port: AnkiIdentityPort,
+    db_port: DbIdentityPort,
+    note_keys: set[str],
+    required_note_types: list[str],
+) -> ImportNoteIdentity:
+    """Resolve keyed Markdown notes to Anki notes before creating anything."""
+    if not note_keys:
+        all_note_ids = set(anki_port.fetch_all_note_ids(required_note_types))
+        anki_notes = anki_port.fetch_notes_info(sorted(all_note_ids))
+        return ImportNoteIdentity(
+            anki_notes=anki_notes,
+            note_ids_by_note_key={},
+            pending_note_mappings=[],
+        )
+
+    db_mappings = db_port.resolve_note_ids(note_keys)
+    all_note_ids = set(anki_port.fetch_all_note_ids(required_note_types))
+    all_note_ids.update(db_mappings.values())
+    anki_notes = anki_port.fetch_notes_info(sorted(all_note_ids))
+
+    embedded_note_ids = _embedded_note_ids_by_key(anki_notes, note_keys)
+    key_field_lookup_note_keys = {
+        note_key
+        for note_key in note_keys
+        if _needs_key_field_lookup(
+            note_key=note_key,
+            mapped_note_id=db_mappings.get(note_key),
+            anki_notes=anki_notes,
+            candidates=_candidate_note_ids(
+                note_key=note_key,
+                mapped_note_id=db_mappings.get(note_key),
+                anki_notes=anki_notes,
+                embedded_note_ids_by_key=embedded_note_ids,
+            ),
+        )
+    }
+
+    key_field_note_ids_by_key = (
+        anki_port.fetch_note_ids_by_note_keys(key_field_lookup_note_keys)
+        if key_field_lookup_note_keys
+        else {}
+    )
+    key_field_note_ids = {
+        note_id
+        for note_ids in key_field_note_ids_by_key.values()
+        for note_id in note_ids
+    }
+    missing_key_field_note_ids = key_field_note_ids - set(anki_notes)
+    if missing_key_field_note_ids:
+        _merge_notes(
+            anki_notes,
+            anki_port.fetch_notes_info(sorted(missing_key_field_note_ids)),
+        )
+
+    embedded_note_ids = _embedded_note_ids_by_key(anki_notes, note_keys)
+    duplicate_errors = _duplicate_errors(
+        note_keys=note_keys,
+        db_mappings=db_mappings,
+        anki_notes=anki_notes,
+        embedded_note_ids_by_key=embedded_note_ids,
+    )
+    if duplicate_errors:
+        raise ValueError(
+            "Aborting import: duplicate AnkiOps Key values found in Anki: "
+            + "; ".join(duplicate_errors)
+        )
+
+    note_ids_by_key = _resolve_note_ids_by_key(
+        note_keys=note_keys,
+        db_mappings=db_mappings,
+        anki_notes=anki_notes,
+        embedded_note_ids_by_key=embedded_note_ids,
+    )
+    pending_note_mappings = [
+        (note_key, note_id)
+        for note_key, note_id in sorted(note_ids_by_key.items())
+        if db_mappings.get(note_key) != note_id
+    ]
+
+    return ImportNoteIdentity(
+        anki_notes=anki_notes,
+        note_ids_by_note_key=note_ids_by_key,
+        pending_note_mappings=pending_note_mappings,
+    )
+
+
+def assert_unique_export_note_keys(
+    *,
+    anki_notes: dict[int, AnkiNote],
+    note_keys_by_id: dict[int, str],
+) -> None:
+    """Block export when two Anki notes claim the same managed identity."""
+    note_ids_by_key: dict[str, set[int]] = {}
+    for anki_note in anki_notes.values():
+        note_key = _embedded_note_key(anki_note) or note_keys_by_id.get(
+            anki_note.note_id,
+            "",
+        )
+        if not note_key:
+            continue
+        note_ids_by_key.setdefault(note_key, set()).add(anki_note.note_id)
+
+    duplicate_errors = _duplicate_key_errors(note_ids_by_key)
+    if duplicate_errors:
+        raise ValueError(
+            "Aborting export: duplicate AnkiOps Key values found in Anki: "
+            + "; ".join(duplicate_errors)
+        )

--- a/ankiops/serializer.py
+++ b/ankiops/serializer.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -16,9 +17,40 @@ from ankiops.config import (
 from ankiops.fs import FileSystemAdapter
 from ankiops.log import clickable_path
 from ankiops.markdown_format import format_note_key_comment, format_note_type_comment
+from ankiops.models import MarkdownFile, NoteTypeConfig
+from ankiops.sources import (
+    SyncSource,
+    discover_sync_sources,
+    load_configs_for_source,
+    markdown_files_for_source,
+)
 from ankiops.tags import format_tags_comment, normalize_tags
 
 logger = logging.getLogger(__name__)
+
+LOCAL_SOURCE_NAME = "local"
+
+
+@dataclass(frozen=True)
+class _ParsedDeck:
+    source: SyncSource
+    source_name: str
+    path: Path
+    deck_name: str
+    parsed: MarkdownFile
+
+
+@dataclass(frozen=True)
+class _ValidatedDeck:
+    source: SyncSource
+    source_name: str
+    name: str
+    notes: list[dict[str, Any]]
+    configs_by_name: dict[str, NoteTypeConfig]
+
+
+def _source_name(source: SyncSource) -> str:
+    return source.source_id or LOCAL_SOURCE_NAME
 
 
 def serialize(
@@ -33,9 +65,9 @@ def serialize(
     if not db_path.exists():
         raise ValueError(f"Not an AnkiOps collection: {collection_dir}")
 
-    fs = FileSystemAdapter()
-    resolved_note_types_dir = note_types_dir or (collection_dir / NOTE_TYPES_DIR)
-    fs.load_note_type_configs(resolved_note_types_dir)
+    sources = discover_sync_sources(collection_dir, note_types_dir=note_types_dir)
+    parsed_decks = _parse_sources(collection_dir, sources)
+    _validate_parsed_decks(parsed_decks)
 
     serialized_data: dict[str, Any] = {
         "collection": {
@@ -44,50 +76,38 @@ def serialize(
         "decks": [],
     }
 
-    md_files = fs.find_markdown_files(collection_dir)
     deck_filter = deck.strip() if isinstance(deck, str) else None
+    filtered_decks = [
+        parsed_deck
+        for parsed_deck in parsed_decks
+        if _deck_matches_filter(
+            parsed_deck.deck_name,
+            deck_filter=deck_filter,
+            no_subdecks=no_subdecks,
+        )
+    ]
 
-    if deck_filter:
-        if no_subdecks:
-            md_files = [
-                md_file
-                for md_file in md_files
-                if file_stem_to_deck_name(md_file.stem) == deck_filter
-            ]
-        else:
-            subdeck_scope = f"{deck_filter}::"
-            md_files = [
-                md_file
-                for md_file in md_files
-                if file_stem_to_deck_name(md_file.stem) == deck_filter
-                or file_stem_to_deck_name(md_file.stem).startswith(subdeck_scope)
-            ]
-
-    for md_file in md_files:
-        try:
-            parsed = fs.read_markdown_file(md_file, context_root=collection_dir)
-        except Exception as error:
-            raise ValueError(f"Error parsing {md_file.name}: {error}") from error
-
-        deck_data: dict[str, Any] = {
-            "name": file_stem_to_deck_name(md_file.stem),
-            "notes": [],
-        }
-        notes_data: list[dict[str, Any]] = deck_data["notes"]
-        for note in parsed.notes:
-            notes_data.append(
+    for parsed_deck in filtered_decks:
+        notes_data = [
+            {
+                "note_key": note.note_key,
+                "note_type": note.note_type,
+                "fields": note.fields,
+                "tags": list(note.tags),
+            }
+            for note in parsed_deck.parsed.notes
+        ]
+        if not notes_data:
+            continue
+        decks_data = serialized_data["decks"]
+        if isinstance(decks_data, list):
+            decks_data.append(
                 {
-                    "note_key": note.note_key,
-                    "note_type": note.note_type,
-                    "fields": note.fields,
-                    "tags": list(note.tags),
+                    "source": parsed_deck.source_name,
+                    "name": parsed_deck.deck_name,
+                    "notes": notes_data,
                 }
             )
-
-        if notes_data:
-            decks_data = serialized_data["decks"]
-            if isinstance(decks_data, list):
-                decks_data.append(deck_data)
 
     total_notes = sum(
         len(deck.get("notes", []))
@@ -96,10 +116,113 @@ def serialize(
     )
     total_decks = len(serialized_data["decks"])
     logger.debug(
-        f"Serialized {total_decks} deck(s), {total_notes} note(s) to in-memory mapping"
+        "Serialized %d deck(s), %d note(s), %d source(s) to in-memory mapping",
+        total_decks,
+        total_notes,
+        len(sources),
     )
 
     return serialized_data
+
+
+def _parse_sources(
+    collection_dir: Path,
+    sources: list[SyncSource],
+) -> list[_ParsedDeck]:
+    parsed_decks: list[_ParsedDeck] = []
+    for source in sources:
+        fs = FileSystemAdapter()
+        configs = load_configs_for_source(source)
+        fs.set_configs(configs)
+        for md_file in markdown_files_for_source(source):
+            try:
+                parsed = fs.read_markdown_file(md_file, context_root=source.root)
+            except Exception as error:
+                display = _display_source_path(collection_dir, source, md_file)
+                raise ValueError(f"Error parsing {display}: {error}") from error
+            parsed_decks.append(
+                _ParsedDeck(
+                    source=source,
+                    source_name=_source_name(source),
+                    path=md_file,
+                    deck_name=file_stem_to_deck_name(md_file.stem),
+                    parsed=parsed,
+                )
+            )
+    parsed_decks.sort(
+        key=lambda item: (
+            0 if item.source_name == LOCAL_SOURCE_NAME else 1,
+            item.source_name,
+            item.deck_name,
+        )
+    )
+    return parsed_decks
+
+
+def _validate_parsed_decks(parsed_decks: list[_ParsedDeck]) -> None:
+    errors: list[str] = []
+    deck_by_name: dict[str, _ParsedDeck] = {}
+    note_key_by_value: dict[str, tuple[_ParsedDeck, int]] = {}
+
+    for parsed_deck in parsed_decks:
+        previous_deck = deck_by_name.get(parsed_deck.deck_name)
+        if previous_deck is not None:
+            errors.append(
+                "Duplicate deck name "
+                f"'{parsed_deck.deck_name}' in "
+                f"{previous_deck.source_name}:{previous_deck.path.name} and "
+                f"{parsed_deck.source_name}:{parsed_deck.path.name}."
+            )
+        else:
+            deck_by_name[parsed_deck.deck_name] = parsed_deck
+
+        for index, note in enumerate(parsed_deck.parsed.notes, start=1):
+            if not isinstance(note.note_key, str) or not note.note_key.strip():
+                errors.append(
+                    f"{parsed_deck.source_name}:{parsed_deck.path.name} note {index} "
+                    "is missing a note_key. Run 'ankiops ma' first to assign keys."
+                )
+                continue
+            previous_note = note_key_by_value.get(note.note_key)
+            if previous_note is not None:
+                previous_deck, previous_index = previous_note
+                errors.append(
+                    "Duplicate note_key "
+                    f"'{note.note_key}' in "
+                    f"{previous_deck.source_name}:{previous_deck.path.name} "
+                    f"note {previous_index} and "
+                    f"{parsed_deck.source_name}:{parsed_deck.path.name} "
+                    f"note {index}."
+                )
+            else:
+                note_key_by_value[note.note_key] = (parsed_deck, index)
+
+    if errors:
+        raise ValueError("Cannot serialize collection:\n- " + "\n- ".join(errors))
+
+
+def _display_source_path(collection_dir: Path, source: SyncSource, path: Path) -> str:
+    try:
+        relative = path.resolve().relative_to(source.root.resolve())
+    except ValueError:
+        try:
+            relative = path.resolve().relative_to(collection_dir.resolve())
+        except ValueError:
+            return str(path)
+    return f"{_source_name(source)}:{relative}"
+
+
+def _deck_matches_filter(
+    deck_name: str,
+    *,
+    deck_filter: str | None,
+    no_subdecks: bool,
+) -> bool:
+    if deck_filter is None:
+        return True
+    if no_subdecks:
+        return deck_name == deck_filter
+    return deck_name == deck_filter or deck_name.startswith(f"{deck_filter}::")
 
 
 def serialize_to_file(
@@ -156,75 +279,33 @@ def deserialize(
     """Deserialize markdown decks from an in-memory JSON-compatible mapping."""
     logger.debug(f"Target directory: {collection_dir}")
 
-    if not isinstance(data, dict):
-        raise ValueError("Serialized data must be a JSON object mapping")
+    db_path = collection_dir / ANKIOPS_DB
+    if not db_path.exists():
+        raise ValueError(f"Not an initialized AnkiOps collection: {collection_dir}")
 
-    decks = data.get("decks")
-    if not isinstance(decks, list):
-        raise ValueError("Serialized data must contain a top-level 'decks' list")
-
-    if not overwrite:
-        existing_md_files = list(collection_dir.glob("*.md"))
-        if existing_md_files:
-            logger.warning(
-                f"Found {len(existing_md_files)} existing markdown file(s) "
-                f"in {collection_dir}. Use --overwrite to replace them."
-            )
-
-    fs = FileSystemAdapter()
-    configs = fs.load_note_type_configs(note_types_dir)
-    config_by_name = {config.name: config for config in configs}
+    decks = _validate_serialized_data(
+        data,
+        collection_dir=collection_dir,
+        note_types_dir=note_types_dir,
+    )
 
     total_decks = 0
     total_notes = 0
-    skipped_notes = 0
 
     for deck in decks:
-        if not isinstance(deck, dict):
-            continue
-        deck_name = deck.get("name")
-        notes = deck.get("notes")
-        if not isinstance(deck_name, str) or not isinstance(notes, list):
-            continue
-
-        filename = deck_name_to_file_stem(deck_name) + ".md"
-        output_path = collection_dir / filename
+        output_path = deck.source.root / (deck_name_to_file_stem(deck.name) + ".md")
 
         lines = []
         written_notes = 0
 
-        for note in notes:
-            note_key = note.get("note_key")
+        for note in deck.notes:
+            note_key = str(note["note_key"])
+            note_type = str(note["note_type"])
             fields = note["fields"]
-            tags = normalize_tags(note.get("tags", ()))
+            tags = normalize_tags(note["tags"])
+            config = deck.configs_by_name[note_type]
 
-            note_type = note.get("note_type")
-            config = (
-                config_by_name.get(note_type) if isinstance(note_type, str) else None
-            )
-
-            if config is None:
-                try:
-                    note_type = fs._infer_note_type(fields)
-                except ValueError as error:
-                    logger.warning(
-                        f"Cannot infer note type in deck '{deck_name}': {error}, "
-                        "skipping note"
-                    )
-                    skipped_notes += 1
-                    continue
-                config = config_by_name.get(note_type)
-
-            if config is None:
-                logger.warning(
-                    f"Unknown note type '{note_type}' in deck '{deck_name}', "
-                    "skipping note"
-                )
-                skipped_notes += 1
-                continue
-
-            if note_key:
-                lines.append(format_note_key_comment(note_key))
+            lines.append(format_note_key_comment(note_key))
             lines.append(format_note_type_comment(note_type))
             tag_comment = format_tags_comment(tags)
             if tag_comment:
@@ -246,6 +327,7 @@ def deserialize(
 
         content = "\n".join(lines)
         if overwrite or not output_path.exists():
+            output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_text(content, encoding="utf-8")
             created_message = (
                 f"  Created {clickable_path(output_path)} ({written_notes} notes)"
@@ -265,31 +347,199 @@ def deserialize(
         total_notes += written_notes
 
     summary_message = (
-        f"Deserialized {total_decks} deck(s), {total_notes} note(s) to {collection_dir}"
+        "Deserialized "
+        f"{total_decks} deck(s), {total_notes} note(s), "
+        f"{len({deck.source_name for deck in decks})} source(s) to {collection_dir}"
     )
     if quiet:
         logger.debug(summary_message)
     else:
         logger.info(summary_message)
-    if skipped_notes:
-        logger.warning(
-            f"Skipped {skipped_notes} note(s) due to missing/invalid note type metadata"
-        )
 
-    db_path = collection_dir / ANKIOPS_DB
-    if not db_path.exists():
-        init_message = (
-            "Run 'ankiops init' to set up this collection with your Anki profile."
-        )
-        if quiet:
-            logger.debug(init_message)
-        else:
-            logger.info(init_message)
+
+def _validate_serialized_data(
+    data: dict[str, Any],
+    *,
+    collection_dir: Path,
+    note_types_dir: Path,
+) -> list[_ValidatedDeck]:
+    errors: list[str] = []
+    if not isinstance(data, dict):
+        raise ValueError("Serialized data must be a JSON object mapping")
+
+    raw_decks = data.get("decks")
+    if not isinstance(raw_decks, list):
+        raise ValueError("Serialized data must contain a top-level 'decks' list")
+
+    sources = discover_sync_sources(collection_dir, note_types_dir=note_types_dir)
+    source_by_name = {_source_name(source): source for source in sources}
+    configs_by_source: dict[str, dict[str, NoteTypeConfig]] = {}
+    referenced_sources = {
+        deck.get("source")
+        for deck in raw_decks
+        if isinstance(deck, dict) and isinstance(deck.get("source"), str)
+    }
+    for source_name in sorted(referenced_sources):
+        source = source_by_name.get(source_name)
+        if source is None:
+            continue
+        try:
+            configs = load_configs_for_source(source)
+        except Exception as error:
+            errors.append(
+                f"Source '{source_name}' note_types/ cannot be loaded: {error}"
+            )
+            continue
+        configs_by_source[source_name] = {config.name: config for config in configs}
+
+    seen_decks: dict[str, int] = {}
+    seen_note_keys: dict[str, tuple[str, int, int]] = {}
+    validated: list[_ValidatedDeck] = []
+
+    for deck_index, raw_deck in enumerate(raw_decks, start=1):
+        if not isinstance(raw_deck, dict):
+            errors.append(f"Deck {deck_index} must be an object.")
+            continue
+
+        source_name = raw_deck.get("source")
+        deck_name = raw_deck.get("name")
+        raw_notes = raw_deck.get("notes")
+        if not isinstance(source_name, str) or not source_name.strip():
+            errors.append(f"Deck {deck_index} is missing required source.")
+            source_name = ""
+        if not isinstance(deck_name, str) or not deck_name.strip():
+            errors.append(f"Deck {deck_index} is missing required name.")
+            deck_name = ""
+        if not isinstance(raw_notes, list):
+            errors.append(f"Deck {deck_index} is missing required notes list.")
+            raw_notes = []
+
+        source = source_by_name.get(source_name)
+        if source_name and source is None:
+            errors.append(
+                f"Deck '{deck_name or deck_index}' references unknown source "
+                f"'{source_name}'."
+            )
+        configs = configs_by_source.get(source_name, {})
+
+        if deck_name:
+            previous_index = seen_decks.get(deck_name)
+            if previous_index is not None:
+                errors.append(
+                    f"Duplicate deck name '{deck_name}' in deck {previous_index} "
+                    f"and deck {deck_index}."
+                )
+            else:
+                seen_decks[deck_name] = deck_index
+
+        notes: list[dict[str, Any]] = []
+        for note_index, raw_note in enumerate(raw_notes, start=1):
+            context = f"Deck '{deck_name or deck_index}' note {note_index}"
+            if not isinstance(raw_note, dict):
+                errors.append(f"{context} must be an object.")
+                continue
+
+            note_key = raw_note.get("note_key")
+            note_type = raw_note.get("note_type")
+            fields = raw_note.get("fields")
+            tags = raw_note.get("tags")
+
+            if not isinstance(note_key, str) or not note_key.strip():
+                errors.append(f"{context} is missing required note_key.")
+            else:
+                previous = seen_note_keys.get(note_key)
+                if previous is not None:
+                    previous_deck, previous_deck_index, previous_note_index = previous
+                    errors.append(
+                        "Duplicate note_key "
+                        f"'{note_key}' in deck {previous_deck_index} "
+                        f"('{previous_deck}') note {previous_note_index} and "
+                        f"deck {deck_index} ('{deck_name}') note {note_index}."
+                    )
+                else:
+                    seen_note_keys[note_key] = (deck_name, deck_index, note_index)
+
+            if not isinstance(note_type, str) or not note_type.strip():
+                errors.append(f"{context} is missing required note_type.")
+            elif source is not None and note_type not in configs:
+                errors.append(
+                    f"{context} references unknown note_type '{note_type}' "
+                    f"for source '{source_name}'."
+                )
+
+            if not isinstance(fields, dict):
+                errors.append(f"{context} fields must be an object.")
+                fields = {}
+            else:
+                for field_name, field_value in fields.items():
+                    if not isinstance(field_name, str) or not field_name.strip():
+                        errors.append(
+                            f"{context} field names must be non-empty strings."
+                        )
+                    if not isinstance(field_value, str):
+                        errors.append(
+                            f"{context} field '{field_name}' must be a string."
+                        )
+
+            if not isinstance(tags, list):
+                errors.append(f"{context} tags must be a list of strings.")
+                tags = []
+            else:
+                for tag in tags:
+                    if not isinstance(tag, str):
+                        errors.append(f"{context} tags must contain only strings.")
+
+            if (
+                isinstance(note_key, str)
+                and note_key.strip()
+                and isinstance(note_type, str)
+                and note_type.strip()
+                and isinstance(fields, dict)
+                and all(
+                    isinstance(field_name, str)
+                    and field_name.strip()
+                    and isinstance(field_value, str)
+                    for field_name, field_value in fields.items()
+                )
+                and isinstance(tags, list)
+                and all(isinstance(tag, str) for tag in tags)
+            ):
+                notes.append(
+                    {
+                        "note_key": note_key,
+                        "note_type": note_type,
+                        "fields": dict(fields),
+                        "tags": list(tags),
+                    }
+                )
+
+        if (
+            source is not None
+            and source_name
+            and deck_name
+            and isinstance(raw_notes, list)
+        ):
+            validated.append(
+                _ValidatedDeck(
+                    source=source,
+                    source_name=source_name,
+                    name=deck_name,
+                    notes=notes,
+                    configs_by_name=configs,
+                )
+            )
+
+    if errors:
+        raise ValueError("Cannot deserialize collection:\n- " + "\n- ".join(errors))
+    return validated
 
 
 def deserialize_from_file(
     json_file: Path,
     overwrite: bool = False,
+    *,
+    collection_dir: Path | None = None,
+    note_types_dir: Path | None = None,
 ) -> None:
     """Deserialize markdown decks from a JSON file.
 
@@ -304,10 +554,11 @@ def deserialize_from_file(
         data = json.load(input_handle)
 
     logger.debug(f"Importing serialized data from: {json_file}")
-    collection_dir = get_collection_dir()
+    collection_dir = collection_dir or get_collection_dir()
+    resolved_note_types_dir = note_types_dir or (collection_dir / NOTE_TYPES_DIR)
     deserialize(
         data,
         collection_dir=collection_dir,
-        note_types_dir=collection_dir / NOTE_TYPES_DIR,
+        note_types_dir=resolved_note_types_dir,
         overwrite=overwrite,
     )

--- a/ankiops/sources.py
+++ b/ankiops/sources.py
@@ -1,0 +1,135 @@
+"""Sync source discovery for local and GitHub-collab decks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+from ankiops.config import NOTE_TYPES_DIR
+from ankiops.fs import FileSystemAdapter
+from ankiops.models import NoteTypeConfig
+
+COLLAB_DIR = "collab"
+COLLAB_BRANCH = "main"
+RESERVED_COLLAB_MARKDOWN = {
+    "README.md",
+    "README.markdown",
+    "LICENSE.md",
+    "CHANGELOG.md",
+}
+
+
+@dataclass(frozen=True)
+class SyncSource:
+    """A filesystem root that contributes decks to one logical collection."""
+
+    root: Path
+    source_id: str
+    note_types_dir: Path
+    is_collab: bool = False
+
+    @classmethod
+    def local(cls, collection_dir: Path, note_types_dir: Path | None = None):
+        return cls(
+            root=collection_dir,
+            source_id="",
+            note_types_dir=note_types_dir or collection_dir / NOTE_TYPES_DIR,
+            is_collab=False,
+        )
+
+    @classmethod
+    def collab(cls, collection_dir: Path, owner: str, repo: str):
+        root = collection_dir / COLLAB_DIR / owner / repo
+        return cls(
+            root=root,
+            source_id=f"{COLLAB_DIR}/{owner}/{repo}",
+            note_types_dir=root / NOTE_TYPES_DIR,
+            is_collab=True,
+        )
+
+    @property
+    def display_name(self) -> str:
+        return self.source_id or "local"
+
+    @property
+    def github_slug(self) -> str | None:
+        if not self.is_collab:
+            return None
+        parts = self.source_id.split("/")
+        if len(parts) != 3:
+            return None
+        return f"{parts[1]}/{parts[2]}"
+
+    @property
+    def github_url(self) -> str | None:
+        slug = self.github_slug
+        return f"https://github.com/{slug}.git" if slug else None
+
+    def scope_note_type_name(self, name: str) -> str:
+        if not self.is_collab:
+            return name
+        prefix = f"{self.source_id}/"
+        return name if name.startswith(prefix) else f"{prefix}{name}"
+
+    def unscoped_note_type_name(self, name: str) -> str:
+        if not self.is_collab:
+            return name
+        prefix = f"{self.source_id}/"
+        return name[len(prefix) :] if name.startswith(prefix) else name
+
+
+@dataclass(frozen=True)
+class SourceConfigs:
+    source: SyncSource
+    configs: list[NoteTypeConfig]
+
+
+def is_reserved_collab_markdown(path: Path) -> bool:
+    name = path.name
+    return name in RESERVED_COLLAB_MARKDOWN or name.startswith("_")
+
+
+def markdown_files_for_source(source: SyncSource) -> list[Path]:
+    files = sorted(source.root.glob("*.md"))
+    if not source.is_collab:
+        return files
+    return [path for path in files if not is_reserved_collab_markdown(path)]
+
+
+def discover_sync_sources(
+    collection_dir: Path,
+    *,
+    note_types_dir: Path | None = None,
+) -> list[SyncSource]:
+    sources = [SyncSource.local(collection_dir, note_types_dir)]
+    collab_root = collection_dir / COLLAB_DIR
+    if not collab_root.exists():
+        return sources
+
+    for owner_dir in sorted(collab_root.iterdir(), key=lambda path: path.name):
+        if not owner_dir.is_dir():
+            continue
+        for repo_dir in sorted(owner_dir.iterdir(), key=lambda path: path.name):
+            if not repo_dir.is_dir():
+                continue
+            sources.append(
+                SyncSource.collab(collection_dir, owner_dir.name, repo_dir.name)
+            )
+    return sources
+
+
+def load_configs_for_source(source: SyncSource) -> list[NoteTypeConfig]:
+    configs = FileSystemAdapter().load_note_type_configs(source.note_types_dir)
+    if not source.is_collab:
+        return configs
+    return [
+        replace(config, name=source.scope_note_type_name(config.name))
+        for config in configs
+    ]
+
+
+def load_configs_for_sources(sources: list[SyncSource]) -> list[SourceConfigs]:
+    return [
+        SourceConfigs(source=source, configs=load_configs_for_source(source))
+        for source in sources
+    ]

--- a/ankiops/sync_media.py
+++ b/ankiops/sync_media.py
@@ -13,6 +13,11 @@ from ankiops.db import SQLiteDbAdapter
 from ankiops.fs import FileSystemAdapter
 from ankiops.log import clickable_path
 from ankiops.models import Change, ChangeType, SyncResult
+from ankiops.sources import (
+    SyncSource,
+    discover_sync_sources,
+    markdown_files_for_source,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -35,8 +40,7 @@ def _extract_media_references(text: str) -> set[str]:
     media_files = set()
     for pattern in [MARKDOWN_IMAGE_PATTERN, ANKI_SOUND_PATTERN, HTML_IMG_PATTERN]:
         for match in re.finditer(pattern, text):
-            # For Markdown pattern, path is in group 1 OR group 2. For others, it's group 1.
-            # Using len(match.groups()) > 1 to safely check if it's the Markdown pattern.
+            # Markdown paths are in group 1 or 2. The other patterns use group 1.
             if len(match.groups()) > 1 and match.re.pattern == MARKDOWN_IMAGE_PATTERN:
                 raw_path = match.group(1) or match.group(2)
             else:
@@ -64,20 +68,29 @@ def _get_hashed_name(file_path: Path, digest: str) -> str:
     return f"{stem}_{digest}{suffix}"
 
 
-def _markdown_cache_key(collection_dir: Path, md_file: Path) -> str:
-    return str(md_file.relative_to(collection_dir))
+def _markdown_cache_key(cache_root: Path, md_file: Path) -> str:
+    return str(md_file.relative_to(cache_root))
 
 
 def _collect_referenced_media(
     fs_port: FileSystemAdapter,
     db_port: SQLiteDbAdapter,
     collection_dir: Path,
+    *,
+    cache_root: Path | None = None,
+    md_files: list[Path] | None = None,
+    prune_cache: bool = True,
 ) -> set[str]:
-    md_files = fs_port.find_markdown_files(collection_dir)
-    md_keys = [_markdown_cache_key(collection_dir, md_file) for md_file in md_files]
-    pruned = db_port.prune_markdown_media_cache(md_keys)
-    if pruned:
-        logger.debug(f"Pruned media cache for {pruned} stale markdown path(s)")
+    resolved_cache_root = cache_root or collection_dir
+    md_files = md_files or fs_port.find_markdown_files(collection_dir)
+    md_keys = [
+        _markdown_cache_key(resolved_cache_root, md_file)
+        for md_file in md_files
+    ]
+    if prune_cache:
+        pruned = db_port.prune_markdown_media_cache(md_keys)
+        if pruned:
+            logger.debug(f"Pruned media cache for {pruned} stale markdown path(s)")
     cached = db_port.resolve_markdown_media_cache(md_keys)
 
     referenced: set[str] = set()
@@ -117,6 +130,10 @@ def hash_and_update_references(
     db_port: SQLiteDbAdapter,
     collection_dir: Path,
     result: SyncResult,
+    *,
+    cache_root: Path | None = None,
+    md_files: list[Path] | None = None,
+    prune_cache: bool = True,
 ) -> tuple[set[str], dict[str, str]]:
     """Hash files, rename them locally, and update markdown."""
     media_root = collection_dir / LOCAL_MEDIA_DIR
@@ -124,7 +141,14 @@ def hash_and_update_references(
         return set(), {}
 
     # 1. Find directly referenced files first
-    referenced = _collect_referenced_media(fs_port, db_port, collection_dir)
+    referenced = _collect_referenced_media(
+        fs_port,
+        db_port,
+        collection_dir,
+        cache_root=cache_root,
+        md_files=md_files,
+        prune_cache=prune_cache,
+    )
 
     rename_map: dict[str, str] = {}
     digest_by_name: dict[str, str] = {}
@@ -224,7 +248,14 @@ def hash_and_update_references(
         count = fs_port.update_media_references(collection_dir, rename_map)
         logger.debug(f"Updated {count} markdown files with {len(rename_map)} renames")
         # 4. Re-collect now-correctly-hashed active references
-        final_referenced = _collect_referenced_media(fs_port, db_port, collection_dir)
+        final_referenced = _collect_referenced_media(
+            fs_port,
+            db_port,
+            collection_dir,
+            cache_root=cache_root,
+            md_files=md_files,
+            prune_cache=False,
+        )
         return final_referenced, digest_by_name
 
     return referenced, digest_by_name
@@ -235,6 +266,10 @@ def sync_media_to_anki(
     fs_port: FileSystemAdapter,
     collection_dir: Path,
     db_port: SQLiteDbAdapter,
+    *,
+    cache_root: Path | None = None,
+    md_files: list[Path] | None = None,
+    prune_cache: bool = True,
 ) -> SyncResult:
     """Push local media to Anki."""
     result = SyncResult.for_media()
@@ -248,7 +283,13 @@ def sync_media_to_anki(
         )
 
     active_refs, digest_by_name = hash_and_update_references(
-        fs_port, db_port, collection_dir, result
+        fs_port,
+        db_port,
+        collection_dir,
+        result,
+        cache_root=cache_root,
+        md_files=md_files,
+        prune_cache=prune_cache,
     )
     if not media_root.exists():
         return result
@@ -363,13 +404,24 @@ def sync_media_from_anki(
     fs_port: FileSystemAdapter,
     collection_dir: Path,
     db_port: SQLiteDbAdapter,
+    *,
+    cache_root: Path | None = None,
+    md_files: list[Path] | None = None,
+    prune_cache: bool = True,
 ) -> SyncResult:
     """Pull missing media from Anki."""
     result = SyncResult.for_media()
     media_root = collection_dir / LOCAL_MEDIA_DIR
     media_root.mkdir(parents=True, exist_ok=True)
 
-    referenced = _collect_referenced_media(fs_port, db_port, collection_dir)
+    referenced = _collect_referenced_media(
+        fs_port,
+        db_port,
+        collection_dir,
+        cache_root=cache_root,
+        md_files=md_files,
+        prune_cache=prune_cache,
+    )
     result.checked = len(referenced)
 
     for name in referenced:
@@ -391,6 +443,77 @@ def sync_media_from_anki(
             result.add_change(Change(ChangeType.SKIP, name, name))
 
     return result
+
+
+def _combine_media_result(target: SyncResult, source: SyncResult) -> None:
+    target.changes.extend(source.changes)
+    target.errors.extend(source.errors)
+    target.checked += source.checked
+    target.unchanged += source.unchanged
+    target.missing += source.missing
+
+
+def _prune_media_cache_for_sources(
+    db_port: SQLiteDbAdapter,
+    collection_dir: Path,
+    sources: list[SyncSource],
+) -> None:
+    md_keys = [
+        _markdown_cache_key(collection_dir, md_file)
+        for source in sources
+        for md_file in markdown_files_for_source(source)
+    ]
+    pruned = db_port.prune_markdown_media_cache(md_keys)
+    if pruned:
+        logger.debug(f"Pruned media cache for {pruned} stale markdown path(s)")
+
+
+def sync_all_media_to_anki(
+    anki_port: AnkiAdapter,
+    fs_port: FileSystemAdapter,
+    collection_dir: Path,
+    db_port: SQLiteDbAdapter,
+) -> SyncResult:
+    """Push media from all active sync sources to Anki."""
+    sources = discover_sync_sources(collection_dir)
+    _prune_media_cache_for_sources(db_port, collection_dir, sources)
+    combined = SyncResult.for_media()
+    for source in sources:
+        source_result = sync_media_to_anki(
+            anki_port,
+            fs_port,
+            source.root,
+            db_port,
+            cache_root=collection_dir,
+            md_files=markdown_files_for_source(source),
+            prune_cache=False,
+        )
+        _combine_media_result(combined, source_result)
+    return combined
+
+
+def sync_all_media_from_anki(
+    anki_port: AnkiAdapter,
+    fs_port: FileSystemAdapter,
+    collection_dir: Path,
+    db_port: SQLiteDbAdapter,
+) -> SyncResult:
+    """Pull referenced media for all active sync sources from Anki."""
+    sources = discover_sync_sources(collection_dir)
+    _prune_media_cache_for_sources(db_port, collection_dir, sources)
+    combined = SyncResult.for_media()
+    for source in sources:
+        source_result = sync_media_from_anki(
+            anki_port,
+            fs_port,
+            source.root,
+            db_port,
+            cache_root=collection_dir,
+            md_files=markdown_files_for_source(source),
+            prune_cache=False,
+        )
+        _combine_media_result(combined, source_result)
+    return combined
 
 
 def format_media_status(media_result: SyncResult, *, from_anki: bool) -> str:

--- a/ankiops/sync_note_types.py
+++ b/ankiops/sync_note_types.py
@@ -59,8 +59,18 @@ def sync_note_types(
     Returns a human-readable summary string, or None if nothing happened.
     """
     configs = fs_port.load_note_type_configs(note_types_dir)
+    return sync_note_type_configs(anki_port, configs, db_port=db_port)
+
+
+def sync_note_type_configs(
+    anki_port: AnkiAdapter,
+    configs,
+    *,
+    db_port: SQLiteDbAdapter | None = None,
+) -> str | None:
+    """Ensure the provided note type configs exist in Anki."""
     if not configs:
-        logger.debug(f"No note types found in {note_types_dir}")
+        logger.debug("No note types provided")
         return None
 
     existing = set(anki_port.fetch_model_names())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ankiops"
-version = "0.5.10"
+version = "0.6.0"
 description = "Anki ↔ Markdown, with bidirectional sync, custom note types, and LLM integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,6 +61,10 @@ def run_ankiops(mock_anki):
     with (
         patch("ankiops.anki_client.invoke", side_effect=mock_anki.invoke),
         patch("ankiops.anki.invoke", side_effect=mock_anki.invoke),
+        patch(
+            "ankiops.anki.change_notes_notetype",
+            side_effect=mock_anki.change_notes_notetype,
+        ),
     ):
         yield
 

--- a/tests/integration/cli/test_cli_sync.py
+++ b/tests/integration/cli/test_cli_sync.py
@@ -115,10 +115,9 @@ def test_run_ma_logs_import_errors_with_actionable_details(tmp_path, caplog):
     )
     sync_result.errors.append(
         "Note type mismatch for note_key: nk-1: markdown uses 'AnkiOpsQA' "
-        "but Anki has 'AnkiOpsCloze'. Anki cannot convert existing notes "
-        "between note types. Remove this note's key comment "
-        "(<!-- note_key: nk-1 -->) to force creating a new note with the "
-        "new type on the next import."
+        "but Anki has 'AnkiOpsCloze'. AnkiOps will not create a duplicate "
+        "note to resolve this. Fix the Markdown note_type metadata or "
+        "intentionally convert the existing Anki note type, then re-run import."
     )
     summary = CollectionResult.for_import(results=[sync_result], untracked_decks=[])
 
@@ -126,7 +125,7 @@ def test_run_ma_logs_import_errors_with_actionable_details(tmp_path, caplog):
 
     assert "Import errors:" in caplog.text
     assert "Rhetorik" in caplog.text
-    assert "Remove this note's key comment" in caplog.text
+    assert "will not create a duplicate note" in caplog.text
     assert "Review and resolve errors above" in caplog.text
 
 
@@ -267,6 +266,26 @@ def test_cli_help_lists_version_flag(capsys):
     assert exc.value.code == 0
     captured = capsys.readouterr()
     assert "--version" in captured.out
+
+
+def test_cli_collab_publish_accepts_public_visibility_flag():
+    captured = []
+
+    with (
+        patch(
+            "ankiops.cli.run_collab_impl",
+            side_effect=lambda args: captured.append(args),
+        ),
+        patch(
+            "sys.argv",
+            ["ankiops", "collab", "publish", "Deck", "owner/repo", "--public"],
+        ),
+    ):
+        main()
+
+    assert captured[0].deck == "Deck"
+    assert captured[0].repo == "owner/repo"
+    assert captured[0].public is True
 
 
 def test_cli_init_exits_cleanly_on_anki_connect_error(caplog):

--- a/tests/integration/cli/test_cli_sync.py
+++ b/tests/integration/cli/test_cli_sync.py
@@ -8,7 +8,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from ankiops.anki_client import AnkiConnectError
-from ankiops.cli import main, run_am, run_fix_image_widths, run_ma, run_serialize
+from ankiops.cli import (
+    main,
+    run_am,
+    run_deserialize,
+    run_fix_image_widths,
+    run_ma,
+    run_serialize,
+)
 from ankiops.config import ANKIOPS_DB, deck_name_to_file_stem
 from ankiops.image_widths import ImageWidthFixResult
 from ankiops.models import (
@@ -384,6 +391,54 @@ def test_run_serialize_rejects_no_subdecks_without_deck(tmp_path):
     assert exc.value.code == 2
 
 
+def test_run_deserialize_snapshots_by_default(tmp_path):
+    json_file = tmp_path / "in.json"
+    json_file.write_text('{"decks": []}', encoding="utf-8")
+    args = SimpleNamespace(
+        input=str(json_file),
+        overwrite=True,
+        no_auto_commit=False,
+    )
+
+    with (
+        patch("ankiops.cli.require_collection_dir", return_value=tmp_path),
+        patch("ankiops.cli.git_snapshot") as snapshot_mock,
+        patch("ankiops.cli.deserialize_from_file") as deserialize_mock,
+    ):
+        run_deserialize(args)
+
+    snapshot_mock.assert_called_once_with(tmp_path, "deserialize")
+    deserialize_mock.assert_called_once_with(
+        json_file,
+        overwrite=True,
+        collection_dir=tmp_path,
+    )
+
+
+def test_run_deserialize_can_skip_snapshot(tmp_path):
+    json_file = tmp_path / "in.json"
+    json_file.write_text('{"decks": []}', encoding="utf-8")
+    args = SimpleNamespace(
+        input=str(json_file),
+        overwrite=False,
+        no_auto_commit=True,
+    )
+
+    with (
+        patch("ankiops.cli.require_collection_dir", return_value=tmp_path),
+        patch("ankiops.cli.git_snapshot") as snapshot_mock,
+        patch("ankiops.cli.deserialize_from_file") as deserialize_mock,
+    ):
+        run_deserialize(args)
+
+    snapshot_mock.assert_not_called()
+    deserialize_mock.assert_called_once_with(
+        json_file,
+        overwrite=False,
+        collection_dir=tmp_path,
+    )
+
+
 def test_run_fix_image_widths_passes_deck_scope_and_snapshots(tmp_path):
     args = SimpleNamespace(
         deck="Parent",
@@ -442,7 +497,7 @@ def test_run_fix_image_widths_can_skip_snapshot_and_logs_sync_reminder(
         run_fix_image_widths(args)
 
     snapshot_mock.assert_not_called()
-    assert "Only local Markdown files were edited" in caplog.text
+    assert "Only Markdown files were edited" in caplog.text
     assert "ankiops ma" in caplog.text
 
 

--- a/tests/integration/cli/test_cli_sync.py
+++ b/tests/integration/cli/test_cli_sync.py
@@ -114,10 +114,8 @@ def test_run_ma_logs_import_errors_with_actionable_details(tmp_path, caplog):
         file_path=tmp_path / "Rhetorik.md",
     )
     sync_result.errors.append(
-        "Note type mismatch for note_key: nk-1: markdown uses 'AnkiOpsQA' "
-        "but Anki has 'AnkiOpsCloze'. AnkiOps will not create a duplicate "
-        "note to resolve this. Fix the Markdown note_type metadata or "
-        "intentionally convert the existing Anki note type, then re-run import."
+        "Failed note type conversion: Cannot convert AnkiOpsCloze to "
+        "AnkiOpsQA: field names differ"
     )
     summary = CollectionResult.for_import(results=[sync_result], untracked_decks=[])
 
@@ -125,7 +123,7 @@ def test_run_ma_logs_import_errors_with_actionable_details(tmp_path, caplog):
 
     assert "Import errors:" in caplog.text
     assert "Rhetorik" in caplog.text
-    assert "will not create a duplicate note" in caplog.text
+    assert "field names differ" in caplog.text
     assert "Review and resolve errors above" in caplog.text
 
 

--- a/tests/integration/media/test_media_sync.py
+++ b/tests/integration/media/test_media_sync.py
@@ -10,7 +10,11 @@ from blake3 import blake3
 
 from ankiops.config import LOCAL_MEDIA_DIR
 from ankiops.db import SQLiteDbAdapter
-from ankiops.sync_media import _extract_media_references, sync_media_to_anki
+from ankiops.sync_media import (
+    _extract_media_references,
+    sync_all_media_to_anki,
+    sync_media_to_anki,
+)
 
 
 class _FakeMediaAnki:
@@ -146,6 +150,49 @@ class TestMediaDirectory:
 
 
 class TestMediaSyncIncremental:
+    def test_sync_all_media_to_anki_resolves_media_relative_to_each_source(
+        self, fs, tmp_path
+    ):
+        root_media = tmp_path / LOCAL_MEDIA_DIR
+        root_media.mkdir()
+        (root_media / "image.png").write_bytes(b"root image")
+        (tmp_path / "RootDeck.md").write_text(
+            "Q: Root\nA: ![img](media/image.png)", encoding="utf-8"
+        )
+
+        collab_root = tmp_path / "collab" / "owner" / "repo"
+        collab_media = collab_root / LOCAL_MEDIA_DIR
+        collab_media.mkdir(parents=True)
+        (collab_media / "image.png").write_bytes(b"collab image")
+        (collab_root / "CollabDeck.md").write_text(
+            "Q: Collab\nA: ![img](media/image.png)", encoding="utf-8"
+        )
+
+        anki_media_dir = tmp_path / "anki_media"
+        anki_media_dir.mkdir()
+        anki = _FakeMediaAnki(anki_media_dir)
+
+        db = SQLiteDbAdapter.open(tmp_path)
+        try:
+            result = sync_all_media_to_anki(anki, fs, tmp_path, db)
+        finally:
+            db.close()
+
+        root_names = sorted(path.name for path in root_media.glob("image_*.png"))
+        collab_names = sorted(path.name for path in collab_media.glob("image_*.png"))
+        assert len(root_names) == 1
+        assert len(collab_names) == 1
+        assert root_names != collab_names
+        assert result.summary.synced == 2
+        assert (anki_media_dir / root_names[0]).exists()
+        assert (anki_media_dir / collab_names[0]).exists()
+        assert f"media/{root_names[0]}" in (tmp_path / "RootDeck.md").read_text(
+            encoding="utf-8"
+        )
+        assert f"media/{collab_names[0]}" in (
+            collab_root / "CollabDeck.md"
+        ).read_text(encoding="utf-8")
+
     def test_sync_media_to_anki_warm_run_skips_unchanged_pushes(self, fs, tmp_path):
         media_dir = tmp_path / LOCAL_MEDIA_DIR
         media_dir.mkdir()

--- a/tests/integration/serialization/test_collection_serializer.py
+++ b/tests/integration/serialization/test_collection_serializer.py
@@ -23,19 +23,46 @@ def _set_collection_paths(monkeypatch, collection_dir):
     )
 
 
-@pytest.fixture
-def collection(tmp_path, fs, monkeypatch):
-    """Create a minimal collection with DB, note types, and one deck file."""
-    _set_collection_paths(monkeypatch, tmp_path)
-
-    db = SQLiteDbAdapter.open(tmp_path)
+def _init_collection(collection_dir, fs):
+    db = SQLiteDbAdapter.open(collection_dir)
     try:
         db.set_profile_name("test")
     finally:
         db.close()
 
-    note_types_dir = tmp_path / "note_types"
+    note_types_dir = collection_dir / "note_types"
     fs.eject_builtin_note_types(note_types_dir)
+    return note_types_dir
+
+
+def _serialized_deck(
+    *,
+    source="local",
+    name="TestDeck",
+    note_key="nk-1",
+    note_type="AnkiOpsQA",
+    fields=None,
+    tags=None,
+):
+    return {
+        "source": source,
+        "name": name,
+        "notes": [
+            {
+                "note_key": note_key,
+                "note_type": note_type,
+                "fields": fields or {"Question": "Q", "Answer": "A"},
+                "tags": [] if tags is None else tags,
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def collection(tmp_path, fs, monkeypatch):
+    """Create a minimal collection with DB, note types, and one deck file."""
+    _set_collection_paths(monkeypatch, tmp_path)
+    _init_collection(tmp_path, fs)
 
     (tmp_path / f"{deck_name_to_file_stem('TestDeck')}.md").write_text(
         (
@@ -58,6 +85,7 @@ def test_basic_serialize(collection, tmp_path, monkeypatch):
     result = serialize_to_file(collection, output)
 
     assert len(result["decks"]) == 1
+    assert result["decks"][0]["source"] == "local"
     assert len(result["decks"][0]["notes"]) == 2
     assert result["decks"][0]["notes"][0]["note_key"] == "nk-1"
 
@@ -67,6 +95,7 @@ def test_in_memory_serialize(collection, monkeypatch):
     result = serialize(collection)
 
     assert len(result["decks"]) == 1
+    assert result["decks"][0]["source"] == "local"
     assert len(result["decks"][0]["notes"]) == 2
     assert result["decks"][0]["notes"][1]["note_key"] == "nk-2"
 
@@ -86,6 +115,101 @@ def test_serialize_includes_tags(collection, monkeypatch):
     result = serialize(collection)
 
     assert result["decks"][0]["notes"][0]["tags"] == ["high-yield", "z"]
+
+
+def test_serialize_includes_collab_sources_and_ignores_reserved_docs(
+    collection, fs, monkeypatch
+):
+    _set_collection_paths(monkeypatch, collection)
+    collab_root = collection / "collab" / "owner" / "repo"
+    fs.eject_builtin_note_types(collab_root / "note_types")
+    (collab_root / "README.md").write_text("# docs", encoding="utf-8")
+    (collab_root / "LICENSE.md").write_text("# license", encoding="utf-8")
+    (collab_root / "CHANGELOG.md").write_text("# changes", encoding="utf-8")
+    (collab_root / "_draft.md").write_text(
+        "<!-- note_key: draft -->\nQ: draft\nA: draft",
+        encoding="utf-8",
+    )
+    (collab_root / "Shared.md").write_text(
+        "<!-- note_key: collab-1 -->\nQ: collab question\nA: collab answer",
+        encoding="utf-8",
+    )
+
+    result = serialize(collection)
+
+    decks = {(deck["source"], deck["name"]): deck for deck in result["decks"]}
+    assert ("local", "TestDeck") in decks
+    assert ("collab/owner/repo", "Shared") in decks
+    assert ("collab/owner/repo", "README") not in decks
+    collab_note = decks[("collab/owner/repo", "Shared")]["notes"][0]
+    assert collab_note["note_type"] == "collab/owner/repo/AnkiOpsQA"
+
+
+def test_serialize_orders_local_before_sorted_collab_sources(
+    collection, fs, monkeypatch
+):
+    _set_collection_paths(monkeypatch, collection)
+    collab_b = collection / "collab" / "z-owner" / "deck"
+    collab_a = collection / "collab" / "a-owner" / "deck"
+    fs.eject_builtin_note_types(collab_b / "note_types")
+    fs.eject_builtin_note_types(collab_a / "note_types")
+    (collab_b / "B.md").write_text(
+        "<!-- note_key: collab-b -->\nQ: b\nA: b",
+        encoding="utf-8",
+    )
+    (collab_a / "A.md").write_text(
+        "<!-- note_key: collab-a -->\nQ: a\nA: a",
+        encoding="utf-8",
+    )
+
+    result = serialize(collection)
+
+    assert [(deck["source"], deck["name"]) for deck in result["decks"]] == [
+        ("local", "TestDeck"),
+        ("collab/a-owner/deck", "A"),
+        ("collab/z-owner/deck", "B"),
+    ]
+
+
+def test_serialize_global_validation_rejects_duplicate_deck_names(
+    collection, fs, monkeypatch
+):
+    _set_collection_paths(monkeypatch, collection)
+    collab_root = collection / "collab" / "owner" / "repo"
+    fs.eject_builtin_note_types(collab_root / "note_types")
+    (collab_root / "TestDeck.md").write_text(
+        "<!-- note_key: collab-1 -->\nQ: collab question\nA: collab answer",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Duplicate deck name 'TestDeck'"):
+        serialize(collection)
+
+
+def test_serialize_global_validation_rejects_duplicate_note_keys(
+    collection, monkeypatch
+):
+    _set_collection_paths(monkeypatch, collection)
+    (collection / "OtherDeck.md").write_text(
+        "<!-- note_key: nk-1 -->\nQ: duplicate\nA: duplicate",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Duplicate note_key 'nk-1'"):
+        serialize(collection)
+
+
+def test_serialize_global_validation_rejects_missing_note_keys(
+    collection, monkeypatch
+):
+    _set_collection_paths(monkeypatch, collection)
+    (collection / "MissingKey.md").write_text(
+        "Q: missing key\nA: missing key",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Run 'ankiops ma' first"):
+        serialize(collection)
 
 
 def test_serialize_single_deck_includes_subdecks_by_default(collection, monkeypatch):
@@ -144,6 +268,19 @@ def test_serialize_to_file_accepts_deck_scope(collection, tmp_path, monkeypatch)
     assert [deck["name"] for deck in result["decks"]] == ["TestDeck"]
 
 
+def test_serialize_validates_whole_collection_before_deck_scope(
+    collection, monkeypatch
+):
+    _set_collection_paths(monkeypatch, collection)
+    (collection / "OtherDeck.md").write_text(
+        "<!-- note_key: nk-1 -->\nQ: duplicate outside scope\nA: duplicate",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Duplicate note_key 'nk-1'"):
+        serialize(collection, deck="TestDeck", no_subdecks=True)
+
+
 def test_serialize_fails_fast_on_parsing_error_by_default(collection, monkeypatch):
     _set_collection_paths(monkeypatch, collection)
 
@@ -166,12 +303,12 @@ def test_serialize_fails_fast_on_parsing_error_by_default(collection, monkeypatc
 
     with pytest.raises(
         ValueError,
-        match=f"Error parsing {broken_name}: synthetic parse failure",
+        match=f"Error parsing local:{broken_name}: synthetic parse failure",
     ):
         serialize(collection)
 
 
-def test_roundtrip(collection, tmp_path, monkeypatch):
+def test_roundtrip(collection, tmp_path, fs, monkeypatch):
     """Serialize then deserialize should preserve deck note content."""
     _set_collection_paths(monkeypatch, collection)
 
@@ -181,10 +318,7 @@ def test_roundtrip(collection, tmp_path, monkeypatch):
     fresh_dir = tmp_path / "fresh"
     fresh_dir.mkdir()
     _set_collection_paths(monkeypatch, fresh_dir)
-
-    fs = FileSystemAdapter()
-    note_types_dst = fresh_dir / "note_types"
-    fs.eject_builtin_note_types(note_types_dst)
+    _init_collection(fresh_dir, fs)
 
     deserialize_from_file(json_file, overwrite=True)
 
@@ -195,7 +329,7 @@ def test_roundtrip(collection, tmp_path, monkeypatch):
     assert "What is 3+3?" in content
 
 
-def test_roundtrip_in_memory(collection, tmp_path, monkeypatch):
+def test_roundtrip_in_memory(collection, tmp_path, fs, monkeypatch):
     _set_collection_paths(monkeypatch, collection)
 
     serialized_data = serialize(collection)
@@ -203,10 +337,7 @@ def test_roundtrip_in_memory(collection, tmp_path, monkeypatch):
     fresh_dir = tmp_path / "fresh-in-memory"
     fresh_dir.mkdir()
     _set_collection_paths(monkeypatch, fresh_dir)
-
-    fs = FileSystemAdapter()
-    note_types_dst = fresh_dir / "note_types"
-    fs.eject_builtin_note_types(note_types_dst)
+    note_types_dst = _init_collection(fresh_dir, fs)
 
     deserialize(
         serialized_data,
@@ -222,7 +353,7 @@ def test_roundtrip_in_memory(collection, tmp_path, monkeypatch):
     assert "What is 3+3?" in content
 
 
-def test_roundtrip_preserves_tags(collection, tmp_path, monkeypatch):
+def test_roundtrip_preserves_tags(collection, tmp_path, fs, monkeypatch):
     _set_collection_paths(monkeypatch, collection)
     deck_file = collection / f"{deck_name_to_file_stem('TestDeck')}.md"
     deck_file.write_text(
@@ -239,10 +370,7 @@ def test_roundtrip_preserves_tags(collection, tmp_path, monkeypatch):
     fresh_dir = tmp_path / "fresh-tags"
     fresh_dir.mkdir()
     _set_collection_paths(monkeypatch, fresh_dir)
-
-    fs = FileSystemAdapter()
-    note_types_dst = fresh_dir / "note_types"
-    fs.eject_builtin_note_types(note_types_dst)
+    note_types_dst = _init_collection(fresh_dir, fs)
 
     deserialize(
         serialized_data,
@@ -257,66 +385,177 @@ def test_roundtrip_preserves_tags(collection, tmp_path, monkeypatch):
     assert "<!-- tags: high-yield z -->" in content
 
 
-def test_deserialize_unknown_note_type_skips_note_without_orphan_key(
-    tmp_path, fs, monkeypatch
-):
-    _set_collection_paths(monkeypatch, tmp_path)
-
+def test_deserialize_requires_initialized_collection(tmp_path, fs):
     note_types_dir = tmp_path / "note_types"
     fs.eject_builtin_note_types(note_types_dir)
 
-    json_file = tmp_path / "in.json"
-    json_file.write_text(
-        """
-{
-  "collection": {"serialized_at": "2025-01-01T00:00:00Z"},
-  "decks": [
-        {
-          "name": "UnknownDeck",
-          "notes": [
+    with pytest.raises(ValueError, match="Not an initialized AnkiOps collection"):
+        deserialize(
+            {"decks": [_serialized_deck()]},
+            collection_dir=tmp_path,
+            note_types_dir=note_types_dir,
+            overwrite=True,
+        )
+
+
+@pytest.mark.parametrize(
+    ("data", "message"),
+    [
+        (
+            {"decks": [{"name": "Deck", "notes": []}]},
+            "missing required source",
+        ),
+        (
+            {"decks": [_serialized_deck(source="collab/missing/repo")]},
+            "unknown source 'collab/missing/repo'",
+        ),
+        (
+            {"decks": [_serialized_deck(note_type="MissingType")]},
+            "unknown note_type 'MissingType'",
+        ),
+        (
+            {"decks": [_serialized_deck(note_key="")]},
+            "missing required note_key",
+        ),
+        (
             {
-              "note_key": "nk-unknown",
-              "note_type": "MissingType",
-              "fields": {"UnknownField": "Only"}
-            }
-          ]
-        }
-      ]
-}
-""".strip(),
-        encoding="utf-8",
-    )
-
-    deserialize_from_file(json_file, overwrite=True)
-
-    content = (tmp_path / f"{deck_name_to_file_stem('UnknownDeck')}.md").read_text(
-        encoding="utf-8"
-    )
-    assert "note_key: nk-unknown" not in content
-    assert content == ""
-
-
-def test_deserialize_unknown_note_type_falls_back_to_inference(
-    tmp_path, fs, monkeypatch
+                "decks": [
+                    _serialized_deck(name="Deck", note_key="nk-1"),
+                    _serialized_deck(name="Deck", note_key="nk-2"),
+                ]
+            },
+            "Duplicate deck name 'Deck'",
+        ),
+        (
+            {
+                "decks": [
+                    _serialized_deck(name="Deck", note_key="nk-1"),
+                    _serialized_deck(name="Other", note_key="nk-1"),
+                ]
+            },
+            "Duplicate note_key 'nk-1'",
+        ),
+        (
+            {
+                "decks": [
+                    _serialized_deck(fields={"Question": 123, "Answer": "A"}),
+                ]
+            },
+            "field 'Question' must be a string",
+        ),
+        (
+            {
+                "decks": [
+                    _serialized_deck(tags=["ok", 123]),
+                ]
+            },
+            "tags must contain only strings",
+        ),
+    ],
+)
+def test_deserialize_rejects_invalid_data_before_writes(
+    tmp_path, fs, data, message
 ):
+    note_types_dir = _init_collection(tmp_path, fs)
+
+    with pytest.raises(ValueError, match=message):
+        deserialize(
+            data,
+            collection_dir=tmp_path,
+            note_types_dir=note_types_dir,
+            overwrite=True,
+        )
+
+    assert not list(tmp_path.glob("*.md"))
+
+
+def test_deserialize_rejects_collab_source_with_missing_note_types(tmp_path, fs):
+    note_types_dir = _init_collection(tmp_path, fs)
+    (tmp_path / "collab" / "owner" / "repo").mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="note_types/ cannot be loaded"):
+        deserialize(
+            {
+                "decks": [
+                    _serialized_deck(
+                        source="collab/owner/repo",
+                        name="Shared",
+                        note_type="collab/owner/repo/AnkiOpsQA",
+                    )
+                ]
+            },
+            collection_dir=tmp_path,
+            note_types_dir=note_types_dir,
+            overwrite=True,
+        )
+
+    assert not (tmp_path / "collab" / "owner" / "repo" / "Shared.md").exists()
+
+
+def test_deserialize_writes_local_and_collab_decks_to_owning_sources(tmp_path, fs):
+    note_types_dir = _init_collection(tmp_path, fs)
+    collab_root = tmp_path / "collab" / "owner" / "repo"
+    fs.eject_builtin_note_types(collab_root / "note_types")
+
+    deserialize(
+        {
+            "decks": [
+                _serialized_deck(name="LocalDeck", note_key="local-1"),
+                _serialized_deck(
+                    source="collab/owner/repo",
+                    name="SharedDeck",
+                    note_key="collab-1",
+                    note_type="collab/owner/repo/AnkiOpsQA",
+                    fields={"Question": "CQ", "Answer": "CA"},
+                ),
+            ]
+        },
+        collection_dir=tmp_path,
+        note_types_dir=note_types_dir,
+        overwrite=True,
+    )
+
+    assert "<!-- note_type: AnkiOpsQA -->" in (
+        tmp_path / "LocalDeck.md"
+    ).read_text(encoding="utf-8")
+    collab_content = (collab_root / "SharedDeck.md").read_text(encoding="utf-8")
+    assert "<!-- note_type: collab/owner/repo/AnkiOpsQA -->" in collab_content
+    assert "Q: CQ" in collab_content
+
+
+def test_deserialize_skips_existing_targets_without_overwrite(tmp_path, fs):
+    note_types_dir = _init_collection(tmp_path, fs)
+    target = tmp_path / "Existing.md"
+    target.write_text("keep me", encoding="utf-8")
+
+    deserialize(
+        {"decks": [_serialized_deck(name="Existing", note_key="nk-existing")]},
+        collection_dir=tmp_path,
+        note_types_dir=note_types_dir,
+        overwrite=False,
+    )
+
+    assert target.read_text(encoding="utf-8") == "keep me"
+
+
+def test_deserialize_from_file_uses_source_schema(tmp_path, fs, monkeypatch):
     _set_collection_paths(monkeypatch, tmp_path)
-
-    note_types_dir = tmp_path / "note_types"
-    fs.eject_builtin_note_types(note_types_dir)
-
+    _init_collection(tmp_path, fs)
     json_file = tmp_path / "in.json"
     json_file.write_text(
         """
 {
-  "collection": {"serialized_at": "2025-01-01T00:00:00Z"},
+  "collection": {"serialized_at": "2026-06-05T00:00:00Z"},
   "decks": [
     {
-      "name": "InferDeck",
+      "source": "local",
+      "name": "FromFile",
       "notes": [
         {
-          "note_key": "nk-infer",
-          "note_type": "MissingType",
-          "fields": {"Question": "Q infer", "Answer": "A infer"}
+          "note_key": "nk-file",
+          "note_type": "AnkiOpsQA",
+          "fields": {"Question": "Q file", "Answer": "A file"},
+          "tags": []
         }
       ]
     }
@@ -328,10 +567,6 @@ def test_deserialize_unknown_note_type_falls_back_to_inference(
 
     deserialize_from_file(json_file, overwrite=True)
 
-    content = (tmp_path / f"{deck_name_to_file_stem('InferDeck')}.md").read_text(
-        encoding="utf-8"
-    )
-    assert "<!-- note_key: nk-infer -->" in content
+    content = (tmp_path / "FromFile.md").read_text(encoding="utf-8")
+    assert "<!-- note_key: nk-file -->" in content
     assert "<!-- note_type: AnkiOpsQA -->" in content
-    assert "Q: Q infer" in content
-    assert "A: A infer" in content

--- a/tests/integration/serialization/test_image_widths_collection.py
+++ b/tests/integration/serialization/test_image_widths_collection.py
@@ -1,3 +1,5 @@
+import pytest
+
 from ankiops.config import deck_name_to_file_stem
 from ankiops.db import SQLiteDbAdapter
 from ankiops.fs import FileSystemAdapter
@@ -83,3 +85,43 @@ def test_fix_image_widths_collection_can_exclude_subdecks(tmp_path):
     assert result.decks_checked == 1
     assert "{width=404}" not in parent.read_text(encoding="utf-8")
     assert "{width=304}" in child.read_text(encoding="utf-8")
+
+
+def test_fix_image_widths_collection_rewrites_collab_deck(tmp_path):
+    note_types_dir = _make_collection(tmp_path)
+    fs = FileSystemAdapter()
+    collab_root = tmp_path / "collab" / "owner" / "repo"
+    fs.eject_builtin_note_types(collab_root / "note_types")
+    collab_file = collab_root / "Shared.md"
+    collab_file.write_text(
+        "<!-- note_key: collab-1 -->\n"
+        "Q: Question\n"
+        "A: ![a](media/a.png){width=400}\n![b](media/b.png){width=404}",
+        encoding="utf-8",
+    )
+
+    result = fix_image_widths_collection(
+        tmp_path,
+        deck="Shared",
+        no_subdecks=True,
+        tolerance=5,
+        note_types_dir=note_types_dir,
+    )
+
+    assert result.decks_checked == 1
+    assert "{width=404}" not in collab_file.read_text(encoding="utf-8")
+
+
+def test_fix_image_widths_collection_fails_on_missing_note_key(tmp_path):
+    note_types_dir = _make_collection(tmp_path)
+    (tmp_path / "Broken.md").write_text(
+        "Q: Question\nA: ![a](a.png){width=400}",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="missing a note_key"):
+        fix_image_widths_collection(
+            tmp_path,
+            tolerance=5,
+            note_types_dir=note_types_dir,
+        )

--- a/tests/integration/sync/test_sync_collab_sources.py
+++ b/tests/integration/sync/test_sync_collab_sources.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import pytest
+
+from ankiops.fs import FileSystemAdapter
+from ankiops.markdown_format import NOTE_SEPARATOR
+
+
+def _setup_collab_root(world):
+    collab_root = world.root / "collab" / "owner" / "repo"
+    FileSystemAdapter().eject_builtin_note_types(collab_root / "note_types")
+    collab_root.mkdir(parents=True, exist_ok=True)
+    return collab_root
+
+
+def _write_collab_qa_deck(
+    collab_root,
+    deck_name: str,
+    question: str,
+    answer: str,
+    note_key: str,
+):
+    path = collab_root / f"{deck_name}.md"
+    path.write_text(
+        "\n".join(
+            [
+                f"<!-- note_key: {note_key} -->",
+                "<!-- note_type: collab/owner/repo/AnkiOpsQA -->",
+                f"Q: {question}",
+                f"A: {answer}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_import_syncs_root_and_collab_sources_as_one_collection(world):
+    collab_root = _setup_collab_root(world)
+
+    root_id = world.add_qa_note(
+        deck_name="RootDeck",
+        question="Root Q",
+        answer="Root A",
+        note_key="root-key-1",
+    )
+    world.mock_anki.add_note(
+        "CollabDeck",
+        "collab/owner/repo/AnkiOpsQA",
+        {
+            "Question": "Collab Q",
+            "Answer": "Collab A",
+            "AnkiOps Key": "collab-key-1",
+        },
+    )
+    collab_id = max(world.mock_anki.notes.keys())
+
+    world.write_qa_deck("RootDeck", [("Root Q", "Root A", "root-key-1")])
+    _write_collab_qa_deck(
+        collab_root,
+        "CollabDeck",
+        "Collab Q",
+        "Collab A",
+        "collab-key-1",
+    )
+
+    with world.db_session() as db:
+        result = world.sync_import(db)
+
+    assert result.summary.deleted == 0
+    assert root_id in world.mock_anki.notes
+    assert collab_id in world.mock_anki.notes
+
+
+def test_import_rejects_duplicate_deck_names_across_sources(world):
+    collab_root = _setup_collab_root(world)
+
+    world.write_qa_deck("Deck", [("Root Q", "Root A", "root-key-1")])
+    (collab_root / "Deck.md").write_text(
+        NOTE_SEPARATOR.join(
+            [
+                "\n".join(
+                    [
+                        "<!-- note_key: collab-key-1 -->",
+                        "<!-- note_type: collab/owner/repo/AnkiOpsQA -->",
+                        "Q: Collab Q",
+                        "A: Collab A",
+                    ]
+                )
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with world.db_session() as db:
+        try:
+            world.sync_import(db)
+        except ValueError as error:
+            assert "deck ownership conflicts" in str(error)
+        else:  # pragma: no cover - assertion clarity
+            raise AssertionError("expected deck ownership conflict")
+
+
+def test_import_rejects_duplicate_ankiops_key_across_root_and_collab_models(world):
+    collab_root = _setup_collab_root(world)
+    note_key = "collab-duplicate-key"
+
+    root_id = world.add_qa_note(
+        deck_name="RootDeck",
+        question="Root Q",
+        answer="Root A",
+        note_key=note_key,
+    )
+    world.mock_anki.add_note(
+        "CollabDeck",
+        "collab/owner/repo/AnkiOpsQA",
+        {
+            "Question": "Collab Q",
+            "Answer": "Collab A",
+            "AnkiOps Key": note_key,
+        },
+    )
+    collab_id = max(world.mock_anki.notes.keys())
+    _write_collab_qa_deck(
+        collab_root,
+        "CollabDeck",
+        "Collab Q",
+        "Collab A",
+        note_key,
+    )
+
+    with world.db_session() as db:
+        db.upsert_note_links([(note_key, collab_id)])
+        with pytest.raises(ValueError, match=f"Duplicate AnkiOps Key '{note_key}'"):
+            world.sync_import(db)
+
+    assert root_id in world.mock_anki.notes
+    assert collab_id in world.mock_anki.notes
+
+
+def test_export_rejects_duplicate_ankiops_key_across_root_and_collab_models(world):
+    collab_root = _setup_collab_root(world)
+    note_key = "collab-export-duplicate-key"
+
+    root_id = world.add_qa_note(
+        deck_name="RootDeck",
+        question="Root Q",
+        answer="Root A",
+        note_key=note_key,
+    )
+    world.mock_anki.add_note(
+        "CollabDeck",
+        "collab/owner/repo/AnkiOpsQA",
+        {
+            "Question": "Collab Q",
+            "Answer": "Collab A",
+            "AnkiOps Key": note_key,
+        },
+    )
+    collab_id = max(world.mock_anki.notes.keys())
+
+    with world.db_session() as db:
+        with pytest.raises(ValueError, match=f"Duplicate AnkiOps Key '{note_key}'"):
+            world.sync_export(db)
+
+    assert not world.deck_path("RootDeck").exists()
+    assert not (collab_root / "CollabDeck.md").exists()
+    assert root_id in world.mock_anki.notes
+    assert collab_id in world.mock_anki.notes
+
+
+def test_import_deletes_root_orphan_without_deleting_collab_note(world):
+    collab_root = _setup_collab_root(world)
+    root_id = world.add_qa_note(
+        deck_name="RootDeck",
+        question="Root Q",
+        answer="Root A",
+        note_key="root-delete-key",
+    )
+    world.mock_anki.add_note(
+        "CollabDeck",
+        "collab/owner/repo/AnkiOpsQA",
+        {
+            "Question": "Collab Q",
+            "Answer": "Collab A",
+            "AnkiOps Key": "collab-keep-key",
+        },
+    )
+    collab_id = max(world.mock_anki.notes.keys())
+
+    world.write_qa_deck("RootDeck", [])
+    _write_collab_qa_deck(
+        collab_root,
+        "CollabDeck",
+        "Collab Q",
+        "Collab A",
+        "collab-keep-key",
+    )
+
+    with world.db_session() as db:
+        db.upsert_note_links(
+            [
+                ("root-delete-key", root_id),
+                ("collab-keep-key", collab_id),
+            ]
+        )
+        result = world.sync_import(db)
+
+    assert result.summary.deleted == 1
+    assert root_id not in world.mock_anki.notes
+    assert collab_id in world.mock_anki.notes
+
+
+def test_import_deletes_collab_orphan_without_deleting_root_note(world):
+    collab_root = _setup_collab_root(world)
+    root_id = world.add_qa_note(
+        deck_name="RootDeck",
+        question="Root Q",
+        answer="Root A",
+        note_key="root-keep-key",
+    )
+    world.mock_anki.add_note(
+        "CollabDeck",
+        "collab/owner/repo/AnkiOpsQA",
+        {
+            "Question": "Collab Q",
+            "Answer": "Collab A",
+            "AnkiOps Key": "collab-delete-key",
+        },
+    )
+    collab_id = max(world.mock_anki.notes.keys())
+
+    world.write_qa_deck("RootDeck", [("Root Q", "Root A", "root-keep-key")])
+    (collab_root / "CollabDeck.md").write_text("", encoding="utf-8")
+
+    with world.db_session() as db:
+        db.upsert_note_links(
+            [
+                ("root-keep-key", root_id),
+                ("collab-delete-key", collab_id),
+            ]
+        )
+        result = world.sync_import(db)
+
+    assert result.summary.deleted == 1
+    assert root_id in world.mock_anki.notes
+    assert collab_id not in world.mock_anki.notes
+
+
+def test_export_writes_anki_edits_back_to_collab_source(world):
+    collab_root = _setup_collab_root(world)
+    _write_collab_qa_deck(
+        collab_root,
+        "CollabDeck",
+        "Collab Q",
+        "Old Collab A",
+        "collab-export-key",
+    )
+    world.mock_anki.add_note(
+        "CollabDeck",
+        "collab/owner/repo/AnkiOpsQA",
+        {
+            "Question": "Collab Q",
+            "Answer": "New Collab A",
+            "AnkiOps Key": "collab-export-key",
+        },
+    )
+    collab_id = max(world.mock_anki.notes.keys())
+
+    with world.db_session() as db:
+        db.upsert_note_links([("collab-export-key", collab_id)])
+        result = world.sync_export(db)
+
+    assert result.summary.updated == 1
+    assert "A: New Collab A" in (collab_root / "CollabDeck.md").read_text(
+        encoding="utf-8"
+    )
+    assert not world.deck_path("CollabDeck").exists()

--- a/tests/integration/sync/test_sync_collab_sources.py
+++ b/tests/integration/sync/test_sync_collab_sources.py
@@ -73,6 +73,110 @@ def test_import_syncs_root_and_collab_sources_as_one_collection(world):
     assert collab_id in world.mock_anki.notes
 
 
+def test_import_converts_root_note_to_scoped_collab_type_without_duplicate(world):
+    collab_root = _setup_collab_root(world)
+    note_key = "published-key-1"
+    world.mock_anki.add_note(
+        "CollabDeck",
+        "AnkiOpsQA",
+        {
+            "Question": "Collab Q",
+            "Answer": "Collab A",
+            "AnkiOps Key": note_key,
+        },
+    )
+    note_id = max(world.mock_anki.notes.keys())
+    _write_collab_qa_deck(
+        collab_root,
+        "CollabDeck",
+        "Collab Q",
+        "Collab A",
+        note_key,
+    )
+
+    with world.db_session() as db:
+        result = world.sync_import(db)
+
+    assert result.summary.converted == 1
+    assert len(world.mock_anki.notes) == 1
+    assert note_id in world.mock_anki.notes
+    assert world.mock_anki.notes[note_id]["modelName"] == (
+        "collab/owner/repo/AnkiOpsQA"
+    )
+    assert (
+        "changeNotesNotetype",
+        {
+            "noteIds": [note_id],
+            "oldModel": "AnkiOpsQA",
+            "newModel": "collab/owner/repo/AnkiOpsQA",
+        },
+    ) in world.mock_anki.calls
+
+
+def test_import_bridge_failure_blocks_conversion_without_duplicate(world, monkeypatch):
+    collab_root = _setup_collab_root(world)
+    note_key = "published-key-bridge-down"
+    world.mock_anki.add_note(
+        "CollabDeck",
+        "AnkiOpsQA",
+        {
+            "Question": "Collab Q",
+            "Answer": "Collab A",
+            "AnkiOps Key": note_key,
+        },
+    )
+    note_id = max(world.mock_anki.notes.keys())
+    _write_collab_qa_deck(
+        collab_root,
+        "CollabDeck",
+        "Collab Q",
+        "Collab A",
+        note_key,
+    )
+    monkeypatch.setattr(
+        "ankiops.anki.change_notes_notetype",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("bridge down")),
+    )
+
+    with world.db_session() as db:
+        result = world.sync_import(db)
+
+    assert result.summary.errors == 1
+    assert len(world.mock_anki.notes) == 1
+    assert world.mock_anki.notes[note_id]["modelName"] == "AnkiOpsQA"
+
+
+def test_import_blocks_cross_collab_conversion_without_duplicate(world):
+    collab_root = _setup_collab_root(world)
+    note_key = "published-key-wrong-collab"
+    world.mock_anki.add_note(
+        "CollabDeck",
+        "collab/owner/old/AnkiOpsQA",
+        {
+            "Question": "Collab Q",
+            "Answer": "Collab A",
+            "AnkiOps Key": note_key,
+        },
+    )
+    note_id = max(world.mock_anki.notes.keys())
+    _write_collab_qa_deck(
+        collab_root,
+        "CollabDeck",
+        "Collab Q",
+        "Collab A",
+        note_key,
+    )
+
+    with world.db_session() as db:
+        result = world.sync_import(db)
+
+    assert result.summary.errors == 1
+    assert len(world.mock_anki.notes) == 1
+    assert world.mock_anki.notes[note_id]["modelName"] == (
+        "collab/owner/old/AnkiOpsQA"
+    )
+
+
 def test_import_rejects_duplicate_deck_names_across_sources(world):
     collab_root = _setup_collab_root(world)
 
@@ -278,3 +382,33 @@ def test_export_writes_anki_edits_back_to_collab_source(world):
         encoding="utf-8"
     )
     assert not world.deck_path("CollabDeck").exists()
+
+
+def test_export_blocks_pending_collab_note_type_conversion(world):
+    collab_root = _setup_collab_root(world)
+    note_key = "pending-conversion-export-key"
+    deck = _write_collab_qa_deck(
+        collab_root,
+        "CollabDeck",
+        "Collab Q",
+        "Local Collab A",
+        note_key,
+    )
+    original = deck.read_text(encoding="utf-8")
+    world.mock_anki.add_note(
+        "CollabDeck",
+        "AnkiOpsQA",
+        {
+            "Question": "Collab Q",
+            "Answer": "Anki Root A",
+            "AnkiOps Key": note_key,
+        },
+    )
+    note_id = max(world.mock_anki.notes.keys())
+
+    with world.db_session() as db:
+        db.upsert_note_links([(note_key, note_id)])
+        result = world.sync_export(db)
+
+    assert result.summary.errors == 1
+    assert deck.read_text(encoding="utf-8") == original

--- a/tests/integration/sync/test_sync_matrix_export.py
+++ b/tests/integration/sync/test_sync_matrix_export.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import logging
 
+import pytest
+
 from ankiops.config import ANKIOPS_DB
 from ankiops.db import SQLiteDbAdapter
 from ankiops.fingerprints import note_fingerprint
@@ -69,6 +71,31 @@ def test_exp_fresh_create_004_exports_anki_tags_to_markdown(world):
             "Q: Q1",
             "A: A1",
         )
+
+
+def test_exp_run_conflict_001_duplicate_ankiops_key_in_anki_blocks_export(world):
+    """Export must not write two Markdown notes with the same note_key."""
+    note_key = "exp-duplicate-key"
+    first_id = world.add_qa_note(
+        deck_name="DuplicateExportDeck",
+        question="Q1",
+        answer="A1",
+        note_key=note_key,
+    )
+    second_id = world.add_qa_note(
+        deck_name="DuplicateExportDeck",
+        question="Q2",
+        answer="A2",
+        note_key=note_key,
+    )
+
+    with world.db_session() as db:
+        with pytest.raises(ValueError, match=f"Duplicate AnkiOps Key '{note_key}'"):
+            world.sync_export(db)
+
+    assert world.deck_path("DuplicateExportDeck").exists() is False
+    assert first_id in world.mock_anki.notes
+    assert second_id in world.mock_anki.notes
 
 
 def test_exp_run_update_001_updates_existing_markdown_note(world):

--- a/tests/integration/sync/test_sync_matrix_import.py
+++ b/tests/integration/sync/test_sync_matrix_import.py
@@ -2,9 +2,41 @@
 
 from __future__ import annotations
 
+import shutil
+
 import pytest
 
 from tests.support.assertions import assert_summary
+
+
+def _copy_qa_note_type(world, new_name: str) -> None:
+    shutil.copytree(
+        world.note_types_dir / "AnkiOpsQA",
+        world.note_types_dir / new_name,
+    )
+
+
+def _write_explicit_qa_deck(world, deck_name: str, note_type: str, note_key: str):
+    world.deck_path(deck_name).write_text(
+        "\n".join(
+            [
+                f"<!-- note_key: {note_key} -->",
+                f"<!-- note_type: {note_type} -->",
+                "Q: Path changed Q",
+                "A: Path changed A",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _ankiops_key_find_note_queries(world) -> list[str]:
+    return [
+        params.get("query", "")
+        for action, params in world.mock_anki.calls
+        if action == "findNotes" and "AnkiOps Key:" in params.get("query", "")
+    ]
 
 
 def test_imp_fresh_create_001_creates_note_and_writes_key(world):
@@ -74,6 +106,7 @@ def test_imp_run_update_001_updates_existing_note(world):
         assert (
             world.mock_anki.notes[note_id]["fields"]["Answer"]["value"] == "Updated A"
         )
+        assert _ankiops_key_find_note_queries(world) == []
 
 
 def test_imp_run_update_003_tag_only_edit_updates_existing_note(world):
@@ -288,6 +321,68 @@ def test_imp_run_conflict_001_duplicate_note_keys_fail_fast(world):
             world.sync_import(db)
 
 
+def test_imp_run_conflict_002_local_note_type_path_change_does_not_duplicate_key(
+    world,
+):
+    """A renamed local note type must not hide the existing keyed Anki note."""
+    note_key = "local-path-change-key"
+    _copy_qa_note_type(world, "RenamedQA")
+    shutil.rmtree(world.note_types_dir / "AnkiOpsQA")
+    old_note_id = world.add_qa_note(
+        deck_name="PathChangeDeck",
+        question="Path changed Q",
+        answer="Path changed A",
+        note_key=note_key,
+    )
+    _write_explicit_qa_deck(world, "PathChangeDeck", "RenamedQA", note_key)
+
+    with world.db_session() as db:
+        db.upsert_note_links([(note_key, old_note_id)])
+        result = world.sync_import(db)
+
+    sync_result = result.results[0]
+    assert len(sync_result.errors) == 1
+    assert "Note type mismatch" in sync_result.errors[0]
+    assert_summary(sync_result.summary, created=0, updated=0, moved=0, deleted=0)
+    assert len(world.mock_anki.notes) == 1
+    assert world.mock_anki.notes[old_note_id]["modelName"] == "AnkiOpsQA"
+    assert _ankiops_key_find_note_queries(world) == []
+
+
+def test_imp_run_conflict_003_duplicate_ankiops_key_across_local_note_types_blocks(
+    world,
+):
+    """If a previous path edit already duplicated a key, import must stop."""
+    note_key = "local-duplicate-key"
+    _copy_qa_note_type(world, "RenamedQA")
+    shutil.rmtree(world.note_types_dir / "AnkiOpsQA")
+    old_note_id = world.add_qa_note(
+        deck_name="PathChangeDeck",
+        question="Old Q",
+        answer="Old A",
+        note_key=note_key,
+    )
+    world.mock_anki.add_note(
+        "PathChangeDeck",
+        "RenamedQA",
+        {
+            "Question": "New Q",
+            "Answer": "New A",
+            "AnkiOps Key": note_key,
+        },
+    )
+    new_note_id = max(world.mock_anki.notes.keys())
+    _write_explicit_qa_deck(world, "PathChangeDeck", "RenamedQA", note_key)
+
+    with world.db_session() as db:
+        db.upsert_note_links([(note_key, old_note_id)])
+        with pytest.raises(ValueError, match=f"Duplicate AnkiOps Key '{note_key}'"):
+            world.sync_import(db)
+
+    assert old_note_id in world.mock_anki.notes
+    assert new_note_id in world.mock_anki.notes
+
+
 def test_imp_run_update_002_note_type_mismatch_records_error_and_skips_update(world):
     """IMP-RUN-UPDATE-002."""
     note_key = "imp-run-type-mismatch-001"
@@ -308,8 +403,7 @@ def test_imp_run_update_002_note_type_mismatch_records_error_and_skips_update(wo
         sync_res = result.results[0]
         assert len(sync_res.errors) == 1
         assert "Note type mismatch" in sync_res.errors[0]
-        assert "Remove this note's key comment" in sync_res.errors[0]
-        assert f"<!-- note_key: {note_key} -->" in sync_res.errors[0]
+        assert "will not create a duplicate note" in sync_res.errors[0]
         assert_summary(sync_res.summary, created=0, updated=0, moved=0, deleted=0)
         assert world.mock_anki.notes[note_id]["modelName"] == "AnkiOpsCloze"
 

--- a/tests/integration/sync/test_sync_matrix_import.py
+++ b/tests/integration/sync/test_sync_matrix_import.py
@@ -6,6 +6,7 @@ import shutil
 
 import pytest
 
+from ankiops.fingerprints import note_fingerprint
 from tests.support.assertions import assert_summary
 
 
@@ -324,7 +325,7 @@ def test_imp_run_conflict_001_duplicate_note_keys_fail_fast(world):
 def test_imp_run_conflict_002_local_note_type_path_change_does_not_duplicate_key(
     world,
 ):
-    """A renamed local note type must not hide the existing keyed Anki note."""
+    """A renamed compatible local note type converts the existing keyed Anki note."""
     note_key = "local-path-change-key"
     _copy_qa_note_type(world, "RenamedQA")
     shutil.rmtree(world.note_types_dir / "AnkiOpsQA")
@@ -341,11 +342,17 @@ def test_imp_run_conflict_002_local_note_type_path_change_does_not_duplicate_key
         result = world.sync_import(db)
 
     sync_result = result.results[0]
-    assert len(sync_result.errors) == 1
-    assert "Note type mismatch" in sync_result.errors[0]
-    assert_summary(sync_result.summary, created=0, updated=0, moved=0, deleted=0)
+    assert sync_result.errors == []
+    assert_summary(
+        sync_result.summary,
+        created=0,
+        updated=0,
+        converted=1,
+        moved=0,
+        deleted=0,
+    )
     assert len(world.mock_anki.notes) == 1
-    assert world.mock_anki.notes[old_note_id]["modelName"] == "AnkiOpsQA"
+    assert world.mock_anki.notes[old_note_id]["modelName"] == "RenamedQA"
     assert _ankiops_key_find_note_queries(world) == []
 
 
@@ -383,6 +390,48 @@ def test_imp_run_conflict_003_duplicate_ankiops_key_across_local_note_types_bloc
     assert new_note_id in world.mock_anki.notes
 
 
+def test_imp_run_update_002_cached_same_type_skip_avoids_markdown_render(
+    world,
+    monkeypatch,
+):
+    """Cached unchanged keyed notes should skip before Markdown-to-HTML rendering."""
+    note_key = "cached-fast-path-key"
+    note_id = world.add_qa_note(
+        deck_name="CachedFastPathDeck",
+        question="Cached Q",
+        answer="Cached A",
+        note_key=note_key,
+    )
+    world.write_qa_deck("CachedFastPathDeck", [("Cached Q", "Cached A", note_key)])
+    md_hash = note_fingerprint(
+        "AnkiOpsQA",
+        {"Question": "Cached Q", "Answer": "Cached A"},
+    )
+    anki_hash = note_fingerprint(
+        "AnkiOpsQA",
+        {
+            "Question": "Cached Q",
+            "Answer": "Cached A",
+            "AnkiOps Key": note_key,
+        },
+    )
+
+    def fail_to_html(*_args, **_kwargs):
+        raise AssertionError("unexpected Markdown render on cached skip")
+
+    monkeypatch.setattr("ankiops.import_notes._to_html", fail_to_html)
+
+    with world.db_session() as db:
+        db.upsert_note_links([(note_key, note_id)])
+        db.upsert_import_hashes([(note_key, md_hash, anki_hash)])
+        result = world.sync_import(db)
+
+    sync_result = result.results[0]
+    assert sync_result.errors == []
+    assert sync_result.summary.skipped == 1
+    assert_summary(sync_result.summary, created=0, updated=0, moved=0, deleted=0)
+
+
 def test_imp_run_update_002_note_type_mismatch_records_error_and_skips_update(world):
     """IMP-RUN-UPDATE-002."""
     note_key = "imp-run-type-mismatch-001"
@@ -402,8 +451,8 @@ def test_imp_run_update_002_note_type_mismatch_records_error_and_skips_update(wo
         assert len(result.results) == 1
         sync_res = result.results[0]
         assert len(sync_res.errors) == 1
-        assert "Note type mismatch" in sync_res.errors[0]
-        assert "will not create a duplicate note" in sync_res.errors[0]
+        assert "Failed note type conversion" in sync_res.errors[0]
+        assert "field names differ" in sync_res.errors[0]
         assert_summary(sync_res.summary, created=0, updated=0, moved=0, deleted=0)
         assert world.mock_anki.notes[note_id]["modelName"] == "AnkiOpsCloze"
 

--- a/tests/support/assertions.py
+++ b/tests/support/assertions.py
@@ -11,6 +11,7 @@ def assert_summary(
     *,
     created: int | None = None,
     updated: int | None = None,
+    converted: int | None = None,
     moved: int | None = None,
     deleted: int | None = None,
     errors: int | None = None,
@@ -21,6 +22,8 @@ def assert_summary(
         assert summary.created == created
     if updated is not None:
         assert summary.updated == updated
+    if converted is not None:
+        assert summary.converted == converted
     if moved is not None:
         assert summary.moved == moved
     if deleted is not None:

--- a/tests/support/fake_anki.py
+++ b/tests/support/fake_anki.py
@@ -20,6 +20,12 @@ class MockAnki:
         self.next_deck_id = 10
         self.calls = []
 
+    def _search_value(self, term: str) -> str:
+        value = term.split(":", 1)[1]
+        if len(value) >= 2 and value[0] == '"' and value[-1] == '"':
+            return value[1:-1].replace('\\"', '"').replace("\\\\", "\\")
+        return value
+
     def invoke(self, action: str, **params) -> Any:
         self.calls.append((action, params))
 
@@ -43,13 +49,13 @@ class MockAnki:
                         matches_all_terms = True
                         for term in terms:
                             if term.startswith("note:"):
-                                model = term.split(":", 1)[1]
+                                model = self._search_value(term)
                                 note = self.notes.get(card["note"])
                                 if not note or note["modelName"] != model:
                                     matches_all_terms = False
                                     break
                             elif term.startswith("deck:"):
-                                deck_name = term.split(":", 1)[1]
+                                deck_name = self._search_value(term)
                                 if card["deckName"] != deck_name:
                                     matches_all_terms = False
                                     break
@@ -275,13 +281,13 @@ class MockAnki:
                         match_all = True
                         for term in terms:
                             if term.startswith("note:"):
-                                model = term.split(":", 1)[1]
+                                model = self._search_value(term)
                                 if note["modelName"] != model:
                                     match_all = False
                                     break
                             elif term.startswith("deck:"):
                                 deck_match = False
-                                target_deck = term.split(":", 1)[1]
+                                target_deck = self._search_value(term)
                                 for card in self.cards.values():
                                     if (
                                         card["note"] == note_id

--- a/tests/support/fake_anki.py
+++ b/tests/support/fake_anki.py
@@ -20,6 +20,13 @@ class MockAnki:
         self.next_deck_id = 10
         self.calls = []
 
+    def _base_model_name(self, model_name: str | None) -> str | None:
+        if model_name == "RenamedQA":
+            return "AnkiOpsQA"
+        if model_name and model_name.startswith("collab/"):
+            return model_name.split("/")[-1]
+        return model_name
+
     def _search_value(self, term: str) -> str:
         value = term.split(":", 1)[1]
         if len(value) >= 2 and value[0] == '"' and value[-1] == '"':
@@ -99,7 +106,7 @@ class MockAnki:
                 ]
 
             case "modelFieldNames":
-                model = params.get("modelName")
+                model = self._base_model_name(params.get("modelName"))
                 if model == "AnkiOpsQA":
                     return [
                         "Question",
@@ -326,3 +333,32 @@ class MockAnki:
                 "tags": list(normalize_tags(tags)),
             },
         )
+
+    def change_notes_notetype(
+        self,
+        note_ids: list[int],
+        old_model: str,
+        new_model: str,
+    ) -> None:
+        self.calls.append(
+            (
+                "changeNotesNotetype",
+                {"noteIds": note_ids, "oldModel": old_model, "newModel": new_model},
+            )
+        )
+        for note_id in note_ids:
+            note = self.notes[note_id]
+            if note["modelName"] != old_model:
+                raise ValueError(
+                    f"note {note_id} has model {note['modelName']}, expected "
+                    f"{old_model}"
+                )
+            old_fields = set(self.invoke("modelFieldNames", modelName=old_model))
+            new_fields = set(self.invoke("modelFieldNames", modelName=new_model))
+            if old_fields != new_fields:
+                raise ValueError(
+                    f"Cannot convert {old_model} to {new_model}: field names differ"
+                )
+            note["modelName"] = new_model
+            for card_id in note["cards"]:
+                self.cards[card_id]["modelName"] = new_model

--- a/tests/unit/adapters/test_anki_adapter.py
+++ b/tests/unit/adapters/test_anki_adapter.py
@@ -166,6 +166,33 @@ def test_fetch_notes_info_maps_tags():
     assert notes[101].tags == ("a", "z")
 
 
+def test_change_notes_notetype_calls_ankiops_bridge():
+    adapter = AnkiAdapter()
+
+    with patch("ankiops.anki.change_notes_notetype") as mock_bridge:
+        adapter.change_notes_notetype([101, 102], "AnkiOpsQA", "collab/o/r/AnkiOpsQA")
+
+    mock_bridge.assert_called_once_with(
+        [101, 102],
+        "AnkiOpsQA",
+        "collab/o/r/AnkiOpsQA",
+    )
+
+
+def test_fetch_note_ids_by_note_keys_searches_key_field_independent_of_model():
+    adapter = AnkiAdapter()
+
+    with patch("ankiops.anki.invoke", return_value=[[101], [201, 202]]) as mock_invoke:
+        note_ids = adapter.fetch_note_ids_by_note_keys({"key-b", "key-a"})
+
+    assert note_ids == {"key-a": [101], "key-b": [201, 202]}
+    assert mock_invoke.call_args.args == ("multi",)
+    assert mock_invoke.call_args.kwargs["actions"] == [
+        {"action": "findNotes", "params": {"query": '"AnkiOps Key:key-a"'}},
+        {"action": "findNotes", "params": {"query": '"AnkiOps Key:key-b"'}},
+    ]
+
+
 def test_apply_note_changes_updates_fields_and_tags_with_update_note():
     adapter = AnkiAdapter()
     update_change = Change(

--- a/tests/unit/domain/test_note_identity.py
+++ b/tests/unit/domain/test_note_identity.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import pytest
+
+from ankiops.models import AnkiNote
+from ankiops.note_identity import (
+    assert_unique_export_note_keys,
+    resolve_import_note_identity,
+)
+
+
+class FakeAnkiIdentity:
+    def __init__(
+        self,
+        notes: dict[int, AnkiNote],
+        *,
+        model_note_ids: list[int] | None = None,
+        note_ids_by_key: dict[str, list[int]] | None = None,
+    ):
+        self.notes = notes
+        self.model_note_ids = model_note_ids or []
+        self.note_ids_by_key = note_ids_by_key or {}
+        self.key_field_lookup_calls: list[set[str]] = []
+
+    def fetch_all_note_ids(self, required_types: list[str]) -> list[int]:
+        return self.model_note_ids
+
+    def fetch_note_ids_by_note_keys(
+        self,
+        note_keys: set[str],
+    ) -> dict[str, list[int]]:
+        self.key_field_lookup_calls.append(set(note_keys))
+        return {
+            note_key: self.note_ids_by_key.get(note_key, [])
+            for note_key in note_keys
+        }
+
+    def fetch_notes_info(self, note_ids: list[int]) -> dict[int, AnkiNote]:
+        return {
+            note_id: self.notes[note_id]
+            for note_id in note_ids
+            if note_id in self.notes
+        }
+
+
+class FakeDbIdentity:
+    def __init__(self, mappings: dict[str, int]):
+        self.mappings = mappings
+
+    def resolve_note_ids(self, note_keys: set[str]) -> dict[str, int]:
+        return {
+            note_key: note_id
+            for note_key, note_id in self.mappings.items()
+            if note_key in note_keys
+        }
+
+
+def _note(
+    note_id: int,
+    note_type: str = "AnkiOpsQA",
+    note_key: str = "key-1",
+) -> AnkiNote:
+    return AnkiNote(
+        note_id=note_id,
+        note_type=note_type,
+        fields={"AnkiOps Key": note_key, "Question": "Q", "Answer": "A"},
+        card_ids=[note_id + 1000],
+    )
+
+
+def test_resolves_healthy_db_mapping_without_key_field_lookup():
+    anki = FakeAnkiIdentity(
+        {101: _note(101)},
+        model_note_ids=[101],
+    )
+    db = FakeDbIdentity({"key-1": 101})
+
+    identity = resolve_import_note_identity(
+        anki_port=anki,
+        db_port=db,
+        note_keys={"key-1"},
+        required_note_types=["AnkiOpsQA"],
+    )
+
+    assert identity.note_ids_by_note_key == {"key-1": 101}
+    assert identity.pending_note_mappings == []
+    assert anki.key_field_lookup_calls == []
+
+
+def test_indexes_missing_db_mapping_from_configured_model_snapshot():
+    anki = FakeAnkiIdentity(
+        {101: _note(101)},
+        model_note_ids=[101],
+    )
+    db = FakeDbIdentity({})
+
+    identity = resolve_import_note_identity(
+        anki_port=anki,
+        db_port=db,
+        note_keys={"key-1"},
+        required_note_types=["AnkiOpsQA"],
+    )
+
+    assert identity.note_ids_by_note_key == {"key-1": 101}
+    assert identity.pending_note_mappings == [("key-1", 101)]
+    assert anki.key_field_lookup_calls == []
+
+
+def test_uses_db_mapped_note_even_when_old_model_is_not_configured():
+    anki = FakeAnkiIdentity(
+        {101: _note(101, note_type="OldQA")},
+        model_note_ids=[],
+    )
+    db = FakeDbIdentity({"key-1": 101})
+
+    identity = resolve_import_note_identity(
+        anki_port=anki,
+        db_port=db,
+        note_keys={"key-1"},
+        required_note_types=["NewQA"],
+    )
+
+    assert identity.note_ids_by_note_key == {"key-1": 101}
+    assert identity.anki_notes[101].note_type == "OldQA"
+    assert anki.key_field_lookup_calls == []
+
+
+def test_uses_key_field_lookup_only_for_unresolved_identity():
+    anki = FakeAnkiIdentity(
+        {101: _note(101, note_type="OldQA")},
+        model_note_ids=[],
+        note_ids_by_key={"key-1": [101]},
+    )
+    db = FakeDbIdentity({})
+
+    identity = resolve_import_note_identity(
+        anki_port=anki,
+        db_port=db,
+        note_keys={"key-1"},
+        required_note_types=["NewQA"],
+    )
+
+    assert identity.note_ids_by_note_key == {"key-1": 101}
+    assert identity.pending_note_mappings == [("key-1", 101)]
+    assert anki.key_field_lookup_calls == [{"key-1"}]
+
+
+def test_blocks_when_key_field_lookup_would_duplicate_existing_key():
+    anki = FakeAnkiIdentity(
+        {
+            101: _note(101, note_key=""),
+            202: _note(202, note_key="key-1"),
+        },
+        model_note_ids=[101],
+        note_ids_by_key={"key-1": [202]},
+    )
+    db = FakeDbIdentity({"key-1": 101})
+
+    with pytest.raises(ValueError, match="Duplicate AnkiOps Key 'key-1'"):
+        resolve_import_note_identity(
+            anki_port=anki,
+            db_port=db,
+            note_keys={"key-1"},
+            required_note_types=["AnkiOpsQA"],
+        )
+
+    assert anki.key_field_lookup_calls == [{"key-1"}]
+
+
+def test_export_identity_blocks_duplicate_embedded_keys():
+    notes = {
+        101: _note(101, note_key="key-1"),
+        202: _note(202, note_key="key-1"),
+    }
+
+    with pytest.raises(ValueError, match="Aborting export"):
+        assert_unique_export_note_keys(
+            anki_notes=notes,
+            note_keys_by_id={},
+        )
+
+
+def test_export_identity_blocks_db_mapping_and_embedded_key_collision():
+    notes = {
+        101: _note(101, note_key=""),
+        202: _note(202, note_key="key-1"),
+    }
+
+    with pytest.raises(ValueError, match="Duplicate AnkiOps Key 'key-1'"):
+        assert_unique_export_note_keys(
+            anki_notes=notes,
+            note_keys_by_id={101: "key-1"},
+        )

--- a/tests/unit/domain/test_note_models.py
+++ b/tests/unit/domain/test_note_models.py
@@ -415,11 +415,11 @@ class TestParseQABlock:
         ):
             fs.read_markdown_file(md)
 
-    def test_qa_with_note_type_metadata(self, fs, tmp_path):
+    def test_qa_with_note_type_metadata_uses_explicit_type(self, fs, tmp_path):
         md = tmp_path / "deck.md"
         md.write_text(
             "<!-- note_key: key-1 -->\n"
-            "<!-- note_type: StaleType -->\n"
+            "<!-- note_type: AnkiOpsQA -->\n"
             "Q: What?\n"
             "A: Answer"
         )
@@ -427,6 +427,18 @@ class TestParseQABlock:
         note = result.notes[0]
         assert note.note_key == "key-1"
         assert note.note_type == "AnkiOpsQA"
+
+    def test_unknown_note_type_metadata_fails(self, fs, tmp_path):
+        md = tmp_path / "deck.md"
+        md.write_text(
+            "<!-- note_key: key-1 -->\n"
+            "<!-- note_type: StaleType -->\n"
+            "Q: What?\n"
+            "A: Answer"
+        )
+
+        with pytest.raises(ValueError, match="Unknown note type 'StaleType'"):
+            fs.read_markdown_file(md)
 
     def test_qa_with_tags_metadata(self, fs, tmp_path):
         md = tmp_path / "deck.md"

--- a/tests/unit/domain/test_sources.py
+++ b/tests/unit/domain/test_sources.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from ankiops.fs import FileSystemAdapter
+from ankiops.sources import (
+    SyncSource,
+    discover_sync_sources,
+    load_configs_for_source,
+    markdown_files_for_source,
+)
+
+
+def test_discover_sync_sources_includes_local_and_collab(tmp_path):
+    (tmp_path / "note_types").mkdir()
+    (tmp_path / "collab" / "owner" / "repo" / "note_types").mkdir(parents=True)
+    (tmp_path / "collab" / "other" / "deck" / "note_types").mkdir(parents=True)
+
+    sources = discover_sync_sources(tmp_path)
+
+    assert [source.display_name for source in sources] == [
+        "local",
+        "collab/other/deck",
+        "collab/owner/repo",
+    ]
+    assert sources[1].github_url == "https://github.com/other/deck.git"
+    assert sources[2].github_url == "https://github.com/owner/repo.git"
+
+
+def test_collab_markdown_files_ignore_reserved_docs(tmp_path):
+    source = SyncSource.collab(tmp_path, "owner", "repo")
+    source.root.mkdir(parents=True)
+    (source.root / "Deck.md").write_text("Q: a\nA: b", encoding="utf-8")
+    (source.root / "README.md").write_text("# docs", encoding="utf-8")
+    (source.root / "LICENSE.md").write_text("# license", encoding="utf-8")
+    (source.root / "CHANGELOG.md").write_text("# changes", encoding="utf-8")
+    (source.root / "_draft.md").write_text("Q: x\nA: y", encoding="utf-8")
+
+    assert [path.name for path in markdown_files_for_source(source)] == ["Deck.md"]
+
+
+def test_reserved_markdown_names_are_not_ignored_in_local_root(tmp_path):
+    source = SyncSource.local(tmp_path)
+    for name in ["README.md", "LICENSE.md", "CHANGELOG.md", "_draft.md"]:
+        (tmp_path / name).write_text("Q: local\nA: deck", encoding="utf-8")
+
+    assert [path.name for path in markdown_files_for_source(source)] == [
+        "CHANGELOG.md",
+        "LICENSE.md",
+        "README.md",
+        "_draft.md",
+    ]
+
+
+def test_collab_configs_are_scoped_by_source(tmp_path):
+    source = SyncSource.collab(tmp_path, "owner", "repo")
+    FileSystemAdapter().eject_builtin_note_types(source.note_types_dir)
+
+    names = {config.name for config in load_configs_for_source(source)}
+
+    assert "collab/owner/repo/AnkiOpsQA" in names
+    assert "AnkiOpsQA" not in names
+
+
+def test_collab_note_type_names_are_path_like(tmp_path):
+    source = SyncSource.collab(tmp_path, "owner", "repo")
+
+    assert source.scope_note_type_name("AnkiOpsQA") == (
+        "collab/owner/repo/AnkiOpsQA"
+    )
+    assert source.scope_note_type_name("collab/owner/repo/AnkiOpsQA") == (
+        "collab/owner/repo/AnkiOpsQA"
+    )
+    assert source.unscoped_note_type_name("collab/owner/repo/AnkiOpsQA") == (
+        "AnkiOpsQA"
+    )

--- a/tests/unit/domain/test_sync_summary.py
+++ b/tests/unit/domain/test_sync_summary.py
@@ -15,15 +15,17 @@ def test_note_summary_prefers_higher_priority_change_per_entity():
         Change(ChangeType.UPDATE, 1, "note_key: one"),
         Change(ChangeType.CREATE, 2, "note_key: two"),
         Change(ChangeType.DELETE, 3, "note_key: three"),
+        Change(ChangeType.CONVERT, 4, "note_key: four"),
     ]
 
     summary = result.summary
 
     assert summary.updated == 1
     assert summary.created == 1
+    assert summary.converted == 1
     assert summary.skipped == 0
     assert summary.deleted == 1
-    assert summary.total == 2
+    assert summary.total == 3
 
 
 def test_media_summary_tracks_sync_and_hash_with_deduplication():

--- a/tests/unit/llm/test_llm_db.py
+++ b/tests/unit/llm/test_llm_db.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import sqlite3
+
 import pytest
 
+from ankiops.config import LLM_DB_FILENAME, LLM_DIR
 from ankiops.llm.llm_db import LlmDb
 from ankiops.llm.types import LlmItemStatus
 
@@ -26,6 +29,36 @@ def test_resolve_job_id_accepts_numeric_and_latest(tmp_path):
         db.close()
 
 
+def test_open_rejects_old_job_item_schema_without_source(tmp_path):
+    llm_dir = tmp_path / LLM_DIR
+    llm_dir.mkdir()
+    db_path = llm_dir / LLM_DB_FILENAME
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE llm_job_item (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                job_id INTEGER NOT NULL,
+                ordinal INTEGER NOT NULL,
+                note_key TEXT,
+                deck_name TEXT NOT NULL,
+                note_type TEXT,
+                item_status TEXT NOT NULL,
+                skip_reason TEXT,
+                error_message TEXT,
+                changed_fields_json TEXT NOT NULL,
+                applied_to_markdown INTEGER NOT NULL DEFAULT 0
+            );
+            """
+        )
+    finally:
+        conn.close()
+
+    with pytest.raises(RuntimeError, match=r"Delete '.*\.llm\.db'"):
+        LlmDb.open(tmp_path)
+
+
 def test_write_tx_rolls_back_request(tmp_path):
     db = LlmDb.open(tmp_path)
     try:
@@ -33,6 +66,7 @@ def test_write_tx_rolls_back_request(tmp_path):
         item_id = db.insert_job_item(
             job_id=job_id,
             ordinal=1,
+            source="local",
             deck_name="Deck",
             note_key="nk-1",
             note_type="AnkiOpsQA",
@@ -75,6 +109,7 @@ def test_get_job_detail_reports_usage_at_request_level(tmp_path):
         first_id = db.insert_job_item(
             job_id=job_id,
             ordinal=1,
+            source="local",
             deck_name="Deck",
             note_key="nk-1",
             note_type="AnkiOpsQA",
@@ -85,6 +120,7 @@ def test_get_job_detail_reports_usage_at_request_level(tmp_path):
         second_id = db.insert_job_item(
             job_id=job_id,
             ordinal=2,
+            source="local",
             deck_name="Deck",
             note_key="nk-2",
             note_type="AnkiOpsQA",
@@ -115,6 +151,7 @@ def test_get_job_detail_reports_usage_at_request_level(tmp_path):
     ]
     assert not hasattr(detail.items[0], "input_tokens")
     assert not hasattr(detail.items[0], "latency_ms")
+    assert detail.items[0].source == "local"
     assert detail.summary.requests == 1
     assert detail.summary.input_tokens == 5
     assert detail.summary.output_tokens == 2
@@ -139,6 +176,7 @@ def test_mark_unfinished_items_canceled_only_updates_queued(tmp_path):
         queued_id = db.insert_job_item(
             job_id=job_id,
             ordinal=1,
+            source="local",
             deck_name="Deck",
             note_key="nk-queued",
             note_type="AnkiOpsQA",
@@ -148,6 +186,7 @@ def test_mark_unfinished_items_canceled_only_updates_queued(tmp_path):
         skipped_id = db.insert_job_item(
             job_id=job_id,
             ordinal=2,
+            source="local",
             deck_name="Deck",
             note_key="nk-skipped",
             note_type="AnkiOpsQA",
@@ -157,6 +196,7 @@ def test_mark_unfinished_items_canceled_only_updates_queued(tmp_path):
         settled_id = db.insert_job_item(
             job_id=job_id,
             ordinal=3,
+            source="local",
             deck_name="Deck",
             note_key="nk-settled",
             note_type="AnkiOpsQA",

--- a/tests/unit/llm/test_runner_execution.py
+++ b/tests/unit/llm/test_runner_execution.py
@@ -120,6 +120,7 @@ def _context(
     items = [
         DiscoveryItem(
             ordinal=index,
+            source="local",
             deck_name="Deck",
             note_key=note["note_key"],
             note_type="AnkiOpsQA",
@@ -140,7 +141,9 @@ def _context(
     return MaterializedTaskContext(
         task=task,
         note_type_configs={"AnkiOpsQA": llm_qa_config},
-        serialized_data={"decks": [{"name": "Deck", "notes": notes}]},
+        serialized_data={
+            "decks": [{"source": "local", "name": "Deck", "notes": notes}]
+        },
         discovery_snapshot=DiscoverySnapshot(
             counts=DiscoveryCounts(decks_seen=1, decks_matched=1, notes_seen=2),
             items=items,
@@ -226,6 +229,7 @@ def test_executor_persists_successful_tag_updates(
     }
     item = DiscoveryItem(
         ordinal=1,
+        source="local",
         deck_name="Deck",
         note_key="nk-1",
         note_type="AnkiOpsQA",
@@ -245,7 +249,9 @@ def test_executor_persists_successful_tag_updates(
     context = MaterializedTaskContext(
         task=task,
         note_type_configs={"AnkiOpsQA": llm_qa_config},
-        serialized_data={"decks": [{"name": "Deck", "notes": [note]}]},
+        serialized_data={
+            "decks": [{"source": "local", "name": "Deck", "notes": [note]}]
+        },
         discovery_snapshot=DiscoverySnapshot(
             counts=DiscoveryCounts(decks_seen=1, decks_matched=1, notes_seen=1),
             items=[item],

--- a/tests/unit/llm/test_runner_plan.py
+++ b/tests/unit/llm/test_runner_plan.py
@@ -2,10 +2,21 @@
 
 from __future__ import annotations
 
+import pytest
+
 from ankiops.config import LLM_DB_FILENAME
+from ankiops.db import SQLiteDbAdapter
 from ankiops.fs import FileSystemAdapter
 from ankiops.llm.runner import plan_task
 from ankiops.llm.types import FieldAccess
+
+
+def _init_collection_db(collection_dir):
+    db = SQLiteDbAdapter.open(collection_dir)
+    try:
+        db.set_profile_name("test")
+    finally:
+        db.close()
 
 
 def test_plan_task_summarizes_scope_surface_and_does_not_persist(
@@ -46,6 +57,7 @@ def test_plan_task_summarizes_scope_surface_and_does_not_persist(
         return {
             "decks": [
                 {
+                    "source": "local",
                     "name": "Deck",
                     "notes": [
                         {
@@ -142,6 +154,7 @@ def test_plan_task_summarizes_autotagger_tag_surface_and_skips_contextless_notes
         return {
             "decks": [
                 {
+                    "source": "local",
                     "name": "Deck",
                     "notes": [
                         {
@@ -192,3 +205,87 @@ def test_plan_task_summarizes_autotagger_tag_surface_and_skips_contextless_notes
     assert surface_by_type["AnkiOpsQA"].read_only_fields == ["Question", "Answer"]
     assert surface_by_type["AnkiOpsCloze"].read_only_fields == ["Text"]
     assert surface_by_type["AnkiOpsReversed"].candidate_notes == 0
+
+
+def test_plan_task_discovers_collab_notes_with_sources(llm_collection, write_file):
+    _init_collection_db(llm_collection)
+    fs = FileSystemAdapter()
+    fs.eject_builtin_note_types(llm_collection / "note_types")
+    collab_root = llm_collection / "collab" / "owner" / "repo"
+    fs.eject_builtin_note_types(collab_root / "note_types")
+    write_file(
+        llm_collection / "Local.md",
+        """
+        <!-- note_key: local-1 -->
+        Q: local question
+        A: local answer
+        """,
+    )
+    write_file(
+        collab_root / "Shared.md",
+        """
+        <!-- note_key: collab-1 -->
+        Q: collab question
+        A: collab answer
+        """,
+    )
+    write_file(
+        llm_collection / "llm/grammar.yaml",
+        """
+        model: test
+        system_prompt: system
+        user_prompt: Fix grammar.
+        request:
+          max_notes_per_request: 4
+        fields:
+          default_access: editable
+          read_only:
+            "*AnkiOpsQA": ["Answer"]
+        """,
+    )
+
+    plan = plan_task(collection_dir=llm_collection, task_name="grammar")
+
+    surface = {
+        (item.source, item.note_type): item
+        for item in plan.field_surface
+    }
+    assert ("local", "AnkiOpsQA") in surface
+    assert ("collab/owner/repo", "collab/owner/repo/AnkiOpsQA") in surface
+    assert surface[("local", "AnkiOpsQA")].candidate_notes == 1
+    assert surface[
+        ("collab/owner/repo", "collab/owner/repo/AnkiOpsQA")
+    ].candidate_notes == 1
+
+
+def test_plan_task_rejects_explicit_note_type_pattern_after_deck_filter(
+    llm_collection,
+    write_file,
+):
+    _init_collection_db(llm_collection)
+    FileSystemAdapter().eject_builtin_note_types(llm_collection / "note_types")
+    write_file(
+        llm_collection / "Deck.md",
+        """
+        <!-- note_key: qa-1 -->
+        Q: question
+        A: answer
+        """,
+    )
+    write_file(
+        llm_collection / "llm/grammar.yaml",
+        """
+        model: test
+        system_prompt: system
+        user_prompt: Fix grammar.
+        request:
+          max_notes_per_request: 4
+        fields:
+          default_access: editable
+          read_only:
+            "AnkiOpsChoice": ["Answer"]
+        """,
+    )
+
+    with pytest.raises(ValueError, match="matched no notes after deck filtering"):
+        plan_task(collection_dir=llm_collection, task_name="grammar")

--- a/tests/unit/llm/test_schemas.py
+++ b/tests/unit/llm/test_schemas.py
@@ -28,6 +28,7 @@ def _parsed_response(*updates, tag_updates=()):
 def _candidate(llm_qa_config) -> EligibleCandidate:
     return EligibleCandidate(
         item_id=1,
+        source="local",
         deck_name="Deck",
         payload=NotePayload(
             note_key="nk-1",
@@ -59,6 +60,7 @@ def _tag_candidate(
     current_tags = ["old"] if tags is None else tags
     return EligibleCandidate(
         item_id=1,
+        source="local",
         deck_name="Deck",
         payload=NotePayload(
             note_key="nk-1",

--- a/tests/unit/test_anki_addon_bridge_actions.py
+++ b/tests/unit/test_anki_addon_bridge_actions.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_BRIDGE_ACTIONS_PATH = (
+    Path(__file__).resolve().parents[2] / "anki_addon" / "bridge_actions.py"
+)
+_SPEC = importlib.util.spec_from_file_location(
+    "ankiops_addon_bridge_actions",
+    _BRIDGE_ACTIONS_PATH,
+)
+bridge_actions = importlib.util.module_from_spec(_SPEC)
+assert _SPEC and _SPEC.loader
+_SPEC.loader.exec_module(bridge_actions)
+
+BridgeActionError = bridge_actions.BridgeActionError
+change_notes_notetype = bridge_actions.change_notes_notetype
+dispatch_bridge_action = bridge_actions.dispatch_bridge_action
+
+
+def _model(model_id: int, name: str, fields=None, templates=None):
+    return {
+        "id": model_id,
+        "name": name,
+        "flds": [{"name": field} for field in (fields or _FIELDS)],
+        "tmpls": [{"name": template} for template in (templates or ["Card 1"])],
+    }
+
+
+_FIELDS = ["Question", "Answer", "AnkiOps Key"]
+
+
+class _FakeNote:
+    def __init__(self, note_id: int, model: dict, fields: dict[str, str]):
+        self.id = note_id
+        self._model = model
+        self.fields = [
+            fields.get(field["name"], "")
+            for field in model["flds"]
+        ]
+
+    def note_type(self):
+        return self._model
+
+
+class _FakeModels:
+    def __init__(self, collection):
+        self.collection = collection
+
+    def by_name(self, name: str):
+        return self.collection.models_by_name.get(name)
+
+    def change_notetype_info(self, old_notetype_id: int, new_notetype_id: int):
+        self.collection.pending_new_model = self.collection.models_by_id[
+            new_notetype_id
+        ]
+        return SimpleNamespace(
+            input=SimpleNamespace(note_ids=[], new_fields=[], new_templates=[]),
+        )
+
+    def change_notetype_of_notes(self, request):
+        new_model = self.collection.pending_new_model
+        for note_id in request.note_ids:
+            note = self.collection.notes[note_id]
+            old_values = list(note.fields)
+            note.fields = [
+                old_values[old_index]
+                for old_index in request.new_fields
+            ]
+            note._model = new_model
+            if self.collection.mutate_card_due_on_change:
+                for card in self.collection.cards.values():
+                    if card["nid"] == note_id:
+                        card["due"] += 1
+
+
+class _FakeCollection:
+    def __init__(self):
+        self.old_model = _model(1, "AnkiOpsQA")
+        self.new_model = _model(2, "collab/owner/repo/AnkiOpsQA")
+        self.models_by_name = {
+            self.old_model["name"]: self.old_model,
+            self.new_model["name"]: self.new_model,
+        }
+        self.models_by_id = {
+            self.old_model["id"]: self.old_model,
+            self.new_model["id"]: self.new_model,
+        }
+        self.models = _FakeModels(self)
+        self.notes = {}
+        self.cards = {}
+        self.pending_new_model = None
+        self.mutate_card_due_on_change = False
+
+    def add_note(self, note_id: int, model: dict, key: str):
+        self.notes[note_id] = _FakeNote(
+            note_id,
+            model,
+            {
+                "Question": f"Q{note_id}",
+                "Answer": f"A{note_id}",
+                "AnkiOps Key": key,
+            },
+        )
+        self.cards[note_id * 10] = {
+            "id": note_id * 10,
+            "nid": note_id,
+            "ord": 0,
+            "did": 1,
+            "queue": 2,
+            "type": 2,
+            "due": 10,
+            "ivl": 5,
+            "factor": 2500,
+            "reps": 3,
+            "lapses": 0,
+            "left": 0,
+            "odue": 0,
+            "odid": 0,
+        }
+
+    def get_note(self, note_id: int):
+        if note_id not in self.notes:
+            raise KeyError(note_id)
+        return self.notes[note_id]
+
+    def ankiops_bridge_cards_snapshot(self, note_ids):
+        return {
+            card_id: tuple(card.values())
+            for card_id, card in self.cards.items()
+            if card["nid"] in note_ids
+        }
+
+
+def test_change_notes_notetype_converts_selected_notes_only():
+    col = _FakeCollection()
+    col.add_note(101, col.old_model, "key-101")
+    col.add_note(102, col.old_model, "key-102")
+
+    result = change_notes_notetype(
+        col,
+        [101],
+        "AnkiOpsQA",
+        "collab/owner/repo/AnkiOpsQA",
+    )
+
+    assert result == {"changed": 1}
+    assert col.notes[101].note_type()["name"] == "collab/owner/repo/AnkiOpsQA"
+    assert col.notes[102].note_type()["name"] == "AnkiOpsQA"
+
+
+def test_change_notes_notetype_blocks_missing_model():
+    col = _FakeCollection()
+    col.add_note(101, col.old_model, "key-101")
+
+    with pytest.raises(BridgeActionError, match="New note type not found"):
+        change_notes_notetype(col, [101], "AnkiOpsQA", "missing")
+
+
+def test_change_notes_notetype_blocks_wrong_current_model():
+    col = _FakeCollection()
+    col.add_note(101, col.new_model, "key-101")
+
+    with pytest.raises(BridgeActionError, match="expected 'AnkiOpsQA'"):
+        change_notes_notetype(
+            col,
+            [101],
+            "AnkiOpsQA",
+            "collab/owner/repo/AnkiOpsQA",
+        )
+
+
+def test_change_notes_notetype_blocks_missing_ankiops_key_field():
+    col = _FakeCollection()
+    col.old_model = _model(1, "AnkiOpsQA", fields=["Question", "Answer"])
+    col.models_by_name["AnkiOpsQA"] = col.old_model
+    col.models_by_id[1] = col.old_model
+    col.add_note(101, col.old_model, "key-101")
+
+    with pytest.raises(BridgeActionError, match="lacks AnkiOps Key"):
+        change_notes_notetype(
+            col,
+            [101],
+            "AnkiOpsQA",
+            "collab/owner/repo/AnkiOpsQA",
+        )
+
+
+def test_change_notes_notetype_blocks_mismatched_fields():
+    col = _FakeCollection()
+    col.new_model = _model(
+        2,
+        "collab/owner/repo/AnkiOpsQA",
+        fields=["Question", "Different", "AnkiOps Key"],
+    )
+    col.models_by_name[col.new_model["name"]] = col.new_model
+    col.models_by_id[2] = col.new_model
+    col.add_note(101, col.old_model, "key-101")
+
+    with pytest.raises(BridgeActionError, match="field names differ"):
+        change_notes_notetype(
+            col,
+            [101],
+            "AnkiOpsQA",
+            "collab/owner/repo/AnkiOpsQA",
+        )
+
+
+def test_change_notes_notetype_blocks_post_verification_failures():
+    col = _FakeCollection()
+    col.add_note(101, col.old_model, "key-101")
+    col.mutate_card_due_on_change = True
+
+    with pytest.raises(BridgeActionError, match="Post-conversion verification failed"):
+        change_notes_notetype(
+            col,
+            [101],
+            "AnkiOpsQA",
+            "collab/owner/repo/AnkiOpsQA",
+        )
+
+
+def test_dispatch_bridge_action_routes_version():
+    assert dispatch_bridge_action(None, "version", {}) == {"version": 1}
+
+
+def test_dispatch_bridge_action_blocks_unknown_action():
+    with pytest.raises(BridgeActionError, match="Unknown AnkiOps bridge action"):
+        dispatch_bridge_action(None, "missing", {})

--- a/tests/unit/test_anki_addon_bridge_host.py
+++ b/tests/unit/test_anki_addon_bridge_host.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+
+def _load_bridge_host_module():
+    addon_dir = Path(__file__).resolve().parents[2] / "anki_addon"
+    package = sys.modules.get("anki_addon")
+    if package is None:
+        package = ModuleType("anki_addon")
+        package.__path__ = [str(addon_dir)]
+        sys.modules["anki_addon"] = package
+    spec = importlib.util.spec_from_file_location(
+        "anki_addon.bridge_host",
+        addon_dir / "bridge_host.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+bridge_host = _load_bridge_host_module()
+AnkiOpsBridgeHost = bridge_host.AnkiOpsBridgeHost
+
+
+def test_bridge_host_dispatches_on_main_thread():
+    collection = object()
+    ran_on_main = []
+    calls = []
+
+    def run_on_main(work):
+        ran_on_main.append(True)
+        work()
+
+    def dispatch_action(col, action, params):
+        calls.append((col, action, params))
+        return {"ok": True}
+
+    host = AnkiOpsBridgeHost(
+        get_collection=lambda: collection,
+        run_on_main=run_on_main,
+        dispatch_action=dispatch_action,
+    )
+
+    assert host.dispatch_payload({"action": "version", "params": {"x": 1}}) == {
+        "ok": True
+    }
+    assert ran_on_main == [True]
+    assert calls == [(collection, "version", {"x": 1})]
+
+
+def test_bridge_host_returns_structured_errors():
+    host = AnkiOpsBridgeHost(
+        get_collection=lambda: None,
+        run_on_main=lambda work: work(),
+    )
+
+    assert host.handle_payload({"action": "version", "params": {}}) == {
+        "result": None,
+        "error": "No Anki collection is open.",
+    }
+
+
+def test_bridge_host_validates_payload_shape():
+    host = AnkiOpsBridgeHost(
+        get_collection=lambda: object(),
+        run_on_main=lambda work: work(),
+    )
+
+    assert host.handle_payload({"action": "version", "params": []}) == {
+        "result": None,
+        "error": "Bridge requests require action and params.",
+    }
+
+
+def test_bridge_host_reads_json_request_body():
+    host = AnkiOpsBridgeHost(
+        get_collection=lambda: object(),
+        run_on_main=lambda work: work(),
+    )
+    body = b'{"action": "version", "params": {}}'
+    handler = SimpleNamespace(
+        headers={
+            "Content-Type": "application/json; charset=utf-8",
+            "Content-Length": str(len(body)),
+        },
+        rfile=io.BytesIO(body),
+    )
+
+    assert host.read_payload(handler) == {"action": "version", "params": {}}

--- a/tests/unit/test_anki_addon_bridge_host.py
+++ b/tests/unit/test_anki_addon_bridge_host.py
@@ -6,6 +6,8 @@ import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
+import pytest
+
 
 def _load_bridge_host_module():
     addon_dir = Path(__file__).resolve().parents[2] / "anki_addon"
@@ -93,3 +95,20 @@ def test_bridge_host_reads_json_request_body():
     )
 
     assert host.read_payload(handler) == {"action": "version", "params": {}}
+
+
+def test_bridge_host_rejects_invalid_content_length():
+    host = AnkiOpsBridgeHost(
+        get_collection=lambda: object(),
+        run_on_main=lambda work: work(),
+    )
+    handler = SimpleNamespace(
+        headers={
+            "Content-Type": "application/json",
+            "Content-Length": "chunked",
+        },
+        rfile=io.BytesIO(b""),
+    )
+
+    with pytest.raises(ValueError, match="Invalid Content-Length header"):
+        host.read_payload(handler)

--- a/tests/unit/test_ankiops_bridge.py
+++ b/tests/unit/test_ankiops_bridge.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import requests
+
+from ankiops.ankiops_bridge import AnkiOpsBridgeClient, AnkiOpsBridgeError
+
+
+def _response(payload):
+    return SimpleNamespace(json=lambda: payload)
+
+
+class _Session:
+    def __init__(self, response=None, error=None):
+        self.response = response
+        self.error = error
+        self.calls = []
+
+    def post(self, url, *, json, timeout):
+        self.calls.append((url, json, timeout))
+        if self.error:
+            raise self.error
+        return self.response
+
+
+def test_bridge_client_version_returns_result():
+    session = _Session(_response({"result": {"version": 1}}))
+    client = AnkiOpsBridgeClient(session=session)
+
+    assert client.version() == {"version": 1}
+    assert session.calls == [
+        (
+            "http://127.0.0.1:8766",
+            {"action": "version", "params": {}},
+            10,
+        )
+    ]
+
+
+def test_bridge_client_change_notes_notetype_sends_feature_payload():
+    session = _Session(_response({"result": {"changed": 2}}))
+    client = AnkiOpsBridgeClient(session=session)
+
+    assert client.change_notes_notetype(
+        [101, 102],
+        "AnkiOpsQA",
+        "collab/o/r/AnkiOpsQA",
+    ) == {"changed": 2}
+    assert session.calls == [
+        (
+            "http://127.0.0.1:8766",
+            {
+                "action": "changeNotesNotetype",
+                "params": {
+                    "noteIds": [101, 102],
+                    "oldModel": "AnkiOpsQA",
+                    "newModel": "collab/o/r/AnkiOpsQA",
+                },
+            },
+            10,
+        )
+    ]
+
+
+def test_bridge_client_raises_structured_error():
+    session = _Session(_response({"error": "boom", "result": None}))
+    client = AnkiOpsBridgeClient(session=session)
+
+    with pytest.raises(AnkiOpsBridgeError, match="boom"):
+        client.version()
+
+
+def test_bridge_client_raises_when_missing():
+    session = _Session(error=requests.ConnectionError("refused"))
+    client = AnkiOpsBridgeClient(session=session)
+
+    with pytest.raises(AnkiOpsBridgeError, match="Unable to reach"):
+        client.version()
+
+
+def test_bridge_client_raises_on_malformed_response():
+    response = SimpleNamespace(json=lambda: (_ for _ in ()).throw(ValueError()))
+    session = _Session(response)
+    client = AnkiOpsBridgeClient(session=session)
+
+    with pytest.raises(AnkiOpsBridgeError, match="non-JSON"):
+        client.version()

--- a/tests/unit/test_collab_commands.py
+++ b/tests/unit/test_collab_commands.py
@@ -33,6 +33,10 @@ def _patch_publish_git(monkeypatch):
 
     monkeypatch.setattr("ankiops.collab._ensure_git_repo", lambda _collection_dir: None)
     monkeypatch.setattr(
+        "ankiops.collab._ensure_clean_git_index",
+        lambda _collection_dir: None,
+    )
+    monkeypatch.setattr(
         "ankiops.collab._ensure_publish_repo",
         lambda collection_dir, source, *, public: calls.append(
             ("ensure_repo", collection_dir, source, public)
@@ -121,6 +125,10 @@ def test_publish_missing_repo_blocks_before_anki_or_file_mutations(
     monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
     monkeypatch.setattr("ankiops.collab._ensure_git_repo", lambda _collection_dir: None)
     monkeypatch.setattr(
+        "ankiops.collab._ensure_clean_git_index",
+        lambda _collection_dir: None,
+    )
+    monkeypatch.setattr(
         "ankiops.collab._ensure_publish_repo",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(
             ValueError("GitHub repository does not exist")
@@ -199,6 +207,10 @@ def test_publish_commit_failure_keeps_source_file(tmp_path, monkeypatch):
     monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
     monkeypatch.setattr("ankiops.collab._ensure_git_repo", lambda _collection_dir: None)
     monkeypatch.setattr(
+        "ankiops.collab._ensure_clean_git_index",
+        lambda _collection_dir: None,
+    )
+    monkeypatch.setattr(
         "ankiops.collab._ensure_publish_repo",
         lambda *_args, **_kwargs: None,
     )
@@ -214,6 +226,61 @@ def test_publish_commit_failure_keeps_source_file(tmp_path, monkeypatch):
     assert not (collection_dir / "collab").exists()
 
 
+def test_publish_dirty_index_blocks_before_file_mutations_and_preserves_stage(
+    tmp_path,
+    monkeypatch,
+):
+    collection_dir = _setup_collection(tmp_path)
+    subprocess.run(["git", "init"], cwd=collection_dir, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.invalid"],
+        cwd=collection_dir,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=collection_dir,
+        check=True,
+    )
+    deck = collection_dir / "Deck.md"
+    original = "<!-- note_key: key-1 -->\nQ: local\nA: deck\n"
+    deck.write_text(original, encoding="utf-8")
+    other = collection_dir / "Other.md"
+    other.write_text("original\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=collection_dir, check=True)
+    subprocess.run(["git", "commit", "-m", "root"], cwd=collection_dir, check=True)
+
+    other.write_text("changed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "Other.md"], cwd=collection_dir, check=True)
+    monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
+    monkeypatch.setattr(
+        "ankiops.collab._ensure_publish_repo",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "ankiops.collab._write_publish_files",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("unexpected write")),
+    )
+    monkeypatch.setattr(
+        "ankiops.collab._cleanup_failed_publish",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("unexpected cleanup")),
+    )
+
+    with pytest.raises(ValueError, match="clean git index"):
+        run_publish(SimpleNamespace(deck="Deck", repo="owner/repo"))
+
+    status = subprocess.run(
+        ["git", "status", "--short"],
+        cwd=collection_dir,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    assert status.stdout == "M  Other.md\n"
+    assert deck.read_text(encoding="utf-8") == original
+    assert not (collection_dir / "collab").exists()
+
+
 def test_publish_subtree_split_failure_keeps_source_file(tmp_path, monkeypatch):
     collection_dir = _setup_collection(tmp_path)
     deck = collection_dir / "Deck.md"
@@ -221,6 +288,10 @@ def test_publish_subtree_split_failure_keeps_source_file(tmp_path, monkeypatch):
     deck.write_text(original, encoding="utf-8")
     monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
     monkeypatch.setattr("ankiops.collab._ensure_git_repo", lambda _collection_dir: None)
+    monkeypatch.setattr(
+        "ankiops.collab._ensure_clean_git_index",
+        lambda _collection_dir: None,
+    )
     monkeypatch.setattr(
         "ankiops.collab._ensure_publish_repo",
         lambda *_args, **_kwargs: None,
@@ -247,6 +318,10 @@ def test_publish_push_failure_keeps_source_file(tmp_path, monkeypatch):
     deck.write_text(original, encoding="utf-8")
     monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
     monkeypatch.setattr("ankiops.collab._ensure_git_repo", lambda _collection_dir: None)
+    monkeypatch.setattr(
+        "ankiops.collab._ensure_clean_git_index",
+        lambda _collection_dir: None,
+    )
     monkeypatch.setattr(
         "ankiops.collab._ensure_publish_repo",
         lambda *_args, **_kwargs: None,

--- a/tests/unit/test_collab_commands.py
+++ b/tests/unit/test_collab_commands.py
@@ -1,0 +1,553 @@
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from ankiops.ankiops_bridge import AnkiOpsBridgeError
+from ankiops.collab import (
+    _ensure_publish_repo,
+    _git_commit_paths,
+    _parse_slug,
+    _subtree_add,
+    _subtree_pull,
+    _subtree_split,
+    run_contribute,
+    run_publish,
+)
+from ankiops.fs import FileSystemAdapter
+from ankiops.markdown_format import NOTE_SEPARATOR
+from ankiops.models import AnkiNote
+from ankiops.sources import SyncSource
+
+
+def _setup_collection(tmp_path):
+    FileSystemAdapter().eject_builtin_note_types(tmp_path / "note_types")
+    (tmp_path / "media").mkdir()
+    return tmp_path
+
+
+def _patch_publish_git(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr("ankiops.collab._ensure_git_repo", lambda _collection_dir: None)
+    monkeypatch.setattr(
+        "ankiops.collab._ensure_publish_repo",
+        lambda collection_dir, source, *, public: calls.append(
+            ("ensure_repo", collection_dir, source, public)
+        ),
+    )
+    monkeypatch.setattr(
+        "ankiops.collab._git_commit_paths",
+        lambda collection_dir, paths, message: calls.append(
+            ("commit", collection_dir, paths, message)
+        ),
+    )
+    monkeypatch.setattr(
+        "ankiops.collab._subtree_split",
+        lambda collection_dir, source: "ankiops-test-branch",
+    )
+
+    def fake_run_git(collection_dir, args):
+        calls.append(("git", collection_dir, args))
+
+    monkeypatch.setattr("ankiops.collab._run_git", fake_run_git)
+    return calls
+
+
+def _empty_anki():
+    anki = MagicMock()
+    anki.fetch_model_names.return_value = []
+    anki.fetch_all_note_ids.return_value = []
+    anki.fetch_notes_info.return_value = {}
+    anki.fetch_cards_info.return_value = {}
+    return anki
+
+
+@pytest.mark.parametrize(
+    ("slug", "expected"),
+    [
+        ("owner/repo", ("owner", "repo")),
+        ("owner-name/repo-name", ("owner-name", "repo-name")),
+        ("o/r", ("o", "r")),
+    ],
+)
+def test_parse_slug_accepts_safe_owner_repo(slug, expected):
+    assert _parse_slug(slug) == expected
+
+
+@pytest.mark.parametrize(
+    "slug",
+    [
+        "owner/Segeln_",
+        "owner/Segeln.",
+        "owner/Segeln+",
+        "owner/-Segeln",
+        "owner/Segeln-",
+        "owner_name/Segeln",
+    ],
+)
+def test_parse_slug_rejects_unsafe_owner_repo(slug):
+    with pytest.raises(ValueError, match="Invalid GitHub repo slug"):
+        _parse_slug(slug)
+
+
+def test_publish_unsynced_deck_moves_files_media_and_note_types(tmp_path, monkeypatch):
+    collection_dir = _setup_collection(tmp_path)
+    deck = collection_dir / "Deck.md"
+    deck.write_text("Q: local\nA: ![img](media/pic.png)\n", encoding="utf-8")
+    (collection_dir / "media" / "pic.png").write_bytes(b"img")
+    anki = _empty_anki()
+    git_calls = _patch_publish_git(monkeypatch)
+    monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
+    monkeypatch.setattr("ankiops.collab.connect_or_exit", lambda: anki)
+
+    run_publish(SimpleNamespace(deck="Deck", repo="owner/repo"))
+
+    collab_root = collection_dir / "collab" / "owner" / "repo"
+    assert not deck.exists()
+    assert (collab_root / "Deck.md").exists()
+    content = (collab_root / "Deck.md").read_text(encoding="utf-8")
+    assert "<!-- note_type: collab/owner/repo/AnkiOpsQA -->" in content
+    assert (collab_root / "media" / "pic.png").read_bytes() == b"img"
+    assert (collab_root / "note_types" / "AnkiOpsQA").is_dir()
+    assert (collab_root / "note_types" / "AnkiOpsStyling.css").exists()
+    assert (collab_root / "note_types" / "SyntaxHighlighting.css").exists()
+    FileSystemAdapter().load_note_type_configs(collab_root / "note_types")
+    anki.change_notes_notetype.assert_not_called()
+    assert any(call[0] == "ensure_repo" and call[3] is False for call in git_calls)
+    assert any(call[0] == "commit" for call in git_calls)
+
+
+def test_publish_missing_repo_blocks_before_anki_or_file_mutations(
+    tmp_path,
+    monkeypatch,
+):
+    collection_dir = _setup_collection(tmp_path)
+    deck = collection_dir / "Deck.md"
+    deck.write_text("Q: local\nA: deck\n", encoding="utf-8")
+    monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
+    monkeypatch.setattr("ankiops.collab._ensure_git_repo", lambda _collection_dir: None)
+    monkeypatch.setattr(
+        "ankiops.collab._ensure_publish_repo",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            ValueError("GitHub repository does not exist")
+        ),
+    )
+    monkeypatch.setattr(
+        "ankiops.collab.connect_or_exit",
+        lambda: (_ for _ in ()).throw(AssertionError("unexpected Anki connect")),
+    )
+
+    with pytest.raises(ValueError, match="GitHub repository does not exist"):
+        run_publish(SimpleNamespace(deck="Deck", repo="owner/repo"))
+
+    assert deck.exists()
+    assert not (collection_dir / "collab").exists()
+
+
+def test_publish_rejects_unsafe_repo_slug_before_git_or_file_mutations(
+    tmp_path,
+    monkeypatch,
+):
+    collection_dir = _setup_collection(tmp_path)
+    deck = collection_dir / "Deck.md"
+    deck.write_text("Q: local\nA: deck\n", encoding="utf-8")
+    monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
+    monkeypatch.setattr(
+        "ankiops.collab._ensure_git_repo",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("unexpected git check")),
+    )
+    monkeypatch.setattr(
+        "ankiops.collab.connect_or_exit",
+        lambda: (_ for _ in ()).throw(AssertionError("unexpected Anki connect")),
+    )
+
+    with pytest.raises(ValueError, match="Invalid GitHub repo slug"):
+        run_publish(SimpleNamespace(deck="Deck", repo="owner/Segeln_"))
+
+    assert deck.exists()
+    assert not (collection_dir / "collab").exists()
+
+
+def test_publish_missing_referenced_media_blocks_before_file_mutations(
+    tmp_path,
+    monkeypatch,
+):
+    collection_dir = _setup_collection(tmp_path)
+    deck = collection_dir / "Deck.md"
+    deck.write_text("Q: local\nA: ![img](media/missing.png)\n", encoding="utf-8")
+    monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
+    monkeypatch.setattr("ankiops.collab._ensure_git_repo", lambda _collection_dir: None)
+
+    with pytest.raises(ValueError, match="referenced media file\\(s\\) missing"):
+        run_publish(SimpleNamespace(deck="Deck", repo="owner/repo"))
+
+    assert deck.exists()
+    assert not (collection_dir / "collab").exists()
+
+
+def test_git_commit_paths_ignores_missing_untracked_source_path(tmp_path):
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.invalid"],
+        cwd=tmp_path,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=tmp_path,
+        check=True,
+    )
+    target = tmp_path / "collab" / "owner" / "repo" / "Segeln.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("Q: moved\nA: deck\n", encoding="utf-8")
+
+    _git_commit_paths(tmp_path, [target, tmp_path / "Segeln.md"], "publish")
+
+    status = subprocess.run(
+        ["git", "status", "--short"],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    assert status.stdout == ""
+
+
+def test_ensure_publish_repo_without_gh_prints_manual_create_command(
+    tmp_path,
+    monkeypatch,
+):
+    source = SyncSource.collab(tmp_path, "owner", "repo")
+    monkeypatch.setattr("ankiops.collab._github_repo_exists", lambda *_args: False)
+    monkeypatch.setattr("ankiops.collab.shutil.which", lambda _name: None)
+
+    with pytest.raises(ValueError, match="gh repo create owner/repo --private"):
+        _ensure_publish_repo(tmp_path, source, public=False)
+
+
+def test_ensure_publish_repo_creates_missing_private_repo_with_gh(
+    tmp_path,
+    monkeypatch,
+):
+    source = SyncSource.collab(tmp_path, "owner", "repo")
+    calls = []
+    monkeypatch.setattr("ankiops.collab._github_repo_exists", lambda *_args: False)
+    monkeypatch.setattr("ankiops.collab.shutil.which", lambda _name: "/bin/gh")
+    monkeypatch.setattr(
+        "ankiops.collab._create_github_repo",
+        lambda collection_dir, source, *, public: calls.append(
+            (collection_dir, source.github_slug, public)
+        ),
+    )
+
+    _ensure_publish_repo(tmp_path, source, public=False)
+
+    assert calls == [(tmp_path, "owner/repo", False)]
+
+
+def test_ensure_publish_repo_creates_missing_public_repo_with_gh(
+    tmp_path,
+    monkeypatch,
+):
+    source = SyncSource.collab(tmp_path, "owner", "repo")
+    calls = []
+    monkeypatch.setattr("ankiops.collab._github_repo_exists", lambda *_args: False)
+    monkeypatch.setattr("ankiops.collab.shutil.which", lambda _name: "/bin/gh")
+    monkeypatch.setattr(
+        "ankiops.collab._create_github_repo",
+        lambda collection_dir, source, *, public: calls.append(
+            (collection_dir, source.github_slug, public)
+        ),
+    )
+
+    _ensure_publish_repo(tmp_path, source, public=True)
+
+    assert calls == [(tmp_path, "owner/repo", True)]
+
+
+def test_publish_synced_deck_creates_scoped_model_and_calls_bridge(
+    tmp_path, monkeypatch
+):
+    collection_dir = _setup_collection(tmp_path)
+    (collection_dir / "Deck.md").write_text(
+        "<!-- note_key: key-1 -->\nQ: local\nA: deck\n",
+        encoding="utf-8",
+    )
+    anki = MagicMock()
+    anki.fetch_all_note_ids.return_value = [100]
+    anki.fetch_notes_info.return_value = {
+        100: AnkiNote(
+            note_id=100,
+            note_type="AnkiOpsQA",
+            fields={"AnkiOps Key": "key-1"},
+            card_ids=[1000],
+        )
+    }
+    anki.fetch_cards_info.return_value = {
+        1000: {"cardId": 1000, "note": 100, "deckName": "Deck"}
+    }
+    anki.fetch_model_names.return_value = ["AnkiOpsQA"]
+    _patch_publish_git(monkeypatch)
+    monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
+    monkeypatch.setattr("ankiops.collab.connect_or_exit", lambda: anki)
+
+    run_publish(SimpleNamespace(deck="Deck", repo="owner/repo"))
+
+    created = anki.create_models.call_args.args[0]
+    assert [config.name for config in created] == ["collab/owner/repo/AnkiOpsQA"]
+    anki.change_notes_notetype.assert_called_once_with(
+        [100],
+        "AnkiOpsQA",
+        "collab/owner/repo/AnkiOpsQA",
+    )
+
+
+def test_publish_shared_model_converts_only_selected_deck_notes(tmp_path, monkeypatch):
+    collection_dir = _setup_collection(tmp_path)
+    (collection_dir / "Deck.md").write_text(
+        "<!-- note_key: key-1 -->\nQ: local\nA: deck\n",
+        encoding="utf-8",
+    )
+    anki = MagicMock()
+    anki.fetch_all_note_ids.return_value = [100, 101]
+    anki.fetch_notes_info.return_value = {
+        100: AnkiNote(
+            note_id=100,
+            note_type="AnkiOpsQA",
+            fields={"AnkiOps Key": "key-1"},
+            card_ids=[1000],
+        ),
+        101: AnkiNote(
+            note_id=101,
+            note_type="AnkiOpsQA",
+            fields={"AnkiOps Key": "other-key"},
+            card_ids=[1001],
+        ),
+    }
+    anki.fetch_cards_info.return_value = {
+        1000: {"cardId": 1000, "note": 100, "deckName": "Deck"},
+        1001: {"cardId": 1001, "note": 101, "deckName": "Other"},
+    }
+    anki.fetch_model_names.return_value = ["AnkiOpsQA"]
+    _patch_publish_git(monkeypatch)
+    monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
+    monkeypatch.setattr("ankiops.collab.connect_or_exit", lambda: anki)
+
+    run_publish(SimpleNamespace(deck="Deck", repo="owner/repo"))
+
+    anki.change_notes_notetype.assert_called_once_with(
+        [100],
+        "AnkiOpsQA",
+        "collab/owner/repo/AnkiOpsQA",
+    )
+
+
+def test_publish_blocks_note_already_scoped_to_different_collab_slug(
+    tmp_path,
+    monkeypatch,
+):
+    collection_dir = _setup_collection(tmp_path)
+    deck = collection_dir / "Deck.md"
+    deck.write_text(
+        "<!-- note_key: key-1 -->\nQ: local\nA: deck\n",
+        encoding="utf-8",
+    )
+    anki = MagicMock()
+    anki.fetch_model_names.return_value = [
+        "AnkiOpsQA",
+        "collab/owner/old/AnkiOpsQA",
+    ]
+    anki.fetch_all_note_ids.return_value = [100]
+    anki.fetch_notes_info.return_value = {
+        100: AnkiNote(
+            note_id=100,
+            note_type="collab/owner/old/AnkiOpsQA",
+            fields={"AnkiOps Key": "key-1"},
+            card_ids=[1000],
+        )
+    }
+    anki.fetch_cards_info.return_value = {
+        1000: {"cardId": 1000, "note": 100, "deckName": "Deck"}
+    }
+    _patch_publish_git(monkeypatch)
+    monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
+    monkeypatch.setattr("ankiops.collab.connect_or_exit", lambda: anki)
+
+    with pytest.raises(ValueError, match="same owner/repo slug"):
+        run_publish(SimpleNamespace(deck="Deck", repo="owner/repo"))
+
+    assert deck.exists()
+    assert not (collection_dir / "collab").exists()
+    anki.change_notes_notetype.assert_not_called()
+
+
+def test_publish_blocks_note_with_cards_inside_and_outside_scope(
+    tmp_path, monkeypatch
+):
+    collection_dir = _setup_collection(tmp_path)
+    deck = collection_dir / "Deck.md"
+    deck.write_text(
+        "<!-- note_key: key-1 -->\nQ: local\nA: deck\n",
+        encoding="utf-8",
+    )
+    anki = MagicMock()
+    anki.fetch_all_note_ids.return_value = [100]
+    anki.fetch_notes_info.return_value = {
+        100: AnkiNote(
+            note_id=100,
+            note_type="AnkiOpsQA",
+            fields={"AnkiOps Key": "key-1"},
+            card_ids=[1000, 1001],
+        )
+    }
+    anki.fetch_cards_info.return_value = {
+        1000: {"cardId": 1000, "note": 100, "deckName": "Deck"},
+        1001: {"cardId": 1001, "note": 100, "deckName": "Other"},
+    }
+    _patch_publish_git(monkeypatch)
+    monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
+    monkeypatch.setattr("ankiops.collab.connect_or_exit", lambda: anki)
+
+    with pytest.raises(ValueError, match="both inside"):
+        run_publish(SimpleNamespace(deck="Deck", repo="owner/repo"))
+
+    assert deck.exists()
+    assert not (collection_dir / "collab").exists()
+
+
+def test_publish_bridge_failure_leaves_files_untouched(tmp_path, monkeypatch):
+    collection_dir = _setup_collection(tmp_path)
+    deck = collection_dir / "Deck.md"
+    deck.write_text(
+        "<!-- note_key: key-1 -->\nQ: local\nA: deck\n",
+        encoding="utf-8",
+    )
+    anki = MagicMock()
+    anki.fetch_all_note_ids.return_value = [100]
+    anki.fetch_notes_info.return_value = {
+        100: AnkiNote(
+            note_id=100,
+            note_type="AnkiOpsQA",
+            fields={"AnkiOps Key": "key-1"},
+            card_ids=[1000],
+        )
+    }
+    anki.fetch_cards_info.return_value = {
+        1000: {"cardId": 1000, "note": 100, "deckName": "Deck"}
+    }
+    anki.fetch_model_names.return_value = ["AnkiOpsQA"]
+    anki.change_notes_notetype.side_effect = AnkiOpsBridgeError("bridge down")
+    _patch_publish_git(monkeypatch)
+    monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
+    monkeypatch.setattr("ankiops.collab.connect_or_exit", lambda: anki)
+
+    with pytest.raises(ValueError, match="bridge down"):
+        run_publish(SimpleNamespace(deck="Deck", repo="owner/repo"))
+
+    assert deck.exists()
+    assert not (collection_dir / "collab").exists()
+
+
+def test_publish_rejects_duplicate_note_keys(tmp_path, monkeypatch):
+    collection_dir = _setup_collection(tmp_path)
+    deck = collection_dir / "Deck.md"
+    deck.write_text(
+        NOTE_SEPARATOR.join(
+            [
+                "<!-- note_key: duplicate -->\nQ: one\nA: one",
+                "<!-- note_key: duplicate -->\nQ: two\nA: two",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    _patch_publish_git(monkeypatch)
+    monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
+
+    with pytest.raises(ValueError, match="Duplicate note_key"):
+        run_publish(SimpleNamespace(deck="Deck", repo="owner/repo"))
+
+    assert deck.exists()
+    assert not (collection_dir / "collab").exists()
+
+
+def test_contribute_rejects_keyless_notes_without_mutating_files(
+    tmp_path,
+    monkeypatch,
+):
+    collection_dir = _setup_collection(tmp_path)
+    collab_root = collection_dir / "collab" / "owner" / "repo"
+    FileSystemAdapter().eject_builtin_note_types(collab_root / "note_types")
+    deck = collab_root / "Deck.md"
+    original = "<!-- note_type: collab/owner/repo/AnkiOpsQA -->\nQ: local\nA: deck\n"
+    deck.write_text(original, encoding="utf-8")
+    monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
+    monkeypatch.setattr("ankiops.collab._ensure_git_repo", lambda _collection_dir: None)
+    monkeypatch.setattr(
+        "ankiops.collab._git_commit_paths",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("unexpected commit")),
+    )
+    monkeypatch.setattr(
+        "ankiops.collab._subtree_split",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("unexpected split")),
+    )
+
+    with pytest.raises(ValueError, match="missing note_key metadata"):
+        run_contribute(SimpleNamespace(repo="owner/repo"))
+
+    assert deck.read_text(encoding="utf-8") == original
+
+
+def test_subtree_commands_use_collab_prefix_and_github_url(tmp_path, monkeypatch):
+    source = SyncSource.collab(tmp_path, "owner", "repo")
+    calls = []
+
+    def fake_run_git(collection_dir, args):
+        calls.append((collection_dir, args))
+
+    monkeypatch.setattr("ankiops.collab._run_git", fake_run_git)
+
+    _subtree_add(tmp_path, source)
+    _subtree_pull(tmp_path, source)
+    branch = _subtree_split(tmp_path, source)
+
+    assert branch.startswith("ankiops-collab-owner-repo-")
+    assert calls[:2] == [
+        (
+            tmp_path,
+            [
+                "subtree",
+                "add",
+                "--prefix",
+                "collab/owner/repo",
+                "https://github.com/owner/repo.git",
+                "main",
+            ],
+        ),
+        (
+            tmp_path,
+            [
+                "subtree",
+                "pull",
+                "--prefix",
+                "collab/owner/repo",
+                "https://github.com/owner/repo.git",
+                "main",
+            ],
+        ),
+    ]
+    assert calls[2] == (
+        tmp_path,
+        [
+            "subtree",
+            "split",
+            "--prefix",
+            "collab/owner/repo",
+            "-b",
+            branch,
+        ],
+    )

--- a/tests/unit/test_collab_commands.py
+++ b/tests/unit/test_collab_commands.py
@@ -214,6 +214,63 @@ def test_publish_commit_failure_keeps_source_file(tmp_path, monkeypatch):
     assert not (collection_dir / "collab").exists()
 
 
+def test_publish_subtree_split_failure_keeps_source_file(tmp_path, monkeypatch):
+    collection_dir = _setup_collection(tmp_path)
+    deck = collection_dir / "Deck.md"
+    original = "<!-- note_key: key-1 -->\nQ: local\nA: deck\n"
+    deck.write_text(original, encoding="utf-8")
+    monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
+    monkeypatch.setattr("ankiops.collab._ensure_git_repo", lambda _collection_dir: None)
+    monkeypatch.setattr(
+        "ankiops.collab._ensure_publish_repo",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "ankiops.collab._git_commit_publish",
+        lambda *_args: None,
+    )
+    monkeypatch.setattr(
+        "ankiops.collab._subtree_split",
+        lambda *_args: (_ for _ in ()).throw(ValueError("split failed")),
+    )
+
+    with pytest.raises(ValueError, match="split failed"):
+        run_publish(SimpleNamespace(deck="Deck", repo="owner/repo"))
+
+    assert deck.read_text(encoding="utf-8") == original
+
+
+def test_publish_push_failure_keeps_source_file(tmp_path, monkeypatch):
+    collection_dir = _setup_collection(tmp_path)
+    deck = collection_dir / "Deck.md"
+    original = "<!-- note_key: key-1 -->\nQ: local\nA: deck\n"
+    deck.write_text(original, encoding="utf-8")
+    monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
+    monkeypatch.setattr("ankiops.collab._ensure_git_repo", lambda _collection_dir: None)
+    monkeypatch.setattr(
+        "ankiops.collab._ensure_publish_repo",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "ankiops.collab._git_commit_publish",
+        lambda *_args: None,
+    )
+    monkeypatch.setattr(
+        "ankiops.collab._subtree_split",
+        lambda *_args: "ankiops-test-branch",
+    )
+
+    def fail_push(_collection_dir, _args):
+        raise ValueError("push failed")
+
+    monkeypatch.setattr("ankiops.collab._run_git", fail_push)
+
+    with pytest.raises(ValueError, match="push failed"):
+        run_publish(SimpleNamespace(deck="Deck", repo="owner/repo"))
+
+    assert deck.read_text(encoding="utf-8") == original
+
+
 def test_git_commit_paths_ignores_missing_untracked_source_path(tmp_path):
     subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
     subprocess.run(

--- a/tests/unit/test_collab_commands.py
+++ b/tests/unit/test_collab_commands.py
@@ -28,6 +28,42 @@ def _setup_collection(tmp_path):
     return tmp_path
 
 
+def _init_git_repo(collection_dir):
+    subprocess.run(["git", "init"], cwd=collection_dir, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.invalid"],
+        cwd=collection_dir,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=collection_dir,
+        check=True,
+    )
+
+
+def _git_head(collection_dir):
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=collection_dir,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _git_status(collection_dir):
+    result = subprocess.run(
+        ["git", "status", "--short"],
+        cwd=collection_dir,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return result.stdout
+
+
 def _patch_publish_git(monkeypatch):
     calls = []
 
@@ -281,24 +317,23 @@ def test_publish_dirty_index_blocks_before_file_mutations_and_preserves_stage(
     assert not (collection_dir / "collab").exists()
 
 
-def test_publish_subtree_split_failure_keeps_source_file(tmp_path, monkeypatch):
+def test_publish_subtree_split_failure_rolls_back_publish_commit(
+    tmp_path,
+    monkeypatch,
+):
     collection_dir = _setup_collection(tmp_path)
+    _init_git_repo(collection_dir)
     deck = collection_dir / "Deck.md"
     original = "<!-- note_key: key-1 -->\nQ: local\nA: deck\n"
     deck.write_text(original, encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=collection_dir, check=True)
+    subprocess.run(["git", "commit", "-m", "root"], cwd=collection_dir, check=True)
+    initial_head = _git_head(collection_dir)
+
     monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
-    monkeypatch.setattr("ankiops.collab._ensure_git_repo", lambda _collection_dir: None)
-    monkeypatch.setattr(
-        "ankiops.collab._ensure_clean_git_index",
-        lambda _collection_dir: None,
-    )
     monkeypatch.setattr(
         "ankiops.collab._ensure_publish_repo",
         lambda *_args, **_kwargs: None,
-    )
-    monkeypatch.setattr(
-        "ankiops.collab._git_commit_publish",
-        lambda *_args: None,
     )
     monkeypatch.setattr(
         "ankiops.collab._subtree_split",
@@ -308,42 +343,66 @@ def test_publish_subtree_split_failure_keeps_source_file(tmp_path, monkeypatch):
     with pytest.raises(ValueError, match="split failed"):
         run_publish(SimpleNamespace(deck="Deck", repo="owner/repo"))
 
+    assert _git_head(collection_dir) == initial_head
+    assert _git_status(collection_dir) == ""
     assert deck.read_text(encoding="utf-8") == original
+    assert not (collection_dir / "collab").exists()
 
 
-def test_publish_push_failure_keeps_source_file(tmp_path, monkeypatch):
+def test_publish_push_failure_rolls_back_publish_commit_and_temp_branch(
+    tmp_path,
+    monkeypatch,
+):
     collection_dir = _setup_collection(tmp_path)
+    _init_git_repo(collection_dir)
     deck = collection_dir / "Deck.md"
     original = "<!-- note_key: key-1 -->\nQ: local\nA: deck\n"
     deck.write_text(original, encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=collection_dir, check=True)
+    subprocess.run(["git", "commit", "-m", "root"], cwd=collection_dir, check=True)
+    initial_head = _git_head(collection_dir)
+    branch = "ankiops-test-branch"
+
     monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
-    monkeypatch.setattr("ankiops.collab._ensure_git_repo", lambda _collection_dir: None)
-    monkeypatch.setattr(
-        "ankiops.collab._ensure_clean_git_index",
-        lambda _collection_dir: None,
-    )
     monkeypatch.setattr(
         "ankiops.collab._ensure_publish_repo",
         lambda *_args, **_kwargs: None,
     )
-    monkeypatch.setattr(
-        "ankiops.collab._git_commit_publish",
-        lambda *_args: None,
-    )
-    monkeypatch.setattr(
-        "ankiops.collab._subtree_split",
-        lambda *_args: "ankiops-test-branch",
-    )
 
-    def fail_push(_collection_dir, _args):
-        raise ValueError("push failed")
+    def fake_split(split_collection_dir, _source):
+        subprocess.run(["git", "branch", branch], cwd=split_collection_dir, check=True)
+        return branch
 
-    monkeypatch.setattr("ankiops.collab._run_git", fail_push)
+    monkeypatch.setattr("ankiops.collab._subtree_split", fake_split)
+
+    def run_git(collection_dir, args):
+        if args[0] == "push":
+            raise ValueError("push failed")
+        return subprocess.run(
+            ["git", *args],
+            cwd=collection_dir,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+
+    monkeypatch.setattr("ankiops.collab._run_git", run_git)
 
     with pytest.raises(ValueError, match="push failed"):
         run_publish(SimpleNamespace(deck="Deck", repo="owner/repo"))
 
+    assert _git_head(collection_dir) == initial_head
+    assert _git_status(collection_dir) == ""
     assert deck.read_text(encoding="utf-8") == original
+    assert not (collection_dir / "collab").exists()
+    branches = subprocess.run(
+        ["git", "branch", "--list", branch],
+        cwd=collection_dir,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    assert branches.stdout == ""
 
 
 def test_git_commit_paths_ignores_missing_untracked_source_path(tmp_path):

--- a/tests/unit/test_collab_commands.py
+++ b/tests/unit/test_collab_commands.py
@@ -2,11 +2,9 @@ from __future__ import annotations
 
 import subprocess
 from types import SimpleNamespace
-from unittest.mock import MagicMock
 
 import pytest
 
-from ankiops.ankiops_bridge import AnkiOpsBridgeError
 from ankiops.collab import (
     _ensure_publish_repo,
     _git_commit_paths,
@@ -21,7 +19,6 @@ from ankiops.collab import (
 )
 from ankiops.fs import FileSystemAdapter
 from ankiops.markdown_format import NOTE_SEPARATOR
-from ankiops.models import AnkiNote
 from ankiops.sources import SyncSource
 
 
@@ -59,15 +56,6 @@ def _patch_publish_git(monkeypatch):
     return calls
 
 
-def _empty_anki():
-    anki = MagicMock()
-    anki.fetch_model_names.return_value = []
-    anki.fetch_all_note_ids.return_value = []
-    anki.fetch_notes_info.return_value = {}
-    anki.fetch_cards_info.return_value = {}
-    return anki
-
-
 @pytest.mark.parametrize(
     ("slug", "expected"),
     [
@@ -99,12 +87,13 @@ def test_parse_slug_rejects_unsafe_owner_repo(slug):
 def test_publish_unsynced_deck_moves_files_media_and_note_types(tmp_path, monkeypatch):
     collection_dir = _setup_collection(tmp_path)
     deck = collection_dir / "Deck.md"
-    deck.write_text("Q: local\nA: ![img](media/pic.png)\n", encoding="utf-8")
+    deck.write_text(
+        "<!-- note_key: key-1 -->\nQ: local\nA: ![img](media/pic.png)\n",
+        encoding="utf-8",
+    )
     (collection_dir / "media" / "pic.png").write_bytes(b"img")
-    anki = _empty_anki()
     git_calls = _patch_publish_git(monkeypatch)
     monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
-    monkeypatch.setattr("ankiops.collab.connect_or_exit", lambda: anki)
 
     run_publish(SimpleNamespace(deck="Deck", repo="owner/repo"))
 
@@ -118,7 +107,6 @@ def test_publish_unsynced_deck_moves_files_media_and_note_types(tmp_path, monkey
     assert (collab_root / "note_types" / "AnkiOpsStyling.css").exists()
     assert (collab_root / "note_types" / "SyntaxHighlighting.css").exists()
     FileSystemAdapter().load_note_type_configs(collab_root / "note_types")
-    anki.change_notes_notetype.assert_not_called()
     assert any(call[0] == "ensure_repo" and call[3] is False for call in git_calls)
     assert any(call[0] == "commit" for call in git_calls)
 
@@ -129,7 +117,7 @@ def test_publish_missing_repo_blocks_before_anki_or_file_mutations(
 ):
     collection_dir = _setup_collection(tmp_path)
     deck = collection_dir / "Deck.md"
-    deck.write_text("Q: local\nA: deck\n", encoding="utf-8")
+    deck.write_text("<!-- note_key: key-1 -->\nQ: local\nA: deck\n", encoding="utf-8")
     monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
     monkeypatch.setattr("ankiops.collab._ensure_git_repo", lambda _collection_dir: None)
     monkeypatch.setattr(
@@ -137,10 +125,6 @@ def test_publish_missing_repo_blocks_before_anki_or_file_mutations(
         lambda *_args, **_kwargs: (_ for _ in ()).throw(
             ValueError("GitHub repository does not exist")
         ),
-    )
-    monkeypatch.setattr(
-        "ankiops.collab.connect_or_exit",
-        lambda: (_ for _ in ()).throw(AssertionError("unexpected Anki connect")),
     )
 
     with pytest.raises(ValueError, match="GitHub repository does not exist"):
@@ -162,11 +146,6 @@ def test_publish_rejects_unsafe_repo_slug_before_git_or_file_mutations(
         "ankiops.collab._ensure_git_repo",
         lambda *_args: (_ for _ in ()).throw(AssertionError("unexpected git check")),
     )
-    monkeypatch.setattr(
-        "ankiops.collab.connect_or_exit",
-        lambda: (_ for _ in ()).throw(AssertionError("unexpected Anki connect")),
-    )
-
     with pytest.raises(ValueError, match="Invalid GitHub repo slug"):
         run_publish(SimpleNamespace(deck="Deck", repo="owner/Segeln_"))
 
@@ -180,7 +159,10 @@ def test_publish_missing_referenced_media_blocks_before_file_mutations(
 ):
     collection_dir = _setup_collection(tmp_path)
     deck = collection_dir / "Deck.md"
-    deck.write_text("Q: local\nA: ![img](media/missing.png)\n", encoding="utf-8")
+    deck.write_text(
+        "<!-- note_key: key-1 -->\nQ: local\nA: ![img](media/missing.png)\n",
+        encoding="utf-8",
+    )
     monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
     monkeypatch.setattr("ankiops.collab._ensure_git_repo", lambda _collection_dir: None)
 
@@ -191,19 +173,35 @@ def test_publish_missing_referenced_media_blocks_before_file_mutations(
     assert not (collection_dir / "collab").exists()
 
 
-def test_publish_commit_failure_keeps_source_file(tmp_path, monkeypatch):
+def test_publish_rejects_missing_note_keys_before_file_mutations(
+    tmp_path,
+    monkeypatch,
+):
     collection_dir = _setup_collection(tmp_path)
     deck = collection_dir / "Deck.md"
-    original = "Q: local\nA: deck\n"
+    deck.write_text("Q: local\nA: deck\n", encoding="utf-8")
+    monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
+    monkeypatch.setattr("ankiops.collab._ensure_git_repo", lambda _collection_dir: None)
+
+    with pytest.raises(ValueError, match="missing note_key metadata"):
+        run_publish(SimpleNamespace(deck="Deck", repo="owner/repo"))
+
+    assert deck.exists()
+    assert not (collection_dir / "collab").exists()
+
+
+def test_publish_commit_failure_keeps_source_file(tmp_path, monkeypatch):
+    collection_dir = _setup_collection(tmp_path)
+    subprocess.run(["git", "init"], cwd=collection_dir, check=True, capture_output=True)
+    deck = collection_dir / "Deck.md"
+    original = "<!-- note_key: key-1 -->\nQ: local\nA: deck\n"
     deck.write_text(original, encoding="utf-8")
-    anki = _empty_anki()
     monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
     monkeypatch.setattr("ankiops.collab._ensure_git_repo", lambda _collection_dir: None)
     monkeypatch.setattr(
         "ankiops.collab._ensure_publish_repo",
         lambda *_args, **_kwargs: None,
     )
-    monkeypatch.setattr("ankiops.collab.connect_or_exit", lambda: anki)
     monkeypatch.setattr(
         "ankiops.collab._git_commit_publish",
         lambda *_args: (_ for _ in ()).throw(ValueError("commit failed")),
@@ -213,7 +211,7 @@ def test_publish_commit_failure_keeps_source_file(tmp_path, monkeypatch):
         run_publish(SimpleNamespace(deck="Deck", repo="owner/repo"))
 
     assert deck.read_text(encoding="utf-8") == original
-    assert (collection_dir / "collab" / "owner" / "repo" / "Deck.md").exists()
+    assert not (collection_dir / "collab").exists()
 
 
 def test_git_commit_paths_ignores_missing_untracked_source_path(tmp_path):
@@ -346,201 +344,6 @@ def test_ensure_publish_repo_creates_missing_public_repo_with_gh(
     _ensure_publish_repo(tmp_path, source, public=True)
 
     assert calls == [(tmp_path, "owner/repo", True)]
-
-
-def test_publish_synced_deck_creates_scoped_model_and_calls_bridge(
-    tmp_path, monkeypatch
-):
-    collection_dir = _setup_collection(tmp_path)
-    (collection_dir / "Deck.md").write_text(
-        "<!-- note_key: key-1 -->\nQ: local\nA: deck\n",
-        encoding="utf-8",
-    )
-    anki = MagicMock()
-    anki.fetch_all_note_ids.return_value = [100]
-    anki.fetch_notes_info.return_value = {
-        100: AnkiNote(
-            note_id=100,
-            note_type="AnkiOpsQA",
-            fields={"AnkiOps Key": "key-1"},
-            card_ids=[1000],
-        )
-    }
-    anki.fetch_cards_info.return_value = {
-        1000: {"cardId": 1000, "note": 100, "deckName": "Deck"}
-    }
-    anki.fetch_model_names.return_value = [
-        "AnkiOpsQA",
-        "AnkiOpsCloze",
-        "Basic",
-        "collab/owner/old/AnkiOpsQA",
-        "collab/owner/old/AnkiOpsCloze",
-    ]
-    _patch_publish_git(monkeypatch)
-    monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
-    monkeypatch.setattr("ankiops.collab.connect_or_exit", lambda: anki)
-
-    run_publish(SimpleNamespace(deck="Deck", repo="owner/repo"))
-
-    anki.fetch_all_note_ids.assert_called_once_with(
-        ["AnkiOpsQA", "collab/owner/old/AnkiOpsQA"]
-    )
-    created = anki.create_models.call_args.args[0]
-    assert [config.name for config in created] == ["collab/owner/repo/AnkiOpsQA"]
-    anki.change_notes_notetype.assert_called_once_with(
-        [100],
-        "AnkiOpsQA",
-        "collab/owner/repo/AnkiOpsQA",
-    )
-
-
-def test_publish_shared_model_converts_only_selected_deck_notes(tmp_path, monkeypatch):
-    collection_dir = _setup_collection(tmp_path)
-    (collection_dir / "Deck.md").write_text(
-        "<!-- note_key: key-1 -->\nQ: local\nA: deck\n",
-        encoding="utf-8",
-    )
-    anki = MagicMock()
-    anki.fetch_all_note_ids.return_value = [100, 101]
-    anki.fetch_notes_info.return_value = {
-        100: AnkiNote(
-            note_id=100,
-            note_type="AnkiOpsQA",
-            fields={"AnkiOps Key": "key-1"},
-            card_ids=[1000],
-        ),
-        101: AnkiNote(
-            note_id=101,
-            note_type="AnkiOpsQA",
-            fields={"AnkiOps Key": "other-key"},
-            card_ids=[1001],
-        ),
-    }
-    anki.fetch_cards_info.return_value = {
-        1000: {"cardId": 1000, "note": 100, "deckName": "Deck"},
-        1001: {"cardId": 1001, "note": 101, "deckName": "Other"},
-    }
-    anki.fetch_model_names.return_value = ["AnkiOpsQA"]
-    _patch_publish_git(monkeypatch)
-    monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
-    monkeypatch.setattr("ankiops.collab.connect_or_exit", lambda: anki)
-
-    run_publish(SimpleNamespace(deck="Deck", repo="owner/repo"))
-
-    anki.change_notes_notetype.assert_called_once_with(
-        [100],
-        "AnkiOpsQA",
-        "collab/owner/repo/AnkiOpsQA",
-    )
-
-
-def test_publish_blocks_note_already_scoped_to_different_collab_slug(
-    tmp_path,
-    monkeypatch,
-):
-    collection_dir = _setup_collection(tmp_path)
-    deck = collection_dir / "Deck.md"
-    deck.write_text(
-        "<!-- note_key: key-1 -->\nQ: local\nA: deck\n",
-        encoding="utf-8",
-    )
-    anki = MagicMock()
-    anki.fetch_model_names.return_value = [
-        "AnkiOpsQA",
-        "collab/owner/old/AnkiOpsQA",
-    ]
-    anki.fetch_all_note_ids.return_value = [100]
-    anki.fetch_notes_info.return_value = {
-        100: AnkiNote(
-            note_id=100,
-            note_type="collab/owner/old/AnkiOpsQA",
-            fields={"AnkiOps Key": "key-1"},
-            card_ids=[1000],
-        )
-    }
-    anki.fetch_cards_info.return_value = {
-        1000: {"cardId": 1000, "note": 100, "deckName": "Deck"}
-    }
-    _patch_publish_git(monkeypatch)
-    monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
-    monkeypatch.setattr("ankiops.collab.connect_or_exit", lambda: anki)
-
-    with pytest.raises(ValueError, match="same owner/repo slug"):
-        run_publish(SimpleNamespace(deck="Deck", repo="owner/repo"))
-
-    anki.fetch_all_note_ids.assert_called_once_with(
-        ["AnkiOpsQA", "collab/owner/old/AnkiOpsQA"]
-    )
-    assert deck.exists()
-    assert not (collection_dir / "collab").exists()
-    anki.change_notes_notetype.assert_not_called()
-
-
-def test_publish_blocks_note_with_cards_inside_and_outside_scope(
-    tmp_path, monkeypatch
-):
-    collection_dir = _setup_collection(tmp_path)
-    deck = collection_dir / "Deck.md"
-    deck.write_text(
-        "<!-- note_key: key-1 -->\nQ: local\nA: deck\n",
-        encoding="utf-8",
-    )
-    anki = MagicMock()
-    anki.fetch_all_note_ids.return_value = [100]
-    anki.fetch_notes_info.return_value = {
-        100: AnkiNote(
-            note_id=100,
-            note_type="AnkiOpsQA",
-            fields={"AnkiOps Key": "key-1"},
-            card_ids=[1000, 1001],
-        )
-    }
-    anki.fetch_cards_info.return_value = {
-        1000: {"cardId": 1000, "note": 100, "deckName": "Deck"},
-        1001: {"cardId": 1001, "note": 100, "deckName": "Other"},
-    }
-    _patch_publish_git(monkeypatch)
-    monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
-    monkeypatch.setattr("ankiops.collab.connect_or_exit", lambda: anki)
-
-    with pytest.raises(ValueError, match="both inside"):
-        run_publish(SimpleNamespace(deck="Deck", repo="owner/repo"))
-
-    assert deck.exists()
-    assert not (collection_dir / "collab").exists()
-
-
-def test_publish_bridge_failure_leaves_files_untouched(tmp_path, monkeypatch):
-    collection_dir = _setup_collection(tmp_path)
-    deck = collection_dir / "Deck.md"
-    deck.write_text(
-        "<!-- note_key: key-1 -->\nQ: local\nA: deck\n",
-        encoding="utf-8",
-    )
-    anki = MagicMock()
-    anki.fetch_all_note_ids.return_value = [100]
-    anki.fetch_notes_info.return_value = {
-        100: AnkiNote(
-            note_id=100,
-            note_type="AnkiOpsQA",
-            fields={"AnkiOps Key": "key-1"},
-            card_ids=[1000],
-        )
-    }
-    anki.fetch_cards_info.return_value = {
-        1000: {"cardId": 1000, "note": 100, "deckName": "Deck"}
-    }
-    anki.fetch_model_names.return_value = ["AnkiOpsQA"]
-    anki.change_notes_notetype.side_effect = AnkiOpsBridgeError("bridge down")
-    _patch_publish_git(monkeypatch)
-    monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
-    monkeypatch.setattr("ankiops.collab.connect_or_exit", lambda: anki)
-
-    with pytest.raises(ValueError, match="bridge down"):
-        run_publish(SimpleNamespace(deck="Deck", repo="owner/repo"))
-
-    assert deck.exists()
-    assert not (collection_dir / "collab").exists()
 
 
 def test_publish_rejects_duplicate_note_keys(tmp_path, monkeypatch):

--- a/tests/unit/test_collab_commands.py
+++ b/tests/unit/test_collab_commands.py
@@ -10,10 +10,12 @@ from ankiops.ankiops_bridge import AnkiOpsBridgeError
 from ankiops.collab import (
     _ensure_publish_repo,
     _git_commit_paths,
+    _git_commit_publish,
     _parse_slug,
     _subtree_add,
     _subtree_pull,
     _subtree_split,
+    _unlink_published_source_files,
     run_contribute,
     run_publish,
 )
@@ -40,9 +42,9 @@ def _patch_publish_git(monkeypatch):
         ),
     )
     monkeypatch.setattr(
-        "ankiops.collab._git_commit_paths",
-        lambda collection_dir, paths, message: calls.append(
-            ("commit", collection_dir, paths, message)
+        "ankiops.collab._git_commit_publish",
+        lambda collection_dir, plan, paths, message: calls.append(
+            ("commit", collection_dir, plan, paths, message)
         ),
     )
     monkeypatch.setattr(
@@ -189,6 +191,31 @@ def test_publish_missing_referenced_media_blocks_before_file_mutations(
     assert not (collection_dir / "collab").exists()
 
 
+def test_publish_commit_failure_keeps_source_file(tmp_path, monkeypatch):
+    collection_dir = _setup_collection(tmp_path)
+    deck = collection_dir / "Deck.md"
+    original = "Q: local\nA: deck\n"
+    deck.write_text(original, encoding="utf-8")
+    anki = _empty_anki()
+    monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
+    monkeypatch.setattr("ankiops.collab._ensure_git_repo", lambda _collection_dir: None)
+    monkeypatch.setattr(
+        "ankiops.collab._ensure_publish_repo",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr("ankiops.collab.connect_or_exit", lambda: anki)
+    monkeypatch.setattr(
+        "ankiops.collab._git_commit_publish",
+        lambda *_args: (_ for _ in ()).throw(ValueError("commit failed")),
+    )
+
+    with pytest.raises(ValueError, match="commit failed"):
+        run_publish(SimpleNamespace(deck="Deck", repo="owner/repo"))
+
+    assert deck.read_text(encoding="utf-8") == original
+    assert (collection_dir / "collab" / "owner" / "repo" / "Deck.md").exists()
+
+
 def test_git_commit_paths_ignores_missing_untracked_source_path(tmp_path):
     subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
     subprocess.run(
@@ -206,6 +233,58 @@ def test_git_commit_paths_ignores_missing_untracked_source_path(tmp_path):
     target.write_text("Q: moved\nA: deck\n", encoding="utf-8")
 
     _git_commit_paths(tmp_path, [target, tmp_path / "Segeln.md"], "publish")
+
+    status = subprocess.run(
+        ["git", "status", "--short"],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    assert status.stdout == ""
+
+
+def test_git_commit_publish_stages_source_removal_before_unlink(tmp_path):
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.invalid"],
+        cwd=tmp_path,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=tmp_path,
+        check=True,
+    )
+    source = tmp_path / "Deck.md"
+    source.write_text("Q: root\nA: deck\n", encoding="utf-8")
+    subprocess.run(["git", "add", "Deck.md"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-m", "root"], cwd=tmp_path, check=True)
+
+    target = tmp_path / "collab" / "owner" / "repo" / "Deck.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("Q: collab\nA: deck\n", encoding="utf-8")
+    plan = SimpleNamespace(files=[SimpleNamespace(source_path=source)])
+
+    _git_commit_publish(
+        tmp_path,
+        plan,
+        [target.parent, target, source],
+        "publish",
+    )
+
+    assert source.exists()
+    show = subprocess.run(
+        ["git", "show", "--name-status", "--format=", "HEAD"],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    assert "D\tDeck.md" in show.stdout
+    assert "A\tcollab/owner/repo/Deck.md" in show.stdout
+
+    _unlink_published_source_files(plan)
 
     status = subprocess.run(
         ["git", "status", "--short"],
@@ -290,13 +369,22 @@ def test_publish_synced_deck_creates_scoped_model_and_calls_bridge(
     anki.fetch_cards_info.return_value = {
         1000: {"cardId": 1000, "note": 100, "deckName": "Deck"}
     }
-    anki.fetch_model_names.return_value = ["AnkiOpsQA"]
+    anki.fetch_model_names.return_value = [
+        "AnkiOpsQA",
+        "AnkiOpsCloze",
+        "Basic",
+        "collab/owner/old/AnkiOpsQA",
+        "collab/owner/old/AnkiOpsCloze",
+    ]
     _patch_publish_git(monkeypatch)
     monkeypatch.setattr("ankiops.collab.require_collection_dir", lambda: collection_dir)
     monkeypatch.setattr("ankiops.collab.connect_or_exit", lambda: anki)
 
     run_publish(SimpleNamespace(deck="Deck", repo="owner/repo"))
 
+    anki.fetch_all_note_ids.assert_called_once_with(
+        ["AnkiOpsQA", "collab/owner/old/AnkiOpsQA"]
+    )
     created = anki.create_models.call_args.args[0]
     assert [config.name for config in created] == ["collab/owner/repo/AnkiOpsQA"]
     anki.change_notes_notetype.assert_called_once_with(
@@ -380,6 +468,9 @@ def test_publish_blocks_note_already_scoped_to_different_collab_slug(
     with pytest.raises(ValueError, match="same owner/repo slug"):
         run_publish(SimpleNamespace(deck="Deck", repo="owner/repo"))
 
+    anki.fetch_all_note_ids.assert_called_once_with(
+        ["AnkiOpsQA", "collab/owner/old/AnkiOpsQA"]
+    )
     assert deck.exists()
     assert not (collection_dir / "collab").exists()
     anki.change_notes_notetype.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "ankiops"
-version = "0.5.10"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds GitHub-native collaboration to AnkiOps, letting users publish decks to public/private repos, subscribe to others' collab sources, pull updates, and contribute edits via PRs. It also introduces note-type conversion (the new `CONVERT` change type) so notes can be migrated between note types during import, backed by a new AnkiOps add-on bridge that performs the conversion directly on Anki's collection.

- `ankiops/collab.py` (829 lines) implements the five `collab` subcommands; `run_publish` has a well-structured try/except with `_cleanup_failed_publish`, but `run_contribute` has no equivalent rollback if `git subtree split` fails after the commit is already written.
- `ankiops/import_notes.py` gains `_NoteTypeConversion` / `_apply_note_type_conversions`; partial failures across multiple model pairs can misreport successfully-converted notes as failed and leave their import fingerprints un-updated until the next sync.
- `ankiops/sources.py`, `note_identity.py`, and the new `anki_addon/bridge_host.py` + `bridge_actions.py` are clean additions with solid test coverage.

<h3>Confidence Score: 4/5</h3>

Safe to merge with awareness that `collab contribute` can leave an orphaned commit when git-subtree split fails

The publish command's error handling is thorough, but contribute's analogous `_subtree_split` call is unguarded: a CalledProcessError leaves a 'AnkiOps: contribute' commit in the user's history with no automated rollback and no hint in the error output that they need to run `git reset HEAD~1` to recover. The rest of the changes are well-covered by the new integration tests.

ankiops/collab.py (`run_contribute`) and ankiops/import_notes.py (`_apply_note_type_conversions`) warrant a second look before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ankiops/collab.py | New 829-line module implementing publish/subscribe/pull/contribute/status collab commands; publish has proper try/except rollback, but contribute leaves an orphaned commit if git-subtree split fails |
| ankiops/import_notes.py | Adds note-type conversion (CONVERT change type) via AnkiOps bridge; partial multi-pair conversion failure reports all entities as failed and skips fingerprint updates for successfully-converted notes |
| ankiops/sources.py | New file defining SyncSource (local/collab) and helpers for discovering, scoping, and loading configs from multiple sync sources; logic is clean and well-tested |
| ankiops/note_identity.py | New file resolving keyed note identity across AnkiConnect and the local DB; handles duplicate detection, embedded key backfill, and pending mapping tracking correctly |
| ankiops/ankiops_bridge.py | New HTTP client for the AnkiOps bridge with clean error handling; module-level singleton is intentional and matches the existing AnkiConnect client pattern |
| anki_addon/bridge_actions.py | Implements changeNotesNotetype with field/template name validation, pre/post conversion snapshot checks, and card scheduling verification; SQL in _card_snapshot uses parameterized queries correctly |
| anki_addon/bridge_host.py | HTTP bridge host with body limit, Content-Length validation (now wrapped in try/except), and main-thread dispatch via threading.Event; all previously flagged concerns have been addressed |
| ankiops/export_notes.py | Extended to discover and load configs from all sync sources; adds deck conflict detection across sources and early-exit on pending note-type conversion errors during export |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI as ankiops CLI
    participant Collab as collab.py
    participant Git
    participant GitHub
    participant Anki
    participant Bridge as AnkiOps Bridge

    Note over User,Bridge: collab publish
    User->>CLI: ankiops collab publish deck owner/repo
    CLI->>Collab: run_publish(args)
    Collab->>Collab: _prepare_publish_plan()
    Collab->>Collab: _write_publish_files()
    Collab->>Git: git commit (removes source files from index)
    Collab->>Git: git subtree split -b branch
    Collab->>GitHub: git push branch:main
    alt success
        Collab->>Collab: _unlink_published_source_files()
    else any step fails
        Collab->>Git: _rollback_publish_commit / git reset
        Collab->>Collab: _remove_publish_source_root()
    end

    Note over User,Bridge: collab contribute
    User->>CLI: ankiops collab contribute owner/repo
    CLI->>Collab: run_contribute(args)
    Collab->>Git: git commit collab/owner/repo
    Collab->>Git: git subtree split -b temp-branch
    Note right of Git: If split fails here, commit is already written with no rollback
    Collab->>GitHub: git push temp-branch
    Collab->>GitHub: gh pr create
```
</details>

<sub>Reviews (8): Last reviewed commit: ["small fixes"](https://github.com/visserle/ankiops/commit/a2d130b2591ee479ff58489be240bedfa873182d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35647676)</sub>

<!-- /greptile_comment -->