### PR TITLE
Refine missing note_key error messages

### DIFF
--- a/ankiops/shared/commands.py
+++ b/ankiops/shared/commands.py
@@ -13,6 +13,7 @@ from ankiops.fs import FileSystemAdapter
 from ankiops.git import CollectionGit
 from ankiops.log import clickable_path
 from ankiops.shared.create import create_shared_deck
+from ankiops.shared.errors import format_missing_note_keys_error
 from ankiops.shared.hosting import open_pr_if_possible
 from ankiops.sources import (
     SyncSource,
@@ -82,11 +83,7 @@ def _ensure_submittable_note_keys(source: SyncSource) -> None:
                 missing.append(f"{md_file.relative_to(source.root)} note {index}")
 
     if missing:
-        raise ValueError(
-            "Cannot submit: notes are missing note_key metadata: "
-            + ", ".join(missing)
-            + ". Run 'ankiops ma' first or add explicit note_key comments."
-        )
+        raise ValueError(format_missing_note_keys_error(len(missing)))
 
 
 def run_create(args) -> None:

--- a/ankiops/shared/create.py
+++ b/ankiops/shared/create.py
@@ -13,6 +13,7 @@ from ankiops.export_notes import _render_notes_to_markdown
 from ankiops.fs import FileSystemAdapter
 from ankiops.git import CollectionGit
 from ankiops.models import MarkdownFile, NoteTypeConfig
+from ankiops.shared.errors import format_missing_note_keys_error
 from ankiops.shared.hosting import ensure_create_repo
 from ankiops.sources import SHARED_BRANCH, SyncSource
 from ankiops.sync_media import _extract_media_references
@@ -156,11 +157,7 @@ def _prepare_create_plan(
                 media_used.update(_extract_media_references(field_value))
 
     if missing_note_keys:
-        raise ValueError(
-            "Cannot create shared source: notes are missing note_key metadata: "
-            + ", ".join(missing_note_keys)
-            + ". Run 'ankiops ma' first or add explicit note_key comments."
-        )
+        raise ValueError(format_missing_note_keys_error(len(missing_note_keys)))
 
     unknown_note_types = sorted(note_types_used - set(root_config_by_name))
     if unknown_note_types:

--- a/ankiops/shared/errors.py
+++ b/ankiops/shared/errors.py
@@ -1,0 +1,13 @@
+"""Shared command error messages."""
+
+from __future__ import annotations
+
+
+def format_missing_note_keys_error(missing_count: int) -> str:
+    note_label = "note" if missing_count == 1 else "notes"
+    return (
+        f"Missing note_keys for {missing_count} {note_label}. "
+        "note_keys are stable IDs AnkiOps needs to match notes across "
+        "collections without duplicates. "
+        "Fix: run 'ankiops ma' to assign them."
+    )

--- a/tests/unit/test_shared_commands.py
+++ b/tests/unit/test_shared_commands.py
@@ -237,9 +237,18 @@ def test_create_rejects_missing_note_keys_before_file_mutations(
     )
     _init_git_repo(collection_dir)
 
-    with pytest.raises(ValueError, match="missing note_key metadata"):
+    with pytest.raises(ValueError) as excinfo:
         run_create(SimpleNamespace(deck="Deck", repo="owner/repo"))
 
+    message = str(excinfo.value)
+    assert message == (
+        "Missing note_keys for 1 note. "
+        "note_keys are stable IDs AnkiOps needs to match notes across "
+        "collections without duplicates. "
+        "Fix: run 'ankiops ma' to assign them."
+    )
+    assert "explicit note_key" not in message
+    assert "Deck.md note" not in message
     assert deck.exists()
     assert not (collection_dir / "shared").exists()
 
@@ -603,9 +612,18 @@ def test_submit_rejects_keyless_notes_without_mutating_files(
         lambda: collection_dir,
     )
 
-    with pytest.raises(ValueError, match="missing note_key metadata"):
+    with pytest.raises(ValueError) as excinfo:
         run_submit(SimpleNamespace(repo="owner/repo"))
 
+    message = str(excinfo.value)
+    assert message == (
+        "Missing note_keys for 1 note. "
+        "note_keys are stable IDs AnkiOps needs to match notes across "
+        "collections without duplicates. "
+        "Fix: run 'ankiops ma' to assign them."
+    )
+    assert "explicit note_key" not in message
+    assert "Deck.md note" not in message
     assert deck.read_text(encoding="utf-8") == original
     assert _git_status(collection_dir) == ""
 


### PR DESCRIPTION
## Summary
- Centralize missing note_key error formatting for shared create and submit flows
- Replace file-specific wording with a concise count-based message
- Tighten unit tests to assert the new message text and key phrasing

## Testing
- Not run (not requested)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralises the missing-`note_key` error message for both the `create` and `submit` flows into a single `format_missing_note_keys_error(count)` helper in a new `errors.py` module, replacing two distinct verbose messages with a shorter count-based one.

- **New `ankiops/shared/errors.py`**: `format_missing_note_keys_error` renders a user-friendly singular/plural message and is imported by both `commands.py` and `create.py`.
- **`commands.py` / `create.py`**: The old per-note detail lists (`\", \".join(missing)`) are replaced by `len(missing)`, though both call sites still build full `list[str]` of formatted strings that go unused.
- **Tests**: Both missing-key test cases now assert the exact message text and add negative assertions to confirm old file-specific wording is absent.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the error path behaviour is correct and the tests verify both flows.

The centralisation is straightforward and the new formatter is correct. Both call sites still build lists of formatted strings that are immediately discarded in favour of the list length, which is a small inefficiency introduced by this PR rather than a pre-existing issue.

ankiops/shared/commands.py and ankiops/shared/create.py — both build throwaway string lists after the refactor.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| ankiops/shared/errors.py | New module introducing `format_missing_note_keys_error(count)` — clean, correct singular/plural handling, well-scoped. |
| ankiops/shared/commands.py | Switched `_ensure_submittable_note_keys` to the shared formatter; still builds a full list of formatted strings that are now discarded (only the length is used). |
| ankiops/shared/create.py | Switched `_prepare_create_plan` to the shared formatter; `missing_note_keys` list now accumulates unused strings — only the count is forwarded. |
| tests/unit/test_shared_commands.py | Tests updated to assert exact message text for both the create and submit missing-key paths; negative assertions confirm old wording is gone. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[run_create] --> B[_prepare_create_plan]
    R[run_submit] --> S[_ensure_submittable_note_keys]

    B --> C{missing_note_keys empty?}
    S --> T{missing empty?}

    C -- No --> E[format_missing_note_keys_error]
    T -- No --> E

    C -- Yes --> G[Continue create flow]
    T -- Yes --> H[Continue submit flow]

    E --> F[raise ValueError with count-based message]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `ankiops/shared/commands.py`, line 77-86 ([link](https://github.com/visserle/ankiops/blob/e72819ac17de740365cf181fa43377cdf99dfb14/ankiops/shared/commands.py#L77-L86)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Now that `format_missing_note_keys_error` only needs a count, the `missing` list accumulates formatted strings (`f"{md_file.relative_to(source.root)} note {index}"`) that are never read — only `len(missing)` is passed to the formatter. A simple integer counter avoids the throwaway allocations and makes the intent clear.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!


2. `ankiops/shared/create.py`, line 141-160 ([link](https://github.com/visserle/ankiops/blob/e72819ac17de740365cf181fa43377cdf99dfb14/ankiops/shared/create.py#L141-L160)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Dead list-building after centralising to a count-only formatter — `missing_note_keys` now holds formatted strings (`f"{md_file.name} note {index}"`) that are never used; only `len(missing_note_keys)` is forwarded to `format_missing_note_keys_error`. The list initialisation on line 141, the `append` on line 148, and the `len()` call on line 160 can all be replaced with a plain integer counter (`missing_count = 0` / `missing_count += 1` / `if missing_count:`), matching the simpler pattern that `_ensure_submittable_note_keys` in `commands.py` could also adopt.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Refine missing note\_key error messages"](https://github.com/visserle/ankiops/commit/e72819ac17de740365cf181fa43377cdf99dfb14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37305524)</sub>

<!-- /greptile_comment -->