### PR TITLE
Suppress empty media sync cache logs

### DIFF
--- a/ankiops/sync_media.py
+++ b/ankiops/sync_media.py
@@ -118,10 +118,11 @@ def _collect_referenced_media(
 
     if updates:
         db_port.upsert_markdown_media_cache(updates)
-    logger.debug(
-        f"Media refs cache: {cache_hits} hits, {cache_misses} misses "
-        f"across {len(md_files)} markdown files"
-    )
+    if md_files:
+        logger.debug(
+            f"Media refs cache: {cache_hits} hits, {cache_misses} misses "
+            f"across {len(md_files)} markdown files"
+        )
     return referenced
 
 
@@ -238,10 +239,11 @@ def hash_and_update_references(
     if fingerprint_removals:
         db_port.delete_media_state(fingerprint_removals)
 
-    logger.debug(
-        f"Media hash cache: {hash_cache_hits} hits, {hash_cache_misses} misses "
-        f"across {len(cache_candidates)} candidate files"
-    )
+    if cache_candidates:
+        logger.debug(
+            f"Media hash cache: {hash_cache_hits} hits, {hash_cache_misses} misses "
+            f"across {len(cache_candidates)} candidate files"
+        )
 
     # 3. Update Markdown files in bulk
     if rename_map:
@@ -395,7 +397,12 @@ def sync_media_to_anki(
     if removed_names:
         db_port.delete_media_state(removed_names)
 
-    logger.debug(f"Skipped {skipped_pushes} unchanged media pushes")
+    if skipped_pushes:
+        noun = "file" if skipped_pushes == 1 else "files"
+        logger.debug(
+            f"Media push cache: {skipped_pushes} unchanged media {noun} "
+            "already present in Anki"
+        )
     return result
 
 

--- a/tests/integration/media/test_media_sync.py
+++ b/tests/integration/media/test_media_sync.py
@@ -7,13 +7,18 @@ from pathlib import Path
 
 from ankiops.config import LOCAL_MEDIA_DIR
 from ankiops.db import SQLiteDbAdapter
-from ankiops.sync_media import sync_all_media_to_anki, sync_media_to_anki
+from ankiops.sync_media import (
+    sync_all_media_from_anki,
+    sync_all_media_to_anki,
+    sync_media_to_anki,
+)
 
 
 class _FakeMediaAnki:
     def __init__(self, media_dir: Path):
         self._media_dir = media_dir
         self.push_count = 0
+        self.pull_count = 0
 
     def get_media_dir(self) -> Path:
         return self._media_dir
@@ -22,6 +27,15 @@ class _FakeMediaAnki:
         self.push_count += 1
         target = self._media_dir / remote_filename
         target.write_bytes(local_path.read_bytes())
+
+    def pull_media(self, remote_filename: str, local_path: Path) -> bool:
+        source = self._media_dir / remote_filename
+        if not source.exists():
+            return False
+        self.pull_count += 1
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        local_path.write_bytes(source.read_bytes())
+        return True
 
 
 def _sync_to_anki(fs, collection_dir: Path, anki: _FakeMediaAnki):
@@ -74,6 +88,32 @@ def test_sync_all_media_to_anki_resolves_media_relative_to_each_source(fs, tmp_p
     )
 
 
+def test_sync_all_media_suppresses_empty_source_cache_debug(fs, tmp_path, caplog):
+    root_media = tmp_path / LOCAL_MEDIA_DIR
+    root_media.mkdir()
+    (root_media / "image.png").write_bytes(b"root image")
+    (tmp_path / "RootDeck.md").write_text(
+        "Q: Root\nA: ![img](media/image.png)", encoding="utf-8"
+    )
+    (tmp_path / "shared" / "owner" / "repo" / LOCAL_MEDIA_DIR).mkdir(parents=True)
+
+    anki_media_dir = tmp_path / "anki_media"
+    anki_media_dir.mkdir()
+    anki = _FakeMediaAnki(anki_media_dir)
+
+    db = SQLiteDbAdapter.open(tmp_path)
+    try:
+        with caplog.at_level(logging.DEBUG, logger="ankiops.sync_media"):
+            sync_all_media_to_anki(anki, fs, tmp_path, db)
+            sync_all_media_from_anki(anki, fs, tmp_path, db)
+    finally:
+        db.close()
+
+    assert "across 0 markdown files" not in caplog.text
+    assert "across 0 candidate files" not in caplog.text
+    assert "Skipped 0 unchanged media pushes" not in caplog.text
+
+
 def test_sync_media_to_anki_handles_markdown_html_audio_and_external_refs(fs, tmp_path):
     media_dir = tmp_path / LOCAL_MEDIA_DIR
     media_dir.mkdir()
@@ -108,7 +148,7 @@ def test_sync_media_to_anki_handles_markdown_html_audio_and_external_refs(fs, tm
     assert "[sound:clip_" in content
 
 
-def test_sync_media_to_anki_warm_run_skips_unchanged_pushes(fs, tmp_path):
+def test_sync_media_to_anki_warm_run_skips_unchanged_pushes(fs, tmp_path, caplog):
     media_dir = tmp_path / LOCAL_MEDIA_DIR
     media_dir.mkdir()
     (media_dir / "img.png").write_bytes(b"image-content")
@@ -123,13 +163,18 @@ def test_sync_media_to_anki_warm_run_skips_unchanged_pushes(fs, tmp_path):
     db = SQLiteDbAdapter.open(tmp_path)
     try:
         first = sync_media_to_anki(anki, fs, tmp_path, db)
-        second = sync_media_to_anki(anki, fs, tmp_path, db)
+        with caplog.at_level(logging.DEBUG, logger="ankiops.sync_media"):
+            second = sync_media_to_anki(anki, fs, tmp_path, db)
     finally:
         db.close()
 
     assert first.summary.synced == 1
     assert second.summary.synced == 0
     assert anki.push_count == 1
+    assert "Media push cache: 1 unchanged media file already present in Anki" in (
+        caplog.text
+    )
+    assert "Skipped 1 unchanged media pushes" not in caplog.text
 
 
 def test_sync_media_to_anki_cache_persists_across_db_connections(fs, tmp_path):


### PR DESCRIPTION
## Summary
- Skip media cache debug logs when there is nothing to report, avoiding noisy `0`-count messages
- Improve the warm-run media push log to use clearer wording and singular/plural form
- Add integration coverage for empty-cache logging and unchanged push behavior

## Testing
- Added integration tests covering empty markdown/candidate sets and warm-run unchanged pushes
- Verified the new log messages appear only when expected and the old `Skipped 0...` output is absent

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR suppresses noisy zero-count debug log lines in the media sync pipeline by guarding each `logger.debug` call behind a truthiness check on the relevant collection, and rewrites the skipped-push message to use clearer wording with singular/plural agreement. New integration tests verify both that the zero-count messages are absent and that the new warm-run message appears correctly.

- Guard `_collect_referenced_media` and `hash_and_update_references` cache-stat logs behind `if md_files:` / `if cache_candidates:` to silence empty-source runs.
- Replace `"Skipped N unchanged media pushes"` with `"Media push cache: N unchanged media file(s) already present in Anki"`, emitted only when `skipped_pushes` is non-zero.
- Add `test_sync_all_media_suppresses_empty_source_cache_debug` and extend the warm-run test with `caplog` assertions for both presence and absence of the new/old message formats.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are limited to conditional guards around debug log statements, with no alteration to data flow or sync logic.

All three changes add a simple truthiness guard before a logger.debug call; no processing logic, return values, or side effects are touched. The new tests positively assert the updated message format and negatively assert the old strings are absent, giving good confidence the intent is correctly captured.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ankiops/sync_media.py | Three small guard additions suppress zero-count debug logs; the skipped-push message gains a singular/plural form and is only emitted when non-zero. Logic is correct and no existing behaviour changes. |
| tests/integration/media/test_media_sync.py | Adds a new integration test for empty-source log suppression and extends the warm-run test with caplog assertions; also adds a pull_media stub and sync_all_media_from_anki import needed by the new test. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[sync_all_media_to_anki] --> B[_collect_referenced_media]
    B --> C{md_files non-empty?}
    C -- Yes --> D[logger.debug refs cache stats]
    C -- No --> E[skip log]

    A --> F[hash_and_update_references]
    F --> G{cache_candidates non-empty?}
    G -- Yes --> H[logger.debug hash cache stats]
    G -- No --> I[skip log]

    A --> J[sync_media_to_anki]
    J --> K{skipped_pushes > 0?}
    K -- Yes --> L["logger.debug 'Media push cache: N unchanged media file(s) already present in Anki'"]
    K -- No --> M[skip log]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Suppress empty media sync cache debug lo..."](https://github.com/visserle/ankiops/commit/5c906180b84579c2bd767dcc743d79315f074c07) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37304391)</sub>

<!-- /greptile_comment -->