### PR TITLE
Harden GitHub Actions workflows and add import recovery coverage

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build distribution
@@ -17,11 +20,17 @@ jobs:
         with:
           python-version-file: ".python-version"
 
-      - name: Install build
-        run: python -m pip install build
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.10.7"
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
 
       - name: Build distributions
-        run: python -m build
+        run: uv build --no-sources
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,13 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -21,9 +28,10 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           version: "0.10.7"
-
-      - name: Sync dependencies
-        run: uv sync --frozen
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
 
       - name: Run tests
-        run: uv run pytest tests/ -v
+        run: uv run --frozen pytest tests/ -v

--- a/tests/integration/sync/test_sync_corruption.py
+++ b/tests/integration/sync/test_sync_corruption.py
@@ -36,8 +36,42 @@ def test_corr_db_002_import_continues_after_db_recovery(world):
         assert len(world.mock_anki.notes) == 1
 
 
-def test_corr_db_003_schema_corruption_is_auto_recovered(tmp_path):
+def test_corr_db_003_import_rebuilds_mapping_from_embedded_key(world):
     """CORR-DB-003."""
+    note_key = "corr-import-rebind"
+    note_id = world.add_qa_note(
+        deck_name="RecoveredImportDeck",
+        question="Recover Q",
+        answer="Old A",
+        note_key=note_key,
+    )
+    world.write_qa_deck("RecoveredImportDeck", [("Recover Q", "New A", note_key)])
+
+    with world.db_session() as db:
+        db.upsert_note_links([(note_key, note_id)])
+
+    world.corrupt_db()
+
+    with world.db_session() as recovered:
+        assert recovered.resolve_note_ids([note_key]).get(note_key) is None
+
+        result = world.sync_import(recovered)
+
+        assert_summary(
+            result.summary, created=0, updated=1, moved=0, deleted=0, errors=0
+        )
+        assert len(world.mock_anki.notes) == 1
+        assert note_id in world.mock_anki.notes
+        assert (
+            world.mock_anki.notes[note_id]["fields"]["Answer"]["value"] == "New A"
+        )
+        assert recovered.resolve_note_ids([note_key]).get(note_key) == note_id
+
+    assert (world.root / f"{ANKIOPS_DB}.corrupt").exists()
+
+
+def test_corr_db_004_schema_corruption_is_auto_recovered(tmp_path):
+    """CORR-DB-004."""
     db_path = tmp_path / ANKIOPS_DB
 
     conn = sqlite3.connect(db_path)


### PR DESCRIPTION
## Summary
- Add explicit `contents: read` permissions to the publish and test workflows.
- Tighten CI execution with workflow concurrency cancellation on pull requests.
- Switch publish builds to `uv build --no-sources` and reuse uv cache setup in CI.
- Extend sync corruption coverage to verify note-link rebuilding from embedded keys after DB recovery.

## Testing
- Not run (not requested)
- Added integration coverage for corrupted DB recovery and import remapping behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens both GitHub Actions workflows with explicit `contents: read` permissions and uv cache reuse, adds PR-level concurrency cancellation in the test workflow, and extends the corruption recovery test suite with a new scenario that verifies note-link rebuilding from embedded keys after a DB loss.

- **`publish.yml`**: Drops the legacy `pip install build` bootstrap in favour of `astral-sh/setup-uv@v7`, switching the build command to `uv build --no-sources` so path-dependency sources are excluded from published artifacts.
- **`test.yml`**: Merges `uv sync --frozen` + `uv run pytest` into a single `uv run --frozen pytest` invocation, adds uv cache configuration, and scopes in-progress cancellation to PR events only (pushes to `main` always complete).
- **`test_sync_corruption.py`**: Introduces `CORR-DB-003` which seeds a note with an embedded `AnkiOps Key`, corrupts the DB, and asserts that `sync_import` can recover the note-ID mapping from the key embedded in the Anki note field — no duplicate notes created, answer updated correctly, and the `.corrupt` backup file exists afterwards.

<h3>Confidence Score: 5/5</h3>

Safe to merge — workflow changes tighten permissions and improve caching without altering test logic, and the new test exercises a well-defined recovery path using existing helper infrastructure.

All three changed files make additive, targeted improvements. The workflow changes follow established GitHub Actions best practices (explicit permission scoping, concurrency groups, uv cache). Collapsing `uv sync --frozen` + `uv run pytest` into `uv run --frozen pytest` is a semantically equivalent simplification. The new test is structurally consistent with the existing CORR-DB suite and its assertions cover the full recovery lifecycle.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/publish.yml | Added workflow-level `contents: read` permission and replaced `pip install build` + `python -m build` with `astral-sh/setup-uv@v7` + `uv build --no-sources`; job-level `id-token: write` on the publish job correctly overrides workflow-level permissions (no capability gap). |
| .github/workflows/test.yml | Added `contents: read`, concurrency cancellation for PRs, and uv cache configuration; the separate `uv sync --frozen` step is collapsed into `uv run --frozen pytest`, which is functionally equivalent in CI. |
| tests/integration/sync/test_sync_corruption.py | Added CORR-DB-003 covering note-link rebuild from embedded key after DB recovery; former CORR-DB-003 correctly renumbered to CORR-DB-004 with its docstring updated. |

</details>

<sub>Reviews (1): Last reviewed commit: ["improve gh workflows"](https://github.com/visserle/ankiops/commit/3111cab07215d99b52887e3d0103baa19c2a8856) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37236570)</sub>

<!-- /greptile_comment -->