### PR TITLE
fix git ops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 collection/
 TODO.md
-docs/
 .vscode/
 
 # Byte-compiled / optimized / DLL files

--- a/ankiops/cli.py
+++ b/ankiops/cli.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import subprocess
+from collections.abc import Sequence
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from types import SimpleNamespace
@@ -33,7 +34,7 @@ from ankiops.log import clickable_path, configure_logging
 from ankiops.models import CollectionResult
 from ankiops.note_type_cli import run as run_note_type
 from ankiops.serializer import (
-    deserialize,
+    apply_deserialization_plan,
     plan_deserialize_from_file,
     serialize_to_file,
 )
@@ -85,52 +86,17 @@ def _has_collab_sources(collection_dir: Path) -> bool:
 
 def _snapshot_paths(
     collection_dir: Path,
-    scoped_paths: list[Path],
+    scoped_paths: Sequence[Path],
     *,
     has_collab_scope: bool = False,
 ) -> list[Path]:
     if has_collab_scope or _has_collab_sources(collection_dir):
         return [collection_dir]
-    return scoped_paths
+    return list(scoped_paths)
 
 
 def _local_markdown_paths(collection_dir: Path) -> list[Path]:
     return sorted(collection_dir.glob("*.md"))
-
-
-def _sync_export_snapshot_paths(collection_dir: Path) -> list[Path]:
-    paths = [*_local_markdown_paths(collection_dir), collection_dir / LOCAL_MEDIA_DIR]
-    return _snapshot_paths(collection_dir, paths)
-
-
-def _sync_import_snapshot_paths(collection_dir: Path) -> list[Path]:
-    paths = [
-        *_local_markdown_paths(collection_dir),
-        collection_dir / LOCAL_MEDIA_DIR,
-        collection_dir / NOTE_TYPES_DIR,
-    ]
-    return _snapshot_paths(collection_dir, paths)
-
-
-def _selected_local_markdown_paths(
-    collection_dir: Path,
-    *,
-    deck: str | None,
-    no_subdecks: bool,
-) -> list[Path]:
-    if not deck:
-        return _local_markdown_paths(collection_dir)
-
-    deck_filter = deck.strip()
-    subdeck_scope = f"{deck_filter}::"
-    selected = []
-    for md_file in _local_markdown_paths(collection_dir):
-        deck_name = file_stem_to_deck_name(md_file.stem)
-        if deck_name == deck_filter:
-            selected.append(md_file)
-        elif not no_subdecks and deck_name.startswith(subdeck_scope):
-            selected.append(md_file)
-    return selected
 
 
 def run_init(args):
@@ -162,7 +128,13 @@ def run_am(args):
         git_snapshot(
             collection_dir,
             action="export",
-            paths=_sync_export_snapshot_paths(collection_dir),
+            paths=_snapshot_paths(
+                collection_dir,
+                [
+                    *_local_markdown_paths(collection_dir),
+                    collection_dir / LOCAL_MEDIA_DIR,
+                ],
+            ),
         )
     else:
         logger.debug("Auto-commit disabled (--no-auto-commit)")
@@ -252,7 +224,14 @@ def run_ma(args):
         git_snapshot(
             collection_dir,
             action="import",
-            paths=_sync_import_snapshot_paths(collection_dir),
+            paths=_snapshot_paths(
+                collection_dir,
+                [
+                    *_local_markdown_paths(collection_dir),
+                    collection_dir / LOCAL_MEDIA_DIR,
+                    collection_dir / NOTE_TYPES_DIR,
+                ],
+            ),
         )
     else:
         logger.debug("Auto-commit disabled (--no-auto-commit)")
@@ -389,11 +368,10 @@ def run_deserialize(args):
     else:
         logger.debug("Auto-commit disabled (--no-auto-commit)")
 
-    deserialize(
-        deserialize_plan.data,
+    apply_deserialization_plan(
+        deserialize_plan,
         overwrite=args.overwrite,
         collection_dir=collection_dir,
-        note_types_dir=collection_dir / NOTE_TYPES_DIR,
     )
 
 
@@ -404,20 +382,26 @@ def run_fix_image_widths(args):
         raise SystemExit(2)
 
     collection_dir = require_collection_dir()
+    selected_paths = _local_markdown_paths(collection_dir)
+    if args.deck:
+        deck_filter = args.deck.strip()
+        subdeck_scope = f"{deck_filter}::"
+        selected_paths = [
+            md_file
+            for md_file in selected_paths
+            if file_stem_to_deck_name(md_file.stem) == deck_filter
+            or (
+                not args.no_subdecks
+                and file_stem_to_deck_name(md_file.stem).startswith(subdeck_scope)
+            )
+        ]
 
     if not args.no_auto_commit:
         logger.debug("Creating pre-image-width-fix git snapshot")
         git_snapshot(
             collection_dir,
             action="fixing image widths",
-            paths=_snapshot_paths(
-                collection_dir,
-                _selected_local_markdown_paths(
-                    collection_dir,
-                    deck=args.deck,
-                    no_subdecks=args.no_subdecks,
-                ),
-            ),
+            paths=_snapshot_paths(collection_dir, selected_paths),
         )
     else:
         logger.debug("Auto-commit disabled (--no-auto-commit)")

--- a/ankiops/cli.py
+++ b/ankiops/cli.py
@@ -11,8 +11,10 @@ from ankiops.anki_client import AnkiConnectionError
 from ankiops.cli_anki import connect_or_exit
 from ankiops.collab import run as run_collab_impl
 from ankiops.config import (
+    LOCAL_MEDIA_DIR,
     NOTE_TYPES_DIR,
     deck_name_to_file_stem,
+    file_stem_to_deck_name,
     require_collection_dir,
 )
 from ankiops.db import SQLiteDbAdapter
@@ -31,7 +33,8 @@ from ankiops.log import clickable_path, configure_logging
 from ankiops.models import CollectionResult
 from ankiops.note_type_cli import run as run_note_type
 from ankiops.serializer import (
-    deserialize_from_file,
+    deserialize,
+    plan_deserialize_from_file,
     serialize_to_file,
 )
 from ankiops.sources import discover_sync_sources, load_configs_for_sources
@@ -72,6 +75,64 @@ def _non_negative_int(value: str) -> int:
     return parsed
 
 
+def _has_collab_sources(collection_dir: Path) -> bool:
+    sources = discover_sync_sources(
+        collection_dir,
+        note_types_dir=collection_dir / NOTE_TYPES_DIR,
+    )
+    return any(source.is_collab for source in sources)
+
+
+def _snapshot_paths(
+    collection_dir: Path,
+    scoped_paths: list[Path],
+    *,
+    has_collab_scope: bool = False,
+) -> list[Path]:
+    if has_collab_scope or _has_collab_sources(collection_dir):
+        return [collection_dir]
+    return scoped_paths
+
+
+def _local_markdown_paths(collection_dir: Path) -> list[Path]:
+    return sorted(collection_dir.glob("*.md"))
+
+
+def _sync_export_snapshot_paths(collection_dir: Path) -> list[Path]:
+    paths = [*_local_markdown_paths(collection_dir), collection_dir / LOCAL_MEDIA_DIR]
+    return _snapshot_paths(collection_dir, paths)
+
+
+def _sync_import_snapshot_paths(collection_dir: Path) -> list[Path]:
+    paths = [
+        *_local_markdown_paths(collection_dir),
+        collection_dir / LOCAL_MEDIA_DIR,
+        collection_dir / NOTE_TYPES_DIR,
+    ]
+    return _snapshot_paths(collection_dir, paths)
+
+
+def _selected_local_markdown_paths(
+    collection_dir: Path,
+    *,
+    deck: str | None,
+    no_subdecks: bool,
+) -> list[Path]:
+    if not deck:
+        return _local_markdown_paths(collection_dir)
+
+    deck_filter = deck.strip()
+    subdeck_scope = f"{deck_filter}::"
+    selected = []
+    for md_file in _local_markdown_paths(collection_dir):
+        deck_name = file_stem_to_deck_name(md_file.stem)
+        if deck_name == deck_filter:
+            selected.append(md_file)
+        elif not no_subdecks and deck_name.startswith(subdeck_scope):
+            selected.append(md_file)
+    return selected
+
+
 def run_init(args):
     """Initialize the current directory as an AnkiOps collection."""
     anki = connect_or_exit()
@@ -98,7 +159,11 @@ def run_am(args):
 
     if not args.no_auto_commit:
         logger.debug("Creating pre-export git snapshot")
-        git_snapshot(collection_dir, "export")
+        git_snapshot(
+            collection_dir,
+            action="export",
+            paths=_sync_export_snapshot_paths(collection_dir),
+        )
     else:
         logger.debug("Auto-commit disabled (--no-auto-commit)")
     fs = FileSystemAdapter()
@@ -184,7 +249,11 @@ def run_ma(args):
 
     if not args.no_auto_commit:
         logger.debug("Creating pre-import git snapshot")
-        git_snapshot(collection_dir, "import")
+        git_snapshot(
+            collection_dir,
+            action="import",
+            paths=_sync_import_snapshot_paths(collection_dir),
+        )
     else:
         logger.debug("Auto-commit disabled (--no-auto-commit)")
 
@@ -301,16 +370,30 @@ def run_deserialize(args):
         raise SystemExit(1)
 
     collection_dir = require_collection_dir()
+    deserialize_plan = plan_deserialize_from_file(
+        serialized_file,
+        collection_dir=collection_dir,
+        note_types_dir=collection_dir / NOTE_TYPES_DIR,
+    )
     if not args.no_auto_commit:
         logger.debug("Creating pre-deserialize git snapshot")
-        git_snapshot(collection_dir, "deserialize")
+        git_snapshot(
+            collection_dir,
+            action="deserializing",
+            paths=_snapshot_paths(
+                collection_dir,
+                deserialize_plan.target_paths,
+                has_collab_scope=deserialize_plan.has_collab_sources,
+            ),
+        )
     else:
         logger.debug("Auto-commit disabled (--no-auto-commit)")
 
-    deserialize_from_file(
-        serialized_file,
+    deserialize(
+        deserialize_plan.data,
         overwrite=args.overwrite,
         collection_dir=collection_dir,
+        note_types_dir=collection_dir / NOTE_TYPES_DIR,
     )
 
 
@@ -324,7 +407,18 @@ def run_fix_image_widths(args):
 
     if not args.no_auto_commit:
         logger.debug("Creating pre-image-width-fix git snapshot")
-        git_snapshot(collection_dir, "fix-image-widths")
+        git_snapshot(
+            collection_dir,
+            action="fixing image widths",
+            paths=_snapshot_paths(
+                collection_dir,
+                _selected_local_markdown_paths(
+                    collection_dir,
+                    deck=args.deck,
+                    no_subdecks=args.no_subdecks,
+                ),
+            ),
+        )
     else:
         logger.debug("Auto-commit disabled (--no-auto-commit)")
 

--- a/ankiops/git.py
+++ b/ankiops/git.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import logging
 import subprocess
+from collections.abc import Sequence
 from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
 from uuid import uuid4
 
@@ -196,8 +196,13 @@ class CollectionGit:
         )
 
 
-def git_snapshot(collection_dir: Path, label: str) -> bool:
-    """Commit all pending changes in the collection directory.
+def git_snapshot(
+    collection_dir: Path,
+    *,
+    action: str,
+    paths: Sequence[Path],
+) -> bool:
+    """Commit pending changes for the supplied collection paths.
 
     Returns True if a commit was created, False otherwise.
     Never raises; logs warnings on failure so sync can proceed.
@@ -208,14 +213,26 @@ def git_snapshot(collection_dir: Path, label: str) -> bool:
             logger.debug("Not a git repository, skipping auto-commit")
             return False
 
-        repo.run(["add", "-A", "."])
-        if not repo.cached_diff_exists():
+        rel_paths = repo._tracked_or_existing_paths(list(paths))
+        if not rel_paths:
+            logger.debug("No scoped paths found, skipping auto-commit")
+            return False
+
+        repo.run(["add", "-A", "--", *rel_paths])
+        if not repo.cached_diff_exists(rel_paths):
             logger.debug("Working tree clean, skipping auto-commit")
             return False
 
-        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M")
-        repo.run(["commit", "-m", f"AnkiOps: pre-{label} snapshot ({timestamp})"])
-        logger.info(f"Auto-committed snapshot before {label}")
+        repo.run(
+            [
+                "commit",
+                "-m",
+                f"AnkiOps: snapshot before {action}",
+                "--",
+                *rel_paths,
+            ]
+        )
+        logger.info(f"Auto-committed snapshot before {action}")
         return True
 
     except subprocess.CalledProcessError as error:

--- a/ankiops/llm/runner.py
+++ b/ankiops/llm/runner.py
@@ -186,6 +186,26 @@ class LlmTaskExecutor:
     async def execute(self) -> LlmJobResult:
         task_context = self.materialized_context
         task = task_context.task
+        logger.debug(
+            "Starting LLM task '%s' (model=%s, collection=%s, deck_scope=%s)",
+            task.name,
+            task.model,
+            self.collection_dir,
+            _format_deck_scope(task),
+        )
+        if not self.no_auto_commit:
+            logger.debug("Creating pre-LLM git snapshot")
+            git_snapshot(
+                self.collection_dir,
+                action=f"LLM task {task.name}",
+                paths=_llm_snapshot_paths(
+                    self.collection_dir,
+                    task_context,
+                ),
+            )
+        else:
+            logger.debug("Auto-commit disabled (--no-auto-commit)")
+
         db = LlmDb.open(self.collection_dir)
         try:
             job_id = db.start_job(
@@ -193,26 +213,6 @@ class LlmTaskExecutor:
                 model=task.model.model,
                 model_id=task.model.model_id,
             )
-            logger.debug(
-                "Starting LLM task '%s' (model=%s, collection=%s, deck_scope=%s)",
-                task.name,
-                task.model,
-                self.collection_dir,
-                _format_deck_scope(task),
-            )
-            if not self.no_auto_commit:
-                logger.debug("Creating pre-LLM git snapshot")
-                git_snapshot(
-                    self.collection_dir,
-                    action=f"LLM task {task.name}",
-                    paths=_llm_snapshot_paths(
-                        self.collection_dir,
-                        task_context,
-                    ),
-                )
-            else:
-                logger.debug("Auto-commit disabled (--no-auto-commit)")
-
             progress_state = _build_progress_state(
                 job_id=job_id,
                 task_name=task.name,

--- a/ankiops/llm/runner.py
+++ b/ankiops/llm/runner.py
@@ -20,7 +20,7 @@ from openai.types.responses import (
     ResponseOutputRefusal,
 )
 
-from ankiops.config import NOTE_TYPES_DIR
+from ankiops.config import NOTE_TYPES_DIR, deck_name_to_file_stem
 from ankiops.git import git_snapshot
 from ankiops.models import ANKIOPS_KEY_FIELD, Note, NoteTypeConfig
 from ankiops.serializer import deserialize, serialize
@@ -202,7 +202,14 @@ class LlmTaskExecutor:
             )
             if not self.no_auto_commit:
                 logger.debug("Creating pre-LLM git snapshot")
-                git_snapshot(self.collection_dir, f"llm:{task.name}")
+                git_snapshot(
+                    self.collection_dir,
+                    action=f"LLM task {task.name}",
+                    paths=_llm_snapshot_paths(
+                        self.collection_dir,
+                        task_context,
+                    ),
+                )
             else:
                 logger.debug("Auto-commit disabled (--no-auto-commit)")
 
@@ -649,6 +656,34 @@ def _load_task(
             )
         raise ValueError(f"Unknown task '{task_name}'")
     return task, {config.name: config for config in note_type_configs}
+
+
+def _llm_snapshot_paths(
+    collection_dir: Path,
+    task_context: MaterializedTaskContext,
+) -> list[Path]:
+    sources = discover_sync_sources(
+        collection_dir,
+        note_types_dir=collection_dir / NOTE_TYPES_DIR,
+    )
+    if any(source.is_collab for source in sources):
+        return [collection_dir]
+
+    if any(
+        item.item_status is LlmItemStatus.QUEUED and item.source != "local"
+        for item in task_context.discovery_snapshot.items
+    ):
+        return [collection_dir]
+
+    deck_names = {
+        item.deck_name
+        for item in task_context.discovery_snapshot.items
+        if item.item_status is LlmItemStatus.QUEUED and item.source == "local"
+    }
+    return [
+        collection_dir / f"{deck_name_to_file_stem(deck_name)}.md"
+        for deck_name in sorted(deck_names)
+    ]
 
 
 def _discover_candidates(

--- a/ankiops/serializer.py
+++ b/ankiops/serializer.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -51,8 +52,8 @@ class _ValidatedDeck:
 
 @dataclass(frozen=True)
 class DeserializationPlan:
-    data: dict[str, Any]
-    target_paths: list[Path]
+    decks: tuple[_ValidatedDeck, ...]
+    target_paths: tuple[Path, ...]
     has_collab_sources: bool
 
 
@@ -291,7 +292,43 @@ def deserialize(
         collection_dir=collection_dir,
         note_types_dir=note_types_dir,
     )
+    _write_validated_decks(
+        decks,
+        collection_dir=collection_dir,
+        overwrite=overwrite,
+        quiet=quiet,
+    )
 
+
+def apply_deserialization_plan(
+    plan: DeserializationPlan,
+    *,
+    collection_dir: Path,
+    overwrite: bool = False,
+    quiet: bool = False,
+) -> None:
+    """Write a previously validated deserialization plan."""
+    logger.debug(f"Target directory: {collection_dir}")
+
+    db_path = collection_dir / ANKIOPS_DB
+    if not db_path.exists():
+        raise ValueError(f"Not an initialized AnkiOps collection: {collection_dir}")
+
+    _write_validated_decks(
+        plan.decks,
+        collection_dir=collection_dir,
+        overwrite=overwrite,
+        quiet=quiet,
+    )
+
+
+def _write_validated_decks(
+    decks: Sequence[_ValidatedDeck],
+    *,
+    collection_dir: Path,
+    overwrite: bool,
+    quiet: bool,
+) -> None:
     total_decks = 0
     total_notes = 0
 
@@ -553,8 +590,8 @@ def plan_deserialize_from_file(
         note_types_dir=note_types_dir,
     )
     return DeserializationPlan(
-        data=data,
-        target_paths=[_deserialize_target_path(deck) for deck in decks],
+        decks=tuple(decks),
+        target_paths=tuple(_deserialize_target_path(deck) for deck in decks),
         has_collab_sources=any(deck.source.is_collab for deck in decks),
     )
 
@@ -582,9 +619,8 @@ def deserialize_from_file(
         collection_dir=collection_dir,
         note_types_dir=resolved_note_types_dir,
     )
-    deserialize(
-        plan.data,
+    apply_deserialization_plan(
+        plan,
         collection_dir=collection_dir,
-        note_types_dir=resolved_note_types_dir,
         overwrite=overwrite,
     )

--- a/ankiops/serializer.py
+++ b/ankiops/serializer.py
@@ -49,6 +49,13 @@ class _ValidatedDeck:
     configs_by_name: dict[str, NoteTypeConfig]
 
 
+@dataclass(frozen=True)
+class DeserializationPlan:
+    data: dict[str, Any]
+    target_paths: list[Path]
+    has_collab_sources: bool
+
+
 def _source_name(source: SyncSource) -> str:
     return source.source_id or LOCAL_SOURCE_NAME
 
@@ -289,7 +296,7 @@ def deserialize(
     total_notes = 0
 
     for deck in decks:
-        output_path = deck.source.root / (deck_name_to_file_stem(deck.name) + ".md")
+        output_path = _deserialize_target_path(deck)
 
         lines = []
         written_notes = 0
@@ -352,6 +359,10 @@ def deserialize(
         logger.debug(summary_message)
     else:
         logger.info(summary_message)
+
+
+def _deserialize_target_path(deck: _ValidatedDeck) -> Path:
+    return deck.source.root / (deck_name_to_file_stem(deck.name) + ".md")
 
 
 def _validate_serialized_data(
@@ -526,6 +537,28 @@ def _validate_serialized_data(
     return validated
 
 
+def plan_deserialize_from_file(
+    json_file: Path,
+    *,
+    collection_dir: Path,
+    note_types_dir: Path,
+) -> DeserializationPlan:
+    with json_file.open("r", encoding="utf-8") as input_handle:
+        data = json.load(input_handle)
+
+    logger.debug(f"Importing serialized data from: {json_file}")
+    decks = _validate_serialized_data(
+        data,
+        collection_dir=collection_dir,
+        note_types_dir=note_types_dir,
+    )
+    return DeserializationPlan(
+        data=data,
+        target_paths=[_deserialize_target_path(deck) for deck in decks],
+        has_collab_sources=any(deck.source.is_collab for deck in decks),
+    )
+
+
 def deserialize_from_file(
     json_file: Path,
     overwrite: bool = False,
@@ -542,14 +575,15 @@ def deserialize_from_file(
         json_file: Path to JSON file to deserialize
         overwrite: If True, overwrite existing markdown files; if False, skip
     """
-    with json_file.open("r", encoding="utf-8") as input_handle:
-        data = json.load(input_handle)
-
-    logger.debug(f"Importing serialized data from: {json_file}")
     collection_dir = collection_dir or get_collection_dir()
     resolved_note_types_dir = note_types_dir or (collection_dir / NOTE_TYPES_DIR)
+    plan = plan_deserialize_from_file(
+        json_file,
+        collection_dir=collection_dir,
+        note_types_dir=resolved_note_types_dir,
+    )
     deserialize(
-        data,
+        plan.data,
         collection_dir=collection_dir,
         note_types_dir=resolved_note_types_dir,
         overwrite=overwrite,

--- a/docs/git_operations.md
+++ b/docs/git_operations.md
@@ -1,0 +1,191 @@
+# Git operations triggered by the AnkiOps CLI
+
+This page lists the Git commands that AnkiOps can run from the `ankiops`
+command line. It covers automatic snapshots, collection initialization, and the
+GitHub-facing collaboration workflow.
+
+The implementation lives mainly in `ankiops/git.py`, with call sites in
+`ankiops/init.py`, `ankiops/cli.py`, `ankiops/llm/runner.py`, and
+`ankiops/collab/`.
+
+## Snapshot convention
+
+AnkiOps uses pre-operation snapshots. A command runs read-only validation or
+planning first, then snapshots the relevant paths, then starts mutating files or
+external state.
+
+Snapshot commits use this subject:
+
+```text
+AnkiOps: snapshot before <action>
+```
+
+Examples:
+
+- `AnkiOps: snapshot before export`
+- `AnkiOps: snapshot before import`
+- `AnkiOps: snapshot before deserializing`
+- `AnkiOps: snapshot before fixing image widths`
+- `AnkiOps: snapshot before LLM task grammar`
+
+## Snapshot Git sequence
+
+Snapshot callers pass an explicit path scope to `git_snapshot`. The scoped
+sequence is:
+
+```text
+git rev-parse --git-dir
+git add -A -- <paths>
+git diff --cached --quiet -- <paths>
+git commit -m "AnkiOps: snapshot before <action>" -- <paths>
+```
+
+When AnkiOps must use the temporary broad fallback, the caller passes the
+collection directory as the only path. That gives Git the collection root as the
+pathspec:
+
+```text
+git add -A -- .
+git diff --cached --quiet -- .
+git commit -m "AnkiOps: snapshot before <action>" -- .
+```
+
+Important behavior:
+
+- Scoped snapshots include pending changes only under the supplied paths.
+- A clean scope creates no commit, even if unrelated files are dirty.
+- Deleted tracked files inside the scope are included.
+- If the directory is not a Git repository, Git is missing, or the commit fails,
+  AnkiOps skips the snapshot or logs a warning and continues.
+- Commands use the broad fallback when collab sources are present. Source-aware
+  collab snapshots are future work.
+
+## Commands that snapshot
+
+| CLI command | Snapshot action | Snapshot scope |
+| --- | --- | --- |
+| `ankiops anki-to-markdown` / `ankiops am` | `export` | Root Markdown deck files plus `media/`. |
+| `ankiops markdown-to-anki` / `ankiops ma` | `import` | Root Markdown deck files plus `media/` and `note_types/`. |
+| `ankiops deserialize` | `deserializing` | Local target Markdown deck files derived from the input JSON after validation. |
+| `ankiops fix-image-widths` | `fixing image widths` | Local Markdown deck files selected by `--deck` and `--no-subdecks`. |
+| `ankiops llm <task> --run` | `LLM task <task>` | Local Markdown deck files containing queued candidate notes. |
+
+Each command accepts `--no-auto-commit` / `-n`, except that LLM only accepts it
+with `<task> --run`.
+
+`ankiops collab pull --to-anki` runs `ankiops ma` after pulling. `ankiops collab
+contribute --from-anki` runs `ankiops am` before preparing the contribution.
+Until collab-aware scoping exists, those nested snapshots use the broad fallback
+when collab sources are present.
+
+## Other Git operations
+
+| CLI command | Git or GitHub operations |
+| --- | --- |
+| `ankiops init` | Checks whether the collection directory is already inside a Git repo with `git rev-parse --git-dir`. If not, runs `git init`. |
+| `ankiops collab publish <deck> <owner>/<repo>` | Requires a Git-backed collection, checks for staged changes, optionally checks or creates the GitHub repo, commits the deck move into `collab/<owner>/<repo>`, splits that subtree to a temporary branch, and pushes it to `main` on the target repo. |
+| `ankiops collab subscribe <owner>/<repo>` | Requires a Git-backed collection and runs `git subtree add` for `https://github.com/<owner>/<repo>.git` at `collab/<owner>/<repo>` from branch `main`. |
+| `ankiops collab pull [owner/repo]` | Requires a Git-backed collection and runs `git subtree pull` for one collab source, or every known collab source when the repo is omitted. |
+| `ankiops collab contribute <owner>/<repo>` | Requires a Git-backed collection, commits changes under `collab/<owner>/<repo>`, splits that subtree to a temporary branch, pushes that branch when possible, and opens a PR with `gh` when available. |
+
+## Collaboration details
+
+All collaboration commands use `collab/<owner>/<repo>` as the local subtree
+prefix and `https://github.com/<owner>/<repo>.git` as the remote URL. The
+collab branch is `main`.
+
+### `collab publish`
+
+`publish` validates that the collection is a Git repo and that the Git index has
+no staged changes:
+
+```text
+git rev-parse --git-dir
+git diff --cached --quiet
+```
+
+It checks whether the target GitHub repository exists. If `gh` is installed, it
+uses `gh repo view <owner>/<repo>` and can create a missing repo with
+`gh repo create <owner>/<repo> --private` or `--public`. Without `gh`, it checks
+the remote with:
+
+```text
+git ls-remote https://github.com/<owner>/<repo>.git
+```
+
+After writing the collab source files, it commits the move:
+
+```text
+git add -A -- <new-collab-paths>
+git rm --cached -f --ignore-unmatch -- <original-deck-paths>
+git diff --cached --quiet
+git commit -m "AnkiOps: publish <deck> to collab/<owner>/<repo>"
+```
+
+Then it publishes the subtree:
+
+```text
+git subtree split --prefix collab/<owner>/<repo> -b ankiops-collab-<owner>-<repo>-<id>
+git push https://github.com/<owner>/<repo>.git <branch>:main
+```
+
+If publish fails after creating a commit or temporary branch, AnkiOps attempts to
+roll back with the appropriate subset of:
+
+```text
+git reset --mixed <initial-head>
+git update-ref -d HEAD
+git branch -D <branch>
+git reset HEAD -- <paths>
+git rm -r --cached --ignore-unmatch -- <paths>
+```
+
+### `collab subscribe`
+
+`subscribe` refreshes the index and adds the GitHub repository as a subtree:
+
+```text
+git rev-parse --git-dir
+git update-index -q --refresh
+git subtree add --prefix collab/<owner>/<repo> https://github.com/<owner>/<repo>.git main
+```
+
+### `collab pull`
+
+`pull` refreshes the index and pulls one or more collab subtrees:
+
+```text
+git rev-parse --git-dir
+git update-index -q --refresh
+git subtree pull --prefix collab/<owner>/<repo> https://github.com/<owner>/<repo>.git main
+```
+
+### `collab contribute`
+
+`contribute` commits local collab source changes, creates a subtree branch, and
+tries to prepare a pull request:
+
+```text
+git rev-parse --git-dir
+git add -A -- collab/<owner>/<repo>
+git diff --cached --quiet -- collab/<owner>/<repo>
+git commit -m "AnkiOps: contribute collab/<owner>/<repo>" -- collab/<owner>/<repo>
+git subtree split --prefix collab/<owner>/<repo> -b ankiops-collab-<owner>-<repo>-<id>
+git push https://github.com/<owner>/<repo>.git <branch>:<branch>
+gh pr create --repo <owner>/<repo> --head <branch> --base main --fill
+```
+
+If `gh` is not installed, or if the push fails, AnkiOps leaves the branch name in
+the log so the user can push it and open a PR manually.
+
+## Commands that do not run Git
+
+The following CLI paths do not trigger Git operations directly:
+
+- `ankiops serialize`
+- `ankiops note-types`
+- `ankiops collab status`
+- `ankiops llm` status output
+- `ankiops llm <task>` dry-run planning
+- `ankiops llm --job <job_id|latest>`
+- `ankiops --help` and `ankiops --version`

--- a/docs/sync-test-contract.md
+++ b/docs/sync-test-contract.md
@@ -1,0 +1,111 @@
+# Sync Test Contract
+
+This document defines the behavior contract that the database and sync test suites must enforce.
+It is intentionally explicit so future changes can be judged against stable expectations.
+
+## Scope
+
+The suite covers note and deck synchronization via:
+
+- `import_collection` (Markdown -> Anki)
+- `export_collection` (Anki -> Markdown)
+- Round-trip flows (`import -> export -> import` and `export -> import -> export`)
+
+The suite must validate behavior for three collection states:
+
+- Fresh collection: no prior mappings and no managed markdown files
+- Running collection: mappings/files exist and are internally consistent
+- Corrupted collection: SQLite mapping DB is unreadable or structurally invalid
+
+## Canonical Source Of Truth
+
+Direction determines the winner when the two sides disagree:
+
+- Import: markdown is canonical
+- Export: Anki is canonical
+- Round-trip: the most recent directional sync defines canonical state
+
+Sync mode is always full-sync in both directions. Partial-sync toggles were removed.
+
+This policy is required to keep behavior deterministic until explicit conflict tracking is implemented.
+
+## Operation Families
+
+Each direction/state combination must cover these operation families.
+
+- Create: note exists only on canonical side and is created on the target side
+- Update: note exists on both sides and canonical fields overwrite target fields
+- Move: note remains the same entity but changes deck/file location
+- Delete: note removed on canonical side is removed from target side
+- Conflict: incompatible concurrent edits requiring explicit policy
+- Drift: metadata or mapping drift between DB, markdown, and Anki state
+
+## Drift Taxonomy
+
+The suite distinguishes drift modes so failures are diagnosable.
+
+- D1 Missing note mapping: note_key exists but DB has no note_key->note_id row
+- D2 Stale note mapping: DB maps note_key->note_id but note_id no longer matches the true note
+- D3 Missing deck mapping: deck exists in Anki but DB has no deck row
+- D4 Stale deck mapping: DB has prior deck name for current deck id (rename)
+- D5 Data loss drift: DB was recreated after corruption and mappings must be rebuilt
+
+## Conflict Taxonomy
+
+- C1 Duplicate `note_key` values in markdown across files
+- C2 Directional content divergence for the same `note_key` (both sides changed)
+- C3 Mapping conflict where one note_id is associated with a different note_key than expected
+
+Current required policy:
+
+- C1 must hard-fail import with a clear error
+- C2 must resolve deterministically by direction (import=markdown wins, export=Anki wins)
+- C3 must not silently duplicate notes
+
+## Core Invariants
+
+All tests in this suite should assert at least one invariant.
+
+1. A managed note has exactly one stable `note_key`.
+2. No operation may duplicate a note for an existing `note_key`.
+3. Import then immediate re-import with no edits is idempotent.
+4. Export then immediate re-export with no edits is idempotent.
+5. Move operations preserve note identity (`note_key`, note id).
+6. Delete operations remove stale entities from the target side.
+7. Deck rename operations keep content but update filename and deck mapping.
+8. DB corruption recovery creates `<db>.corrupt` backup and resumes with a clean DB.
+9. After corruption recovery, mappings can be rebuilt from embedded `AnkiOps Key`.
+10. Round-trip cycles do not introduce unexpected creates/updates/deletes.
+
+## Scenario Naming
+
+Scenario IDs use this shape:
+
+`<DIR>-<STATE>-<OP>-<NNN>`
+
+- `DIR`: `IMP`, `EXP`, `RT`
+- `STATE`: `FRESH`, `RUN`, `CORR`
+- `OP`: `CREATE`, `UPDATE`, `MOVE`, `DELETE`, `CONFLICT`, `DRIFT`
+- `NNN`: sequence number
+
+Examples:
+
+- `IMP-FRESH-CREATE-001`
+- `EXP-RUN-DRIFT-003`
+- `RT-CORR-DELETE-002`
+
+## Minimum Matrix For Phase 1
+
+Phase 1 must include deterministic tests for:
+
+- 3 directions (`IMP`, `EXP`, `RT`)
+- 3 states (`FRESH`, `RUN`, `CORR`)
+- 7 operation families (`CREATE`, `UPDATE`, `MOVE`, `DELETE`, `CONFLICT`, `DRIFT`, `RENAME`)
+
+Target: 63 deterministic scenarios.
+
+## Gating
+
+- Conflict/drift behaviors not implemented yet should be represented with `xfail(strict=True)`.
+- Once implementation lands, flip to required-pass tests and remove `xfail`.
+- This suite is a release gate for sync/database changes.

--- a/tests/integration/cli/test_cli_sync.py
+++ b/tests/integration/cli/test_cli_sync.py
@@ -1,5 +1,6 @@
 """CLI sync behavior tests."""
 
+import json
 import logging
 from pathlib import Path
 from types import SimpleNamespace
@@ -17,6 +18,7 @@ from ankiops.cli import (
     run_serialize,
 )
 from ankiops.config import ANKIOPS_DB, deck_name_to_file_stem
+from ankiops.fs import FileSystemAdapter
 from ankiops.image_widths import ImageWidthFixResult
 from ankiops.models import (
     Change,
@@ -135,12 +137,20 @@ def test_run_ma_logs_import_errors_with_actionable_details(tmp_path, caplog):
 
 
 def test_run_ma_auto_commit_runs_before_media_sync(tmp_path):
+    (tmp_path / "Deck.md").write_text("Q: old\nA: old\n", encoding="utf-8")
     fake_anki = MagicMock()
     fake_anki.get_active_profile.return_value = "TestProfile"
     args = SimpleNamespace(no_auto_commit=False)
     order: list[str] = []
 
-    def _record_git(*_args, **_kwargs):
+    def _record_git(collection_dir, *, action, paths):
+        assert collection_dir == tmp_path
+        assert action == "import"
+        assert paths == [
+            tmp_path / "Deck.md",
+            tmp_path / "media",
+            tmp_path / "note_types",
+        ]
         order.append("git")
         return True
 
@@ -170,6 +180,33 @@ def test_run_ma_auto_commit_runs_before_media_sync(tmp_path):
         run_ma(args)
 
     assert order == ["git", "media", "note_types", "import"]
+
+
+def test_run_am_auto_commit_scopes_markdown_and_media(tmp_path):
+    (tmp_path / "Deck.md").write_text("Q: old\nA: old\n", encoding="utf-8")
+    fake_anki = MagicMock()
+    fake_anki.get_active_profile.return_value = "TestProfile"
+    args = SimpleNamespace(no_auto_commit=False)
+    media_result = SyncResult.for_media()
+
+    with (
+        patch("ankiops.cli.connect_or_exit", return_value=fake_anki),
+        patch("ankiops.cli.require_collection_dir", return_value=tmp_path),
+        patch("ankiops.cli.SQLiteDbAdapter.open", return_value=MagicMock()),
+        patch("ankiops.cli.git_snapshot") as snapshot_mock,
+        patch(
+            "ankiops.cli.export_collection",
+            return_value=CollectionResult.for_export(results=[], extra_changes=[]),
+        ),
+        patch("ankiops.cli.sync_media_from_anki", return_value=media_result),
+    ):
+        run_am(args)
+
+    snapshot_mock.assert_called_once_with(
+        tmp_path,
+        action="export",
+        paths=[tmp_path / "Deck.md", tmp_path / "media"],
+    )
 
 
 def test_run_ma_logs_media_status_in_normal_mode(tmp_path, caplog):
@@ -392,8 +429,19 @@ def test_run_serialize_rejects_no_subdecks_without_deck(tmp_path):
 
 
 def test_run_deserialize_snapshots_by_default(tmp_path):
+    FileSystemAdapter().eject_builtin_note_types(tmp_path / "note_types")
+    (tmp_path / "Other.md").write_text("unrelated\n", encoding="utf-8")
     json_file = tmp_path / "in.json"
-    json_file.write_text('{"decks": []}', encoding="utf-8")
+    payload = {
+        "decks": [
+            {
+                "source": "local",
+                "name": "Target",
+                "notes": [],
+            }
+        ]
+    }
+    json_file.write_text(json.dumps(payload), encoding="utf-8")
     args = SimpleNamespace(
         input=str(json_file),
         overwrite=True,
@@ -403,15 +451,20 @@ def test_run_deserialize_snapshots_by_default(tmp_path):
     with (
         patch("ankiops.cli.require_collection_dir", return_value=tmp_path),
         patch("ankiops.cli.git_snapshot") as snapshot_mock,
-        patch("ankiops.cli.deserialize_from_file") as deserialize_mock,
+        patch("ankiops.cli.deserialize") as deserialize_mock,
     ):
         run_deserialize(args)
 
-    snapshot_mock.assert_called_once_with(tmp_path, "deserialize")
+    snapshot_mock.assert_called_once_with(
+        tmp_path,
+        action="deserializing",
+        paths=[tmp_path / "Target.md"],
+    )
     deserialize_mock.assert_called_once_with(
-        json_file,
+        payload,
         overwrite=True,
         collection_dir=tmp_path,
+        note_types_dir=tmp_path / "note_types",
     )
 
 
@@ -427,19 +480,23 @@ def test_run_deserialize_can_skip_snapshot(tmp_path):
     with (
         patch("ankiops.cli.require_collection_dir", return_value=tmp_path),
         patch("ankiops.cli.git_snapshot") as snapshot_mock,
-        patch("ankiops.cli.deserialize_from_file") as deserialize_mock,
+        patch("ankiops.cli.deserialize") as deserialize_mock,
     ):
         run_deserialize(args)
 
     snapshot_mock.assert_not_called()
     deserialize_mock.assert_called_once_with(
-        json_file,
+        {"decks": []},
         overwrite=False,
         collection_dir=tmp_path,
+        note_types_dir=tmp_path / "note_types",
     )
 
 
 def test_run_fix_image_widths_passes_deck_scope_and_snapshots(tmp_path):
+    (tmp_path / "Parent.md").write_text("Q: old\nA: old\n", encoding="utf-8")
+    (tmp_path / "Parent__Child.md").write_text("Q: child\nA: child\n", encoding="utf-8")
+    (tmp_path / "Other.md").write_text("Q: other\nA: other\n", encoding="utf-8")
     args = SimpleNamespace(
         deck="Parent",
         no_subdecks=True,
@@ -466,7 +523,11 @@ def test_run_fix_image_widths_passes_deck_scope_and_snapshots(tmp_path):
     ):
         run_fix_image_widths(args)
 
-    snapshot_mock.assert_called_once_with(tmp_path, "fix-image-widths")
+    snapshot_mock.assert_called_once_with(
+        tmp_path,
+        action="fixing image widths",
+        paths=[tmp_path / "Parent.md"],
+    )
     fix_mock.assert_called_once_with(
         tmp_path,
         deck="Parent",
@@ -499,6 +560,34 @@ def test_run_fix_image_widths_can_skip_snapshot_and_logs_sync_reminder(
     snapshot_mock.assert_not_called()
     assert "Only Markdown files were edited" in caplog.text
     assert "ankiops ma" in caplog.text
+
+
+def test_run_fix_image_widths_uses_broad_snapshot_with_collab_sources(tmp_path):
+    (tmp_path / "Deck.md").write_text("Q: old\nA: old\n", encoding="utf-8")
+    (tmp_path / "collab" / "owner" / "repo").mkdir(parents=True)
+    args = SimpleNamespace(
+        deck=None,
+        no_subdecks=False,
+        tolerance=5,
+        width=None,
+        no_auto_commit=False,
+    )
+
+    with (
+        patch("ankiops.cli.require_collection_dir", return_value=tmp_path),
+        patch("ankiops.cli.git_snapshot") as snapshot_mock,
+        patch(
+            "ankiops.cli.fix_image_widths_collection",
+            return_value=ImageWidthFixResult(),
+        ),
+    ):
+        run_fix_image_widths(args)
+
+    snapshot_mock.assert_called_once_with(
+        tmp_path,
+        action="fixing image widths",
+        paths=[tmp_path],
+    )
 
 
 def test_run_fix_image_widths_rejects_no_subdecks_without_deck(tmp_path):

--- a/tests/integration/cli/test_cli_sync.py
+++ b/tests/integration/cli/test_cli_sync.py
@@ -451,7 +451,7 @@ def test_run_deserialize_snapshots_by_default(tmp_path):
     with (
         patch("ankiops.cli.require_collection_dir", return_value=tmp_path),
         patch("ankiops.cli.git_snapshot") as snapshot_mock,
-        patch("ankiops.cli.deserialize") as deserialize_mock,
+        patch("ankiops.cli.apply_deserialization_plan") as deserialize_mock,
     ):
         run_deserialize(args)
 
@@ -460,11 +460,12 @@ def test_run_deserialize_snapshots_by_default(tmp_path):
         action="deserializing",
         paths=[tmp_path / "Target.md"],
     )
+    plan = deserialize_mock.call_args.args[0]
+    assert plan.target_paths == (tmp_path / "Target.md",)
     deserialize_mock.assert_called_once_with(
-        payload,
+        plan,
         overwrite=True,
         collection_dir=tmp_path,
-        note_types_dir=tmp_path / "note_types",
     )
 
 
@@ -480,16 +481,17 @@ def test_run_deserialize_can_skip_snapshot(tmp_path):
     with (
         patch("ankiops.cli.require_collection_dir", return_value=tmp_path),
         patch("ankiops.cli.git_snapshot") as snapshot_mock,
-        patch("ankiops.cli.deserialize") as deserialize_mock,
+        patch("ankiops.cli.apply_deserialization_plan") as deserialize_mock,
     ):
         run_deserialize(args)
 
     snapshot_mock.assert_not_called()
+    plan = deserialize_mock.call_args.args[0]
+    assert plan.target_paths == ()
     deserialize_mock.assert_called_once_with(
-        {"decks": []},
+        plan,
         overwrite=False,
         collection_dir=tmp_path,
-        note_types_dir=tmp_path / "note_types",
     )
 
 

--- a/tests/unit/llm/test_runner_execution.py
+++ b/tests/unit/llm/test_runner_execution.py
@@ -6,6 +6,7 @@ import asyncio
 from dataclasses import replace
 from types import SimpleNamespace
 
+from ankiops.llm.llm_db import LlmDb
 from ankiops.llm.model_registry import ModelSpec
 from ankiops.llm.runner import (
     LlmTaskExecutor,
@@ -240,6 +241,50 @@ def test_executor_snapshots_queued_deck_paths(
     assert snapshot_calls == [
         (tmp_path, "LLM task grammar", [tmp_path / "Deck.md"])
     ]
+
+
+def test_executor_snapshots_before_opening_llm_db(
+    tmp_path,
+    monkeypatch,
+    llm_qa_config,
+):
+    context = _context(llm_qa_config)
+    events = []
+    real_open = LlmDb.open
+
+    async def fake_call_openai(*, batch, **_kwargs):
+        return _success(
+            _parsed_response(("nk-1", "Question", "Fixed question")),
+            input_tokens=12,
+            output_tokens=6,
+        )
+
+    def fake_deserialize(*_args, **_kwargs):
+        pass
+
+    def record_open(collection_dir):
+        events.append("db_open")
+        return real_open(collection_dir)
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr("ankiops.llm.runner.AsyncOpenAI", _FakeAsyncOpenAI)
+    monkeypatch.setattr("ankiops.llm.runner._call_openai", fake_call_openai)
+    monkeypatch.setattr("ankiops.llm.runner.deserialize", fake_deserialize)
+    monkeypatch.setattr("ankiops.llm.runner.LlmDb.open", staticmethod(record_open))
+    monkeypatch.setattr(
+        "ankiops.llm.runner.git_snapshot",
+        lambda *_args, **_kwargs: events.append("snapshot") or True,
+    )
+
+    asyncio.run(
+        LlmTaskExecutor(
+            collection_dir=tmp_path,
+            materialized_context=context,
+            no_auto_commit=False,
+        ).execute()
+    )
+
+    assert events[:2] == ["snapshot", "db_open"]
 
 
 def test_executor_uses_broad_snapshot_when_collab_source_exists(

--- a/tests/unit/llm/test_runner_execution.py
+++ b/tests/unit/llm/test_runner_execution.py
@@ -199,6 +199,91 @@ def test_executor_persists_successful_updates(
     assert persisted["data"]["decks"][0]["notes"][0]["tags"] == ["keep-me"]
 
 
+def test_executor_snapshots_queued_deck_paths(
+    tmp_path,
+    monkeypatch,
+    llm_qa_config,
+):
+    context = _context(llm_qa_config)
+    snapshot_calls = []
+
+    async def fake_call_openai(*, batch, **_kwargs):
+        return _success(
+            _parsed_response(("nk-1", "Question", "Fixed question")),
+            input_tokens=12,
+            output_tokens=6,
+        )
+
+    def fake_deserialize(*_args, **_kwargs):
+        pass
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr("ankiops.llm.runner.AsyncOpenAI", _FakeAsyncOpenAI)
+    monkeypatch.setattr("ankiops.llm.runner._call_openai", fake_call_openai)
+    monkeypatch.setattr("ankiops.llm.runner.deserialize", fake_deserialize)
+    monkeypatch.setattr(
+        "ankiops.llm.runner.git_snapshot",
+        lambda collection_dir, *, action, paths: snapshot_calls.append(
+            (collection_dir, action, paths)
+        )
+        or True,
+    )
+
+    asyncio.run(
+        LlmTaskExecutor(
+            collection_dir=tmp_path,
+            materialized_context=context,
+            no_auto_commit=False,
+        ).execute()
+    )
+
+    assert snapshot_calls == [
+        (tmp_path, "LLM task grammar", [tmp_path / "Deck.md"])
+    ]
+
+
+def test_executor_uses_broad_snapshot_when_collab_source_exists(
+    tmp_path,
+    monkeypatch,
+    llm_qa_config,
+):
+    context = _context(llm_qa_config)
+    snapshot_calls = []
+    (tmp_path / "collab" / "owner" / "repo").mkdir(parents=True)
+
+    async def fake_call_openai(*, batch, **_kwargs):
+        return _success(
+            _parsed_response(("nk-1", "Question", "Fixed question")),
+            input_tokens=12,
+            output_tokens=6,
+        )
+
+    def fake_deserialize(*_args, **_kwargs):
+        pass
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr("ankiops.llm.runner.AsyncOpenAI", _FakeAsyncOpenAI)
+    monkeypatch.setattr("ankiops.llm.runner._call_openai", fake_call_openai)
+    monkeypatch.setattr("ankiops.llm.runner.deserialize", fake_deserialize)
+    monkeypatch.setattr(
+        "ankiops.llm.runner.git_snapshot",
+        lambda collection_dir, *, action, paths: snapshot_calls.append(
+            (collection_dir, action, paths)
+        )
+        or True,
+    )
+
+    asyncio.run(
+        LlmTaskExecutor(
+            collection_dir=tmp_path,
+            materialized_context=context,
+            no_auto_commit=False,
+        ).execute()
+    )
+
+    assert snapshot_calls == [(tmp_path, "LLM task grammar", [tmp_path])]
+
+
 def test_executor_persists_successful_tag_updates(
     tmp_path,
     monkeypatch,

--- a/tests/unit/test_git.py
+++ b/tests/unit/test_git.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import subprocess
+
+from ankiops.git import git_snapshot
+
+
+def _init_git_repo(collection_dir):
+    subprocess.run(["git", "init"], cwd=collection_dir, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.invalid"],
+        cwd=collection_dir,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=collection_dir,
+        check=True,
+    )
+
+
+def _commit_all(collection_dir, message):
+    subprocess.run(["git", "add", "."], cwd=collection_dir, check=True)
+    subprocess.run(["git", "commit", "-m", message], cwd=collection_dir, check=True)
+
+
+def _git_status(collection_dir):
+    result = subprocess.run(
+        ["git", "status", "--short"],
+        cwd=collection_dir,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def _git_head(collection_dir):
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=collection_dir,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _head_subject(collection_dir):
+    result = subprocess.run(
+        ["git", "log", "-1", "--format=%s"],
+        cwd=collection_dir,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _head_name_status(collection_dir):
+    result = subprocess.run(
+        ["git", "show", "--name-status", "--format=", "HEAD"],
+        cwd=collection_dir,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def test_git_snapshot_commits_only_scoped_paths(tmp_path):
+    _init_git_repo(tmp_path)
+    scoped = tmp_path / "Deck.md"
+    outside = tmp_path / "Other.md"
+    scoped.write_text("old\n", encoding="utf-8")
+    outside.write_text("old\n", encoding="utf-8")
+    _commit_all(tmp_path, "root")
+
+    scoped.write_text("new\n", encoding="utf-8")
+    outside.write_text("new\n", encoding="utf-8")
+
+    assert git_snapshot(tmp_path, action="test", paths=[scoped])
+
+    assert _head_subject(tmp_path) == "AnkiOps: snapshot before test"
+    show = _head_name_status(tmp_path)
+    assert "M\tDeck.md" in show
+    assert "Other.md" not in show
+    assert _git_status(tmp_path) == " M Other.md\n"
+
+
+def test_git_snapshot_commits_deleted_tracked_scoped_path(tmp_path):
+    _init_git_repo(tmp_path)
+    deck = tmp_path / "Deck.md"
+    deck.write_text("old\n", encoding="utf-8")
+    _commit_all(tmp_path, "root")
+
+    deck.unlink()
+
+    assert git_snapshot(tmp_path, action="delete test", paths=[deck])
+    assert "D\tDeck.md" in _head_name_status(tmp_path)
+    assert _git_status(tmp_path) == ""
+
+
+def test_git_snapshot_skips_clean_scope(tmp_path):
+    _init_git_repo(tmp_path)
+    scoped = tmp_path / "Deck.md"
+    outside = tmp_path / "Other.md"
+    scoped.write_text("old\n", encoding="utf-8")
+    outside.write_text("old\n", encoding="utf-8")
+    _commit_all(tmp_path, "root")
+    initial_head = _git_head(tmp_path)
+
+    outside.write_text("new\n", encoding="utf-8")
+
+    assert not git_snapshot(tmp_path, action="clean test", paths=[scoped])
+    assert _git_head(tmp_path) == initial_head
+    assert _git_status(tmp_path) == " M Other.md\n"
+
+
+def test_git_snapshot_collection_path_keeps_broad_behavior(tmp_path):
+    _init_git_repo(tmp_path)
+    first = tmp_path / "Deck.md"
+    second = tmp_path / "Other.md"
+    first.write_text("old\n", encoding="utf-8")
+    second.write_text("old\n", encoding="utf-8")
+    _commit_all(tmp_path, "root")
+
+    first.write_text("new\n", encoding="utf-8")
+    second.write_text("new\n", encoding="utf-8")
+
+    assert git_snapshot(tmp_path, action="broad test", paths=[tmp_path])
+
+    show = _head_name_status(tmp_path)
+    assert "M\tDeck.md" in show
+    assert "M\tOther.md" in show
+    assert _git_status(tmp_path) == ""


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes git snapshot operations to use explicit path scoping instead of staging and committing the entire collection on every operation. It also splits deserialization into a plan-then-apply pattern so target file paths are known before the snapshot runs.

- `git_snapshot` now accepts an `action` keyword and a `paths` sequence; each call site passes only the markdown files and directories relevant to that operation (or falls back to the whole collection root when collab sources are present).
- `DeserializationPlan` / `plan_deserialize_from_file` / `apply_deserialization_plan` are introduced so `run_deserialize` can derive snapshot paths from validated data before touching the filesystem.
- The LLM-runner snapshot is moved before `LlmDb.open()`, ensuring the pre-operation state is captured before any DB mutation.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are well-scoped refactors with matching unit and integration test coverage.

The snapshot-scoping logic is thoroughly exercised: real-git unit tests cover scoped commits, deleted-file handling, clean-scope skipping, and broad-scope fallback; CLI integration tests assert the exact keyword arguments and path lists passed to `git_snapshot` for every command. The plan/apply deserialization split correctly preserves the validate-before-write ordering, and the LLM-runner snapshot-before-db-open reordering is confirmed by a dedicated ordering test. No logic errors or missing edge cases were found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ankiops/git.py | Refactored `git_snapshot` to require `action` and `paths` kwargs; uses `_tracked_or_existing_paths` to convert absolute paths to relative strings, stages and commits only those paths, and correctly falls back to a no-op when nothing matches. |
| ankiops/cli.py | Each snapshot call now passes a scoped path list; helper `_snapshot_paths` / `_has_collab_sources` / `_local_markdown_paths` encapsulate the scope-selection logic. `run_deserialize` uses the new plan-then-apply pattern. |
| ankiops/serializer.py | Introduces `DeserializationPlan`, `plan_deserialize_from_file`, and `apply_deserialization_plan`; writing logic extracted to `_write_validated_decks` and `_deserialize_target_path`; `deserialize_from_file` now delegates to the new plan/apply pair. |
| ankiops/llm/runner.py | Snapshot moved before `LlmDb.open()` to capture pre-mutation state; `_llm_snapshot_paths` computes scoped deck file paths from the task's queued items, with collab and non-local item fallbacks. |
| tests/unit/test_git.py | New test file covering scoped commits, deleted-file commits, clean-scope skipping, and broad-scope (collection-root path) behavior with real `git` subprocesses. |
| tests/integration/cli/test_cli_sync.py | Updated existing snapshot tests to assert the new keyword-argument signature and scoped paths; added new tests for the am export scope, collab broad-fallback, and the deserialize plan/apply split. |
| tests/unit/llm/test_runner_execution.py | Three new tests verify: queued-deck path scoping, snapshot-before-db-open ordering, and broad-scope fallback when a collab source exists. |
| docs/git_operations.md | New doc describing snapshot conventions, per-command scope tables, and the full Git command sequences used by each CLI path. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CLI as CLI / LlmTaskExecutor
    participant Planner as plan_deserialize_from_file
    participant Validator as _validate_serialized_data
    participant Git as git_snapshot
    participant Writer as apply_deserialization_plan

    CLI->>Planner: plan_deserialize_from_file(json_file, collection_dir, note_types_dir)
    Planner->>Validator: _validate_serialized_data(data, ...)
    Validator-->>Planner: [_ValidatedDeck, ...]
    Planner-->>CLI: DeserializationPlan(decks, target_paths, has_collab_sources)

    alt no_auto_commit is False
        CLI->>Git: "git_snapshot(collection_dir, action="deserializing", paths=target_paths)"
        Note over Git: git add -A -- scoped paths
        Git-->>CLI: True / False
    end

    CLI->>Writer: apply_deserialization_plan(plan, overwrite, collection_dir)
    Writer-->>CLI: None
```
</details>

<sub>Reviews (2): Last reviewed commit: ["add docs dir"](https://github.com/visserle/ankiops/commit/66c9c9f81d99760f8c8ebf38ade2bc806716c7a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37175525)</sub>

<!-- /greptile_comment -->