### PR TITLE
fix rich link logging

### DIFF
--- a/ankiops/collab/commands.py
+++ b/ankiops/collab/commands.py
@@ -6,6 +6,8 @@ import logging
 import re
 from pathlib import Path
 
+from rich.markup import escape as rich_escape
+
 from ankiops.collab.hosting import open_pr_if_possible
 from ankiops.collab.publish import publish_deck
 from ankiops.config import require_collection_dir
@@ -111,7 +113,12 @@ def run_subscribe(args) -> None:
     if source.root.exists():
         raise ValueError(f"Collab source already exists: {source.source_id}")
     repo.subtree_add(source)
-    logger.info("Subscribed to %s at %s", args.repo, clickable_path(source.root))
+    logger.info(
+        "Subscribed to %s at %s",
+        rich_escape(args.repo),
+        clickable_path(source.root),
+        extra={"markup": True},
+    )
 
 
 def run_pull(args) -> None:
@@ -161,7 +168,12 @@ def run_status(args) -> None:
         logger.info("No collab sources found.")
         return
     for source in sources:
-        logger.info("%s  %s", source.source_id, clickable_path(source.root))
+        logger.info(
+            "%s  %s",
+            rich_escape(source.source_id),
+            clickable_path(source.root),
+            extra={"markup": True},
+        )
 
 
 def run(args) -> None:

--- a/tests/unit/test_collab_commands.py
+++ b/tests/unit/test_collab_commands.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import logging
 import subprocess
 from types import SimpleNamespace
 
 import pytest
 
-from ankiops.collab import run_contribute, run_publish
+from ankiops.collab import run_contribute, run_publish, run_status
 from ankiops.collab.commands import _parse_slug
 from ankiops.collab.hosting import ensure_publish_repo
 from ankiops.collab.publish import _unlink_published_source_files
@@ -93,6 +94,24 @@ def test_parse_slug_accepts_safe_owner_repo(slug, expected):
 def test_parse_slug_rejects_unsafe_owner_repo(slug):
     with pytest.raises(ValueError, match="Invalid GitHub repo slug"):
         _parse_slug(slug)
+
+
+def test_status_logs_clickable_paths_as_rich_markup(tmp_path, monkeypatch, caplog):
+    collab_root = tmp_path / "collab" / "[owner]" / "repo"
+    collab_root.mkdir(parents=True)
+    monkeypatch.setattr(
+        "ankiops.collab.commands.require_collection_dir",
+        lambda: tmp_path,
+    )
+
+    with caplog.at_level(logging.INFO, logger="ankiops.collab.commands"):
+        run_status(SimpleNamespace())
+
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert getattr(record, "markup") is True
+    assert "collab/\\[owner]/repo" in record.getMessage()
+    assert f"[link={collab_root.resolve().as_uri()}]repo[/link]" in record.getMessage()
 
 
 def test_publish_unsynced_deck_moves_files_media_and_note_types(tmp_path, monkeypatch):


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Rich markup logging by adding `rich_escape()` around user-controlled string arguments and opting each log record into markup rendering via `extra={\"markup\": True}`. Without this, `clickable_path()` output — which returns `[link=…]…[/link]` Rich markup — was rendered as literal text by the handler (which defaults to `markup=False`), and any path components containing `[` or `]` characters would have caused markup parse errors at the display layer once rendering was enabled.

- `run_subscribe` and `run_status` now escape their first format argument with `rich_escape()` and pass `extra={\"markup\": True}` so the `clickable_path()` hyperlink markup is properly rendered.
- A new unit test for `run_status` verifies that a collab directory with bracket characters in its owner name (e.g., `[owner]`) produces a log record with `markup=True`, the brackets escaped as `\\[owner]`, and a correct `[link=…]` tag from `clickable_path()`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrow, the fix is correct, and the new test exercises the exact failure scenario that motivated the PR.

Both changed call sites correctly escape user-controlled strings before enabling markup, and the new test exercises the tricky case of bracket characters in a filesystem path component. The only loose end is that `run_subscribe` receives the same treatment but has no dedicated test added; however, `args.repo` is validated upstream by `_parse_slug` to contain only alphanumerics and hyphens, so there are no markup-sensitive characters in that argument in practice.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ankiops/collab/commands.py | Adds `rich_escape()` on user-controlled log arguments and enables per-record markup in `run_subscribe` and `run_status`; the rest of the file is unchanged. |
| tests/unit/test_collab_commands.py | Adds `test_status_logs_clickable_paths_as_rich_markup` covering the escape and markup flag on `run_status`; `run_subscribe` does not get a parallel test. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Cmd as commands.py
    participant Log as logging (RichHandler)
    participant Rich as Rich renderer

    Note over Log: Handler configured with markup=False (global)

    Cmd->>Cmd: rich_escape(source.source_id)
    Note right of Cmd: e.g. collab/[owner]/repo → collab/\[owner]/repo
    Cmd->>Cmd: clickable_path(source.root)
    Note right of Cmd: returns [link=file:///…]repo[/link]
    Cmd->>Log: "logger.info("%s  %s", escaped_id, link_markup, extra={"markup": True})"
    Note over Log: LogRecord.markup = True overrides handler default
    Log->>Rich: "emit(record) with markup=True"
    Rich->>Rich: "Parses [link=…] as hyperlink"
    Rich->>Rich: Renders \[owner] as literal [owner]
    Rich-->>Log: Terminal output with clickable link
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix rich link logging"](https://github.com/visserle/ankiops/commit/fb240c6fe5c91fe8b0037b48215f02768c29cad8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37240781)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->