### PR TITLE
Allow note type access rules outside deck scope

### DIFF
--- a/ankiops/llm/planning.py
+++ b/ankiops/llm/planning.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field, replace
-from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import Any
 
@@ -196,7 +195,6 @@ def materialize_task_context(
         task=task,
         note_type_configs=note_type_configs,
     )
-    _validate_note_type_patterns_match_scope(task, discovery_snapshot)
     return MaterializedTaskContext(
         task=task,
         note_type_configs=note_type_configs,
@@ -483,32 +481,6 @@ def _invalid_discovery_item(
         note_type_config=None,
         serialized_note=serialized_note,
     )
-
-
-def _validate_note_type_patterns_match_scope(
-    task: TaskConfig,
-    snapshot: DiscoverySnapshot,
-) -> None:
-    observed_note_types = {
-        item.note_type
-        for item in snapshot.items
-        if item.note_type is not None and item.note_type_config is not None
-    }
-    missing_patterns: list[str] = []
-    for rule in task.field_rules:
-        for pattern in rule.note_types:
-            if pattern == "*":
-                continue
-            if not any(
-                fnmatchcase(note_type, pattern) for note_type in observed_note_types
-            ):
-                missing_patterns.append(pattern)
-
-    if missing_patterns:
-        missing = ", ".join(sorted(set(missing_patterns)))
-        raise ValueError(
-            f"LLM note type pattern(s) matched no notes after deck filtering: {missing}"
-        )
 
 
 def build_candidate_batches(

--- a/tests/unit/llm/test_planning.py
+++ b/tests/unit/llm/test_planning.py
@@ -241,18 +241,19 @@ def test_plan_task_discovers_shared_notes_with_sources(llm_collection, write_fil
     )
 
 
-def test_plan_task_rejects_explicit_note_type_pattern_after_deck_filter(
+def test_plan_task_allows_note_type_access_rule_absent_from_deck_scope(
     llm_collection,
     write_file,
 ):
-    _init_collection_db(llm_collection)
     _eject_note_types(llm_collection)
     write_file(
-        llm_collection / "Deck.md",
+        llm_collection / "Psychotherapie__Stoerungen.md",
         """
         <!-- note_key: qa-1 -->
         Q: question
         A: answer
+        S: source
+        AI: private
         """,
     )
     write_file(
@@ -265,10 +266,25 @@ def test_plan_task_rejects_explicit_note_type_pattern_after_deck_filter(
           max_notes_per_request: 4
         fields:
           default_access: editable
+          hidden:
+            "*": ["AI Notes"]
+            "AnkiOpsImageOcclusion": ["*"]
           read_only:
             "AnkiOpsChoice": ["Answer"]
         """,
     )
 
-    with pytest.raises(ValueError, match="matched no notes after deck filtering"):
-        plan_task(collection_dir=llm_collection, task_name="grammar")
+    plan = plan_task(
+        collection_dir=llm_collection,
+        task_name="grammar",
+        deck_override="Psychotherapie::Stoerungen",
+    )
+
+    assert plan.summary.decks_seen == 1
+    assert plan.summary.decks_matched == 1
+    assert plan.summary.notes_seen == 1
+    assert plan.summary.eligible == 1
+    assert plan.requests_estimate == 1
+    surface_by_type = {surface.note_type: surface for surface in plan.field_surface}
+    assert set(surface_by_type) == {"AnkiOpsQA"}
+    assert "AI Notes" in surface_by_type["AnkiOpsQA"].hidden_fields


### PR DESCRIPTION
## Summary
- Remove the planning-time validation that rejected note type patterns when no notes remained after deck filtering
- Keep task planning working when access rules target note types outside the selected deck scope
- Update the unit test to cover deck override behavior and verify the expected field surface

## Testing
- Unit tests updated to validate planning output for a deck-scoped task with note type access rules

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes a planning-time validation that rejected note type access rules when no notes matching those rules existed in the current deck scope. The change enables task configs — which often define access rules for multiple note types — to be used with `deck_override` targeting a deck that only contains a subset of those note types.

- **`planning.py`**: Deletes `_validate_note_type_patterns_match_scope` and its single call site in `materialize_task_context`, plus the now-unused `fnmatch` import.
- **`test_planning.py`**: Converts the old "must raise" test into a passing scenario: a grammar task with `AnkiOpsChoice`/`AnkiOpsImageOcclusion` rules runs cleanly against a deck containing only `AnkiOpsQA` notes, and the `"*": ["AI Notes"]` wildcard rule still applies correctly to the present note type.

<h3>Confidence Score: 4/5</h3>

Safe to merge — removes an overly strict guard that blocked valid deck-scoped runs without touching any data-writing or request-execution paths.

The deleted function was the only place that enforced note type pattern coverage against the discovered scope. Removing it means a typo in a note type name (e.g. `"AnkiOpsChoise"`) will now silently do nothing instead of raising an early error, which is a minor regression in misconfiguration feedback. The rest of the change — the `fnmatch` import removal and the test rewrite — is clean.

No files require special attention; both changed files are straightforward.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ankiops/llm/planning.py | Removes the `_validate_note_type_patterns_match_scope` guard and the `fnmatch` import — a clean deletion with no residual call sites. |
| tests/unit/llm/test_planning.py | Test renamed and rewritten from "must raise" to a positive assertion; exercises `deck_override`, verifies correct field surface for the note types actually present, and confirms absent note type rules do not surface spurious entries. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[plan_task] --> B[materialize_task_context]
    B --> C[_load_task\nload TaskConfig + NoteType configs]
    B --> D{deck_override?}
    D -- yes --> E[replace task.decks\nwith DeckScope deck_override]
    D -- no --> F[use task.decks as-is]
    E --> G[serialize collection]
    F --> G
    G --> H[_discover_candidates\nfilter notes by deck scope]
    H --> I[DiscoverySnapshot]
    I --> J[_build_task_plan_result\nfield_surface, summary, estimates]
    J --> K[TaskPlanResult]

    style L fill:#f9f,stroke:#333,stroke-width:2px
    L[REMOVED: _validate_note_type_patterns_match_scope\nraised ValueError if any non-wildcard\nnote type pattern matched 0 notes\nafter deck filtering]

    I -.->|previously called here\nbefore return| L
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Allow note type rules outside deck scope"](https://github.com/visserle/ankiops/commit/fc895642ef775c895b7e7d4c11e3adf606777b4e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37427781)</sub>

<!-- /greptile_comment -->