### PR TITLE
Enable compact HTML table markdown output

### DIFF
--- a/ankiops/html_converter.py
+++ b/ankiops/html_converter.py
@@ -286,18 +286,15 @@ def _enforce_link_angle_brackets(md: str) -> str:
 class HTMLToMarkdown:
     """Convert HTML to clean Markdown."""
 
-    @staticmethod
-    def _build_options() -> ConversionOptions:
-        return ConversionOptions(
-            heading_style="atx",
-            bullets="-",
-            list_indent_width=3,
-            highlight_style="double-equal",
-            autolinks=False,
-            extract_metadata=False,
-        )
-
-    _OPTIONS = _build_options.__func__()
+    _OPTIONS = ConversionOptions(
+        heading_style="atx",
+        bullets="-",
+        list_indent_width=3,
+        highlight_style="double-equal",
+        autolinks=False,
+        compact_tables=True,
+        extract_metadata=False,
+    )
 
     def convert(self, html: str) -> str:
         """Convert HTML to Markdown."""
@@ -345,7 +342,7 @@ class HTMLToMarkdown:
             .replace("\u2260", "=/=")
         )
 
-        def _normalize_code_blocks(match):
+        def _normalize_code_blocks(match: re.Match[str]) -> str:
             content = match.group(1)
             if not content.strip():
                 return ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 dependencies = [
     "beautifulsoup4>=4.14.3",
     "blake3>=1.0.8",
-    "html-to-markdown>=3.4.0",
+    "html-to-markdown>=3.5.0,!=3.6.0",
     "mistune>=3.2.0",
     "openai>=2.36.0",
     "pydantic>=2.13.4",

--- a/tests/unit/conversion/test_converters.py
+++ b/tests/unit/conversion/test_converters.py
@@ -52,7 +52,9 @@ def test_links_with_parentheses_are_wrapped_for_stable_roundtrips(
     markdown = "[Wiki](https://example.com/Python_(programming_language))"
 
     html = md_to_html.convert(markdown)
-    assert html == '<a href="https://example.com/Python_(programming_language)">Wiki</a>'
+    assert (
+        html == '<a href="https://example.com/Python_(programming_language)">Wiki</a>'
+    )
     assert (
         html_to_md.convert(html)
         == "[Wiki](<https://example.com/Python_(programming_language)>)"
@@ -172,6 +174,26 @@ def test_underlines_remain_explicit_html(md_to_html, html_to_md):
 
     assert markdown == "<u>underlined</u>"
     assert md_to_html.convert(markdown) == "<u>underlined</u>"
+
+
+def test_html_tables_export_in_compact_markdown(html_to_md):
+    html = (
+        "<table><thead><tr><th>Short</th><th>Long heading</th></tr></thead>"
+        "<tbody><tr><td>a</td><td>bbb</td></tr></tbody></table>"
+    )
+
+    assert html_to_md.convert(html) == (
+        "| Short | Long heading |\n| --- | --- |\n| a | bbb |"
+    )
+
+
+def test_html_table_escaped_pipes_stay_in_their_cells(html_to_md):
+    html = (
+        "<table><tr><th>A</th><th>B</th></tr>"
+        "<tr><td>a | b</td><td><code>c | d</code></td></tr></table>"
+    )
+
+    assert html_to_md.convert(html) == "| A | B |\n| --- | --- |\n| a \\| b | `c | d` |"
 
 
 def test_python_code_blocks_keep_language_and_text(md_to_html, html_to_md):

--- a/uv.lock
+++ b/uv.lock
@@ -33,7 +33,7 @@ dev = [
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "blake3", specifier = ">=1.0.8" },
-    { name = "html-to-markdown", specifier = ">=3.4.0" },
+    { name = "html-to-markdown", specifier = ">=3.5.0,!=3.6.0" },
     { name = "mistune", specifier = ">=3.2.0" },
     { name = "openai", specifier = ">=2.36.0" },
     { name = "pydantic", specifier = ">=2.13.4" },
@@ -323,15 +323,15 @@ wheels = [
 
 [[package]]
 name = "html-to-markdown"
-version = "3.4.0"
+version = "3.5.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ae/30/a4aa8f9c9febf6096b0d14e3fa3559a8e100802fa81bd67deb8a8031c14d/html_to_markdown-3.4.0.tar.gz", hash = "sha256:3e7e0813cc871c7abe2d5ea927e9038374bea339e8dd72f3b4c2f1c0b8e51672", size = 283028, upload-time = "2026-05-09T11:07:49.784Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/e5/bc0e6e6787f49dd37953406941260bb7ed2f8de0c403d450d20b08a3901f/html_to_markdown-3.5.7.tar.gz", hash = "sha256:f2eb59a614830da827e6dcac0aa253d2613735cd104429323682751ecd79b0da", size = 4394226, upload-time = "2026-05-29T14:25:09.944Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/57/24c42910133dfac8eb82115cb2141b91616c82020df135ba9b63dc73cf2a/html_to_markdown-3.4.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:58c98e3fe34b81c767096567ba91992e6ae4e66e272c490d308467ea0a1778d6", size = 6032604, upload-time = "2026-05-09T11:07:40.225Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/ae/d3b4769193d2ffba87a8089aceb790050cc276cfa5ec115033473c3b0414/html_to_markdown-3.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4f8e444a9f47ff25fcfe1dde42a9123a8e7619b556c22e99d3c9ddb06236b4e7", size = 5678905, upload-time = "2026-05-09T11:07:42.184Z" },
-    { url = "https://files.pythonhosted.org/packages/98/83/39ce1eb03fcdab852cc1e7a3d19ae93131d80892f52c3cef344df005b987/html_to_markdown-3.4.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7679a0815688bd86326d73760d653e6ed53d43bf4312c3fc71992f62e4427832", size = 5838301, upload-time = "2026-05-09T11:07:44.157Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/cb/23e17d7695b4fd56c9da9ce4dc90c4d96e558b96776a2af68ab4483ea38c/html_to_markdown-3.4.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:57090642966c1ec67ccb851387c63c9c500153d23f0b9bf81e64ff01c46ca1d1", size = 6205593, upload-time = "2026-05-09T11:07:46.307Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/57/2009607007027b0e8581796a51546246b1a475ce2f35c63a2eff45aafa83/html_to_markdown-3.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:85ef60342922074227936ece6f6746836d50a17fc38ec6cb4bba6a12810b38c5", size = 6226485, upload-time = "2026-05-09T11:07:47.878Z" },
+    { url = "https://files.pythonhosted.org/packages/77/de/3ce5f55ae5163a2d53a616190a2c13d0cf3f96dad50e8c9804237f6f2baa/html_to_markdown-3.5.7-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:4641c566abff4a5faa5a49d2dc4b21b1bf73480f53f45eb9b45b1983fb0dea5d", size = 6092338, upload-time = "2026-05-29T14:25:02.282Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/ca/89fd1ad259591656517a86e702e18c348b145fbc8550708bed9c4325bb58/html_to_markdown-3.5.7-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:0c253e440864a01519031073a534b3838393f6aea6f88957bdf3546f3ee97325", size = 5736293, upload-time = "2026-05-29T14:25:03.962Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f1/585666b4665156fe2c6183e5a5ca8c512822a1c2c9757ae6ce4b281f735c/html_to_markdown-3.5.7-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f7c9f67c84abb1b86858743b6caed4e714dc32cc4e0ed28bd31aa17ed74eb30e", size = 5890957, upload-time = "2026-05-29T14:25:05.453Z" },
+    { url = "https://files.pythonhosted.org/packages/61/31/e6d7bb7de03570d4622790e90b6519ddac1ee7c943cc3e9eb73327dd8272/html_to_markdown-3.5.7-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0b35cd7e8d0b7687f2c974f8fcaf962c3965248bcfcee740858a2a33833fb67b", size = 6262247, upload-time = "2026-05-29T14:25:08.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/7e/26a0a7b74fcffe5e9f3c0a648888bb59aad1bc2efff290e99e4469502d5f/html_to_markdown-3.5.7-cp310-abi3-win_amd64.whl", hash = "sha256:a0eaa429bd3a5b5301a60fde594288c9624ab7791a2f356af4f7b5495b756094", size = 6285999, upload-time = "2026-05-29T14:25:06.984Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Turn on compact table conversion in the HTML to Markdown pipeline
- Pin `html-to-markdown` to a version that supports the new table behavior while avoiding 3.6.0
- Add regression coverage for compact table formatting and escaped pipe handling

## Testing
- Added unit tests for table export formatting and cell content preservation
- Not run (not requested)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables compact (non-padded) Markdown table output in the HTML-to-Markdown conversion pipeline by adding `compact_tables=True` to `ConversionOptions`, and pins the `html-to-markdown` dependency to `>=3.5.0,!=3.6.0` where the feature was introduced. The `_OPTIONS` initialization is also simplified from an unusual `_build_options.__func__()` pattern to a plain class-level constant.

- Adds `compact_tables=True` to `HTMLToMarkdown._OPTIONS`, producing `| --- |` separators instead of padded `| ----------- |` ones; two new unit tests cover the compact output and pipe-escaping within cells.
- Updates `html-to-markdown` from `>=3.4.0` to `>=3.5.0,!=3.6.0` and resolves the lock file to `3.5.7`.
- Improves the `_normalize_code_blocks` inner function signature with explicit `re.Match[str] -> str` type hints (minor quality improvement).

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is small and focused, with direct test coverage for the new behavior.

The only open question is the !=3.6.0 point exclusion in pyproject.toml — the reason is not documented and there is no upper bound, so a future breaking release would not be caught. The core logic change (compact_tables=True) is straightforward and well-covered by the two new unit tests.

pyproject.toml — the version exclusion rationale is worth clarifying.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ankiops/html_converter.py | Adds `compact_tables=True` to conversion options and simplifies the `_OPTIONS` class variable initialization; also tightens type annotation on `_normalize_code_blocks`. |
| pyproject.toml | Updates `html-to-markdown` constraint to `>=3.5.0,!=3.6.0`; single-point exclusion of 3.6.0 with no upper bound leaves future version regressions unguarded. |
| tests/unit/conversion/test_converters.py | Adds two well-targeted tests: one for compact separator formatting and one for pipe-escaping in plain vs. code-span table cells. |
| uv.lock | Lock file updated from `html-to-markdown` 3.4.0 to 3.5.7; all wheel hashes look consistent with the PyPI release. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[HTML input] --> B{looks like HTML?}
    B -- yes --> C[protect literal chars\nreplace special chars with placeholders]
    B -- no --> D[pass through as-is]
    C --> E[prepare custom tag placeholders\nimg and u and br become tokens]
    E --> F[convert_html_to_markdown\nConversionOptions with compact_tables=True]
    F --> G[restore custom tag placeholders]
    G --> H[enforce link angle brackets]
    H --> I[restore escaped chars\nplaceholders become backslash-escaped chars]
    D --> I
    I --> J[post-processing\nNBSP, arrows, code blocks, collapse newlines]
    J --> K[Compact Markdown output\ncolumns use minimal dashes not padded]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Enable compact HTML table markdown"](https://github.com/visserle/ankiops/commit/0316aeb7934fdb5553a3fdf5f611dedd6f80ce66) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37299694)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->