### PR TITLE
fix stale subtree index

### DIFF
--- a/ankiops/git.py
+++ b/ankiops/git.py
@@ -65,6 +65,9 @@ class CollectionGit:
             result.check_returncode()
         return result.returncode == 1
 
+    def refresh_index(self) -> None:
+        self.run(["update-index", "-q", "--refresh"], check=False)
+
     def tracked(self, rel_path: str) -> bool:
         return (
             self.run(
@@ -180,6 +183,7 @@ class CollectionGit:
     def _run_subtree(self, source: SyncSource, action: str) -> None:
         if source.github_url is None:
             raise ValueError(f"Cannot derive GitHub URL for {source.display_name}")
+        self.refresh_index()
         self.run(
             [
                 "subtree",

--- a/tests/unit/test_collab_commands.py
+++ b/tests/unit/test_collab_commands.py
@@ -660,7 +660,12 @@ def test_subtree_commands_use_collab_prefix_and_github_url(tmp_path, monkeypatch
     branch = repo.subtree_split(source)
 
     assert branch.startswith("ankiops-collab-owner-repo-")
-    assert calls[:2] == [
+    assert calls[:4] == [
+        (
+            tmp_path,
+            ["update-index", "-q", "--refresh"],
+            False,
+        ),
         (
             tmp_path,
             [
@@ -675,6 +680,11 @@ def test_subtree_commands_use_collab_prefix_and_github_url(tmp_path, monkeypatch
         ),
         (
             tmp_path,
+            ["update-index", "-q", "--refresh"],
+            False,
+        ),
+        (
+            tmp_path,
             [
                 "subtree",
                 "pull",
@@ -686,7 +696,7 @@ def test_subtree_commands_use_collab_prefix_and_github_url(tmp_path, monkeypatch
             True,
         ),
     ]
-    assert calls[2] == (
+    assert calls[4] == (
         tmp_path,
         [
             "subtree",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes stale-index failures that caused `git subtree add` and `git subtree pull` to abort when the stat cache was out of date, by running `git update-index -q --refresh` immediately before each call.

- A new `refresh_index()` method is added to `CollectionGit`; it calls `update-index -q --refresh` with `check=False` so a non-zero exit (e.g., outside a repo) is silently ignored.
- `_run_subtree()` (shared by `subtree_add` and `subtree_pull`) now calls `refresh_index()` before the actual subtree command; `subtree_split` is intentionally left without a refresh because it only reads commit history and does not run `git diff-index`.
- The existing integration-style test is updated to assert the new call order (refresh → subtree operation) for both add and pull, keeping `calls[4]` for the standalone split.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrow, targeted, and well-covered by the updated test.

The fix is a single, well-understood git operation placed exactly where the stale-index problem surfaces. check=False is the right choice because a non-zero exit from the refresh should not block the subsequent command. subtree_split is intentionally skipped since it never calls diff-index. The test verifies the precise call order for both add and pull, and the untouched split path is also exercised.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ankiops/git.py | Adds refresh_index() that runs git update-index -q --refresh and calls it before every subtree add/pull operation to prevent false dirty-index failures from stale stat cache entries. |
| tests/unit/test_collab_commands.py | Updates test_subtree_commands_use_collab_prefix_and_github_url to assert that update-index -q --refresh is emitted before each subtree add and subtree pull call; subtree split (index-read-only) is correctly left without a refresh. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant CollectionGit
    participant Git as git process

    note over Caller,Git: subtree_add / subtree_pull
    Caller->>CollectionGit: subtree_add(source) / subtree_pull(source)
    CollectionGit->>CollectionGit: _run_subtree(source, action)
    CollectionGit->>Git: "update-index -q --refresh (check=False)"
    Git-->>CollectionGit: refresh stat cache, non-zero exit OK
    CollectionGit->>Git: subtree add/pull --prefix ... url branch
    Git-->>CollectionGit: "result (check=True)"
    CollectionGit-->>Caller: done

    note over Caller,Git: subtree_split (no network, no diff-index)
    Caller->>CollectionGit: subtree_split(source)
    CollectionGit->>Git: subtree split --prefix ... -b branch
    Git-->>CollectionGit: "result (check=True)"
    CollectionGit-->>Caller: branch name
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix stale subtree index"](https://github.com/visserle/ankiops/commit/f50429af482837a9b951c3b7683a1887fd8869f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36010779)</sub>

<!-- /greptile_comment -->