### PR TITLE
Rename sync commands to files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [![Tests](https://github.com/visserle/AnkiOps/actions/workflows/test.yml/badge.svg)](https://github.com/visserle/AnkiOps/actions/workflows/test.yml) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![PyPI version](https://img.shields.io/pypi/v/ankiops.svg)](https://pypi.org/project/ankiops/) 
 
-AnkiOps is a bidirectional Anki ↔ Markdown bridge where each deck becomes a Markdown file. Edit in plain text, version with Git, enhance with LLMs, and sync changes both ways. 
+AnkiOps is a bidirectional Anki ↔ files bridge where each deck becomes an editable Markdown file. Edit in plain text, version with Git, enhance with LLMs, and sync changes both ways. 
 
 ## Features
 
 - **Full Anki support**: Safe, performant bidirectional syncing of notes with custom note types, (sub-)decks, and media files
 - **Markdown-first**: Edit in your favourite editor and render Markdown features in Anki (including syntax highlighting)
-- **Simple CLI interface** for importing and exporting between Anki and the filesystem
+- **Simple CLI interface** for syncing between Anki and your local files
 - **LLM-integration**: Run programmable tasks such as content review, grammar fixes, or translations on your collection
 - **GitHub shared**: Create shared deck sources on GitHub, add shared decks, update them, and submit changes through PRs (experimental)
 
@@ -47,16 +47,16 @@ ankiops init --tutorial
 
 
 
-3. **Import Markdown into Anki**: Import the current collection of Markdown decks into Anki.
+3. **Sync files to Anki**: Apply the current files, including Markdown decks, media, and note types, to Anki.
 
 ```bash
-ankiops ma # alias for markdown-to-anki (import)
+ankiops fa # alias for files-to-anki
 ```
 
-4. **Sync Anki back to Markdown**: After you review or edit cards in Anki, export those changes. Each sync makes one side match the other.
+4. **Sync Anki back to files**: After you review or edit cards in Anki, apply those changes to your local files. Each sync makes one side match the other.
 
 ```bash
-ankiops am # alias for anki-to-markdown (export)
+ankiops af # alias for anki-to-files
 ```
 
 ## FAQ
@@ -71,7 +71,7 @@ Yes, AnkiOps will never modify notes that are not defined within the `note_types
 
 ### How do I create new notes?
 
-Create a new Markdown file in your initialized AnkiOps folder. On the first import, AnkiOps uses the file name as the deck name. Subdecks use `__` (for example, `Anatomy::Heart` maps to `Anatomy__Heart.md`). Separate notes with a blank line, three dashes `---`, and another blank line. You can add new notes anywhere in an existing file.
+Create a new Markdown file in your initialized AnkiOps folder. On the first files-to-Anki sync, AnkiOps uses the file name as the deck name. Subdecks use `__` (for example, `Anatomy::Heart` maps to `Anatomy__Heart.md`). Separate notes with a blank line, three dashes `---`, and another blank line. You can add new notes anywhere in an existing file.
 
 ```markdown
 <!-- note_key: 123487556abc -->
@@ -101,7 +101,7 @@ C3: randomized answers.
 A: 1, 3
 ```
 
-On the next import, AnkiOps assigns a `note_key` and `note_type` comment to the last note.
+On the next files-to-Anki sync, AnkiOps assigns a `note_key` and `note_type` comment to the last note.
 
 ### How are different note types handled?
 
@@ -114,8 +114,8 @@ You can migrate existing notes in three ways: write matching note type files in 
 For Anki browser conversion, use this workflow:
 
 1. Convert your existing notes to the matching AnkiOps note types via `Change Note Type…` in the Anki browser.
-2. Export your notes from Anki to Markdown using `ankiops am`.
-3. Review the Git diff after the first re-import. Original Anki HTML may not match CommonMark, so the first Markdown-to-Anki sync can change formatting. Formatting issues can be fixed by hand or via LLM tasks.
+2. Sync your notes from Anki to files using `ankiops af`.
+3. Review the Git diff after the first files-to-Anki sync. Original Anki HTML may not match CommonMark, so the first files-to-Anki sync can change formatting. Formatting issues can be fixed by hand or via LLM tasks.
 
 ### How does it work?
 
@@ -144,7 +144,7 @@ ankiops shared add owner/repo
 ankiops shared update owner/repo --to-anki
 ```
 
-`add` adds the GitHub repository as a subtree. `update` refreshes one source, or all sources when you omit `owner/repo`. `--to-anki` runs Markdown-to-Anki after the update.
+`add` adds the GitHub repository as a subtree. `update` refreshes one source, or all sources when you omit `owner/repo`. `--to-anki` runs files-to-Anki after the update.
 
 To submit local edits back:
 
@@ -152,15 +152,15 @@ To submit local edits back:
 ankiops shared submit owner/repo --from-anki
 ```
 
-`--from-anki` exports Anki edits to Markdown first. `submit` then commits the shared source, creates a subtree branch, and opens a pull request with `gh` when possible. Without `gh`, AnkiOps leaves you with the branch name and GitHub remote so you can push and open the PR yourself.
+`--from-anki` syncs Anki edits to files first. `submit` then commits the shared source, creates a subtree branch, and opens a pull request with `gh` when possible. Without `gh`, AnkiOps leaves you with the branch name and GitHub remote so you can push and open the PR yourself.
 
 ### How do I upgrade AnkiOps to the latest version?
 
-AnkiOps is in early development, so breaking changes are expected. Use `pipx upgrade ankiops` to upgrade AnkiOps. Delete local AnkiOps support files except your Markdown decks, re-initialize the same folder with `ankiops init`, and export from Anki with `ankiops am`. If your collection is in Git, inspect the diff before you continue syncing.
+AnkiOps is in early development, so breaking changes are expected. Use `pipx upgrade ankiops` to upgrade AnkiOps. Delete local AnkiOps support files except your Markdown decks, re-initialize the same folder with `ankiops init`, and sync from Anki with `ankiops af`. If your collection is in Git, inspect the diff before you continue syncing.
 
 ### What is the Add-on for?
 
-The Add-on has two purposes. It adds `am` and `ma` buttons to the Anki toolbar for quick sync andit implements AnkiOpsConnect, a rewrite of AnkiConnect that enables operations for the shared features (mainly the conversion of note types without losing schedule information). The Add-on is still experimental and not available on AnkiWeb yet. To install it, download the folder and put it in your Anki add-ons directory.
+The Add-on has two purposes. It adds `af` and `fa` buttons to the Anki toolbar for quick sync and it implements AnkiOpsConnect, a rewrite of AnkiConnect that enables operations for the shared features (mainly the conversion of note types without losing schedule information). The Add-on is still experimental and not available on AnkiWeb yet. To install it, download the folder and put it in your Anki add-ons directory.
 
 ### How can I develop AnkiOps locally?
 
@@ -171,7 +171,7 @@ git clone https://github.com/visserle/ankiops.git
 cd ankiops
 uv sync
 uv run python -m main init --tutorial
-uv run python -m main ma
+uv run python -m main fa
 ```
 
 ### Are Pull Requests welcome?
@@ -188,10 +188,10 @@ Yes. Bug fixes, feature work, and documentation PRs are welcome. Open an issue f
 **`init`:**
 - `--tutorial` - Create tutorial markdown file
 
-**`anki-to-markdown` / `am`:**
+**`anki-to-files` / `af`:**
 - `--no-auto-commit`, `-n` - Skip automatic git commit
 
-**`markdown-to-anki` / `ma`:**
+**`files-to-anki` / `fa`:**
 - `--no-auto-commit`, `-n` - Skip automatic git commit
 
 **`note-types`:**

--- a/anki_addon/config.md
+++ b/anki_addon/config.md
@@ -1,6 +1,6 @@
 # AnkiOps add-on
 
-Adds import (**ma**) and export (**am**) buttons to Anki's top toolbar that shell out to the `ankiops` CLI (`ankiops ma` and `ankiops am`).
+Adds file sync buttons (**af** and **fa**) to Anki's top toolbar that shell out to the `ankiops` CLI (`ankiops af` and `ankiops fa`).
 
 ## Setup
 
@@ -12,4 +12,3 @@ Adds import (**ma**) and export (**am**) buttons to Anki's top toolbar that shel
 
 - **`collection_dir`** — absolute path to your AnkiOps collection directory (the folder containing `.ankiops.db`). Required.
 - **`ankiops_path`** — absolute path to the `ankiops` binary. Optional; leave empty to auto-discover from `PATH` and common pipx locations (`~/.local/bin`, `/opt/homebrew/bin`, `/usr/local/bin`).
-

--- a/anki_addon/toolbar.py
+++ b/anki_addon/toolbar.py
@@ -61,7 +61,7 @@ class AnkiOpsCommandRunner:
             output = ((result.stdout or "") + (result.stderr or "")).strip()
             if result.returncode == 0:
                 self._show_output(f"ankiops {command} — done", output)
-                if command == "ma":
+                if command == "fa":
                     self._mw.reset()
             else:
                 self._show_output(
@@ -123,20 +123,20 @@ def add_toolbar_links(links: list[str], toolbar, runner: AnkiOpsCommandRunner) -
     links.insert(
         -2,
         toolbar.create_link(
-            cmd="ankiops_anki_to_markdown",
-            label="am",
-            func=lambda: runner.run("am"),
-            tip="ankiops anki-to-markdown",
-            id="ankiops-anki-to-markdown",
+            cmd="ankiops_anki_to_files",
+            label="af",
+            func=lambda: runner.run("af"),
+            tip="ankiops anki-to-files",
+            id="ankiops-anki-to-files",
         ),
     )
     links.insert(
         -2,
         toolbar.create_link(
-            cmd="ankiops_markdown_to_anki",
-            label="ma",
-            func=lambda: runner.run("ma"),
-            tip="ankiops markdown-to-anki",
-            id="ankiops-markdown-to-anki",
+            cmd="ankiops_files_to_anki",
+            label="fa",
+            func=lambda: runner.run("fa"),
+            tip="ankiops files-to-anki",
+            id="ankiops-files-to-anki",
         ),
     )

--- a/ankiops/cli.py
+++ b/ankiops/cli.py
@@ -4,12 +4,12 @@ from importlib.metadata import PackageNotFoundError, version
 
 from ankiops.anki_rpc import AnkiConnectionError
 from ankiops.cli_commands import (
-    run_am,
+    run_af,
     run_deserialize,
+    run_fa,
     run_fix_image_widths,
     run_init,
     run_llm,
-    run_ma,
     run_note_type,
     run_serialize,
     run_shared,
@@ -71,33 +71,33 @@ def main():
     )
     init_parser.set_defaults(handler=run_init)
 
-    # Anki to Markdown (am) parser
-    am_parser = subparsers.add_parser(
-        "anki-to-markdown",
-        aliases=["am"],
-        help="Anki -> Markdown (export)",
+    # Anki to files (af) parser
+    af_parser = subparsers.add_parser(
+        "anki-to-files",
+        aliases=["af"],
+        help="Anki -> files",
     )
-    am_parser.add_argument(
+    af_parser.add_argument(
         "--no-auto-commit",
         "-n",
         action="store_true",
         help="Skip the automatic git commit for this operation",
     )
-    am_parser.set_defaults(handler=run_am)
+    af_parser.set_defaults(handler=run_af)
 
-    # Markdown to Anki (ma) parser
-    ma_parser = subparsers.add_parser(
-        "markdown-to-anki",
-        aliases=["ma"],
-        help="Markdown -> Anki (import)",
+    # Files to Anki (fa) parser
+    fa_parser = subparsers.add_parser(
+        "files-to-anki",
+        aliases=["fa"],
+        help="Files -> Anki",
     )
-    ma_parser.add_argument(
+    fa_parser.add_argument(
         "--no-auto-commit",
         "-n",
         action="store_true",
         help="Skip the automatic git commit for this operation",
     )
-    ma_parser.set_defaults(handler=run_ma)
+    fa_parser.set_defaults(handler=run_fa)
 
     # Serialize parser
     serialize_parser = subparsers.add_parser(
@@ -236,7 +236,7 @@ def main():
     shared_update.add_argument(
         "--to-anki",
         action="store_true",
-        help="Run Markdown -> Anki after updating files",
+        help="Run files -> Anki after updating files",
     )
     shared_update.set_defaults(handler=run_shared)
 
@@ -251,7 +251,7 @@ def main():
     shared_submit.add_argument(
         "--from-anki",
         action="store_true",
-        help="Run Anki -> Markdown before preparing the submission",
+        help="Run Anki -> files before preparing the submission",
     )
     shared_submit.set_defaults(handler=run_shared)
 
@@ -296,15 +296,15 @@ def main():
         # Show welcome screen when no command is provided
         cli_version = _get_cli_version()
         print("=" * 60)
-        print(f"AnkiOps v{cli_version} – A bidirectional Anki-Markdown bridge")
+        print(f"AnkiOps v{cli_version} – A bidirectional Anki-files bridge")
         print("=" * 60)
         print()
         print("Available commands:")
         print(
             "  init              Initialize current directory as an AnkiOps collection"
         )
-        print("  anki-to-markdown  Export Anki decks to Markdown files (alias: am)")
-        print("  markdown-to-anki  Import Markdown files into Anki (alias: ma)")
+        print("  anki-to-files     Sync Anki changes into files (alias: af)")
+        print("  files-to-anki     Sync file changes into Anki (alias: fa)")
         print("  serialize         Serialize Markdown decks to JSON format")
         print("  deserialize       Deserialize JSON file to Markdown decks")
         print("  fix-image-widths  Normalize or force Markdown image widths")
@@ -317,12 +317,12 @@ def main():
             "  ankiops init --tutorial                      # Initialize with tutorial"
         )
         print(
-            "  ankiops am                                   "
-            "# Export all decks to Markdown"
+            "  ankiops af                                   "
+            "# Sync Anki to files"
         )
         print(
-            "  ankiops ma                                   "
-            "# Import all Markdown files to Anki"
+            "  ankiops fa                                   "
+            "# Sync files to Anki"
         )
         print(
             "  ankiops serialize -o my-deck.json            "

--- a/ankiops/cli_commands.py
+++ b/ankiops/cli_commands.py
@@ -98,8 +98,8 @@ def run_init(args):
     )
 
 
-def run_am(args):
-    """Anki -> Markdown: export decks to markdown files."""
+def run_af(args):
+    """Anki -> files: sync Anki changes into local files."""
     anki = connect_or_exit()
     active_profile = anki.get_active_profile()
 
@@ -107,10 +107,10 @@ def run_am(args):
     logger.debug(f"Collection directory: {collection_dir}")
 
     if not args.no_auto_commit:
-        logger.debug("Creating pre-export git snapshot")
+        logger.debug("Creating pre-anki-to-files git snapshot")
         git_snapshot(
             collection_dir,
-            action="export",
+            action="anki-to-files",
             paths=_snapshot_paths(
                 collection_dir,
                 [
@@ -124,7 +124,7 @@ def run_am(args):
     db = SyncState.open(collection_dir)
     note_types_dir = collection_dir / NOTE_TYPES_DIR
 
-    logger.debug("Starting note export (Anki -> Markdown)")
+    logger.debug("Starting note sync (Anki -> files)")
     export_summary: CollectionReport = sync_collection_from_anki(
         anki_port=anki,
         db_port=db,
@@ -136,7 +136,9 @@ def run_am(args):
     note_count = note_summary.total
     changes = note_summary.format()
 
-    logger.info(f"Export: {deck_count} decks with {note_count} notes — {changes}")
+    logger.info(
+        f"Anki -> files: {deck_count} decks with {note_count} notes — {changes}"
+    )
     for res in export_summary.results:
         deck_summary = res.summary
         deck_fmt = deck_summary.format()
@@ -152,13 +154,13 @@ def run_am(args):
         logger.warning(
             "Protected "
             f"{protected_total} local markdown note(s) without note_key comments "
-            "during export."
+            "during Anki -> files sync."
         )
         logger.warning(f"Affected deck file(s): {len(protected)}")
         for group in protected:
             logger.warning(f"  - {group.deck_name} ({group.note_count} notes)")
         logger.warning(
-            "These notes were kept and not deleted. Use 'ankiops ma' to "
+            "These notes were kept and not deleted. Use 'ankiops fa' to "
             "import them and assign note_key comments."
         )
 
@@ -171,14 +173,14 @@ def run_am(args):
         logger.warning(f"Media sync failed: {error}")
 
 
-def _log_import_errors(import_summary: CollectionReport) -> None:
+def _log_files_to_anki_errors(import_summary: CollectionReport) -> None:
     has_errors = False
     for result in import_summary.results:
         if not result.errors:
             continue
 
         if not has_errors:
-            logger.error("Import errors:")
+            logger.error("Files -> Anki errors:")
             has_errors = True
 
         source = rich_escape(result.name or "unknown deck")
@@ -192,8 +194,8 @@ def _log_import_errors(import_summary: CollectionReport) -> None:
             )
 
 
-def run_ma(args):
-    """Markdown -> Anki: import markdown files into Anki."""
+def run_fa(args):
+    """Files -> Anki: sync local file changes into Anki."""
     anki = connect_or_exit()
     active_profile = anki.get_active_profile()
 
@@ -201,10 +203,10 @@ def run_ma(args):
     logger.debug(f"Collection directory: {collection_dir}")
 
     if not args.no_auto_commit:
-        logger.debug("Creating pre-import git snapshot")
+        logger.debug("Creating pre-files-to-anki git snapshot")
         git_snapshot(
             collection_dir,
-            action="import",
+            action="files-to-anki",
             paths=_snapshot_paths(
                 collection_dir,
                 [
@@ -232,7 +234,7 @@ def run_ma(args):
     if nt_summary:
         logger.info(f"Note types: {nt_summary}")
 
-    logger.debug("Starting note import (Markdown -> Anki)")
+    logger.debug("Starting note sync (files -> Anki)")
     import_summary: CollectionReport = sync_collection_to_anki(
         anki_port=anki,
         db_port=db,
@@ -245,7 +247,9 @@ def run_ma(args):
     untracked = import_summary.untracked_decks
     changes = note_summary.format()
 
-    logger.info(f"Import: {deck_count} decks with {note_count} notes — {changes}")
+    logger.info(
+        f"Files -> Anki: {deck_count} decks with {note_count} notes — {changes}"
+    )
     for res in import_summary.results:
         deck_summary = res.summary
         deck_fmt = deck_summary.format()
@@ -253,21 +257,22 @@ def run_ma(args):
             logger.info(f"  {res.name}  {deck_fmt}")
 
     if note_summary.errors:
-        _log_import_errors(import_summary)
+        _log_files_to_anki_errors(import_summary)
 
     protected = import_summary.protected_note_groups
     if protected:
         protected_total = sum(group.note_count for group in protected)
         logger.warning(
-            f"Protected {protected_total} keyless Anki note(s) during import."
+            f"Protected {protected_total} keyless Anki note(s) during "
+            "files -> Anki sync."
         )
         logger.warning(f"Affected deck(s): {len(protected)}")
         for group in protected:
             logger.warning(f"  - {group.deck_name} ({group.note_count} notes)")
         logger.warning(
             "These notes were kept and not deleted because they do not have "
-            "an AnkiOps Key. Add note_key comments in markdown and re-import "
-            "to bring them under sync management."
+            "an AnkiOps Key. Add note_key comments in markdown and run "
+            "'ankiops fa' to bring them under sync management."
         )
 
     if untracked:
@@ -277,12 +282,12 @@ def run_ma(args):
         )
         for deck in untracked:
             logger.warning(f"  - {deck.deck_name} ({len(deck.note_ids)} notes)")
-        logger.warning("Use 'ankiops am' to bring them into your collection.")
+        logger.warning("Use 'ankiops af' to bring them into your files.")
 
     if note_summary.errors:
         logger.critical(
-            "Review and resolve errors above, then re-run the import — "
-            "or you risk losing notes with the next export."
+            "Review and resolve errors above, then re-run files -> Anki — "
+            "or you risk losing notes with the next Anki -> files sync."
         )
 
 
@@ -410,7 +415,7 @@ def run_fix_image_widths(args):
         f"{result.images_changed} images changed"
     )
     if result.changed:
-        logger.info("Only Markdown files were edited. Run 'ankiops ma' to sync.")
+        logger.info("Only Markdown files were edited. Run 'ankiops fa' to sync.")
 
 
 def run_llm(args):
@@ -445,10 +450,10 @@ def run_note_type(args):
 def run_shared(args):
     try:
         if getattr(args, "shared_command", None) == "submit" and args.from_anki:
-            run_am(SimpleNamespace(no_auto_commit=False))
+            run_af(SimpleNamespace(no_auto_commit=False))
         run_shared_impl(args)
         if getattr(args, "shared_command", None) == "update" and args.to_anki:
-            run_ma(SimpleNamespace(no_auto_commit=False))
+            run_fa(SimpleNamespace(no_auto_commit=False))
     except ValueError as error:
         logger.error(str(error))
         raise SystemExit(1) from error

--- a/ankiops/collection.py
+++ b/ankiops/collection.py
@@ -1,4 +1,4 @@
-"""Collection paths, initialization, and local workspace shape."""
+"""Collection paths, initialization, and local file tree shape."""
 
 from __future__ import annotations
 

--- a/ankiops/shared/commands.py
+++ b/ankiops/shared/commands.py
@@ -95,7 +95,7 @@ def run_create(args) -> None:
     )
     logger.info(
         "Created shared source %s from %s. "
-        "Run 'ankiops ma' to apply scoped note types to Anki.",
+        "Run 'ankiops fa' to apply scoped note types to Anki.",
         source.source_id,
         args.deck,
     )

--- a/ankiops/shared/errors.py
+++ b/ankiops/shared/errors.py
@@ -9,5 +9,5 @@ def format_missing_note_keys_error(missing_count: int) -> str:
         f"Missing note_keys for {missing_count} {note_label}. "
         "note_keys are stable IDs AnkiOps needs to match notes across "
         "collections without duplicates. "
-        "Fix: run 'ankiops ma' to assign them."
+        "Fix: run 'ankiops fa' to assign them."
     )

--- a/ankiops/sync/from_anki.py
+++ b/ankiops/sync/from_anki.py
@@ -63,7 +63,7 @@ def _format_pending_note_type_conversion_error(
     return (
         f"Pending note type conversion for note_key {note_key}: Markdown uses "
         f"'{markdown_note_type}' but Anki has '{anki_note_type}'. Run "
-        "'ankiops ma' before exporting with 'ankiops am'."
+        "'ankiops fa' before syncing with 'ankiops af'."
     )
 
 

--- a/ankiops/tutorial/AnkiOps Tutorial.md
+++ b/ankiops/tutorial/AnkiOps Tutorial.md
@@ -45,7 +45,7 @@ E: *Everything renders beautifully on desktop and mobile.*
 ---
 
 Q: How do I get started?
-A: Run `ankiops ma` to import Markdown --> Anki
+A: Run `ankiops fa` to sync files --> Anki
 
-Run `ankiops am` to export Anki --> Markdown
+Run `ankiops af` to sync Anki --> files
 E: Check the README for detailed documentation!

--- a/docs/git_operations.md
+++ b/docs/git_operations.md
@@ -22,8 +22,8 @@ AnkiOps: snapshot before <action>
 
 Examples:
 
-- `AnkiOps: snapshot before export`
-- `AnkiOps: snapshot before import`
+- `AnkiOps: snapshot before anki-to-files`
+- `AnkiOps: snapshot before files-to-anki`
 - `AnkiOps: snapshot before deserializing`
 - `AnkiOps: snapshot before fixing image widths`
 - `AnkiOps: snapshot before LLM task grammar`
@@ -64,8 +64,8 @@ Important behavior:
 
 | CLI command | Snapshot action | Snapshot scope |
 | --- | --- | --- |
-| `ankiops anki-to-markdown` / `ankiops am` | `export` | Root Markdown deck files plus `media/`. |
-| `ankiops markdown-to-anki` / `ankiops ma` | `import` | Root Markdown deck files plus `media/` and `note_types/`. |
+| `ankiops anki-to-files` / `ankiops af` | `anki-to-files` | Root Markdown deck files plus `media/`. |
+| `ankiops files-to-anki` / `ankiops fa` | `files-to-anki` | Root Markdown deck files plus `media/` and `note_types/`. |
 | `ankiops deserialize` | `deserializing` | Local target Markdown deck files derived from the input JSON after validation. |
 | `ankiops fix-image-widths` | `fixing image widths` | Local Markdown deck files selected by `--deck` and `--no-subdecks`. |
 | `ankiops llm <task> --run` | `LLM task <task>` | Local Markdown deck files containing queued candidate notes. |
@@ -73,8 +73,8 @@ Important behavior:
 Each command accepts `--no-auto-commit` / `-n`, except that LLM only accepts it
 with `<task> --run`.
 
-`ankiops shared update --to-anki` runs `ankiops ma` after updating. `ankiops
-shared submit --from-anki` runs `ankiops am` before preparing the submission.
+`ankiops shared update --to-anki` runs `ankiops fa` after updating. `ankiops
+shared submit --from-anki` runs `ankiops af` before preparing the submission.
 Until shared-aware scoping exists, those nested snapshots use the broad fallback
 when shared sources are present.
 

--- a/docs/module-architecture-plan.md
+++ b/docs/module-architecture-plan.md
@@ -170,7 +170,7 @@ Owns terminal-adjacent helpers:
 
 ### `collection.py`
 
-Owns the AnkiOps collection as a local workspace:
+Owns the AnkiOps collection as a local file tree:
 
 - well-known names: `.ankiops.db`, `note_types/`, `media/`, `llm/`
 - deck name to filename mapping

--- a/tests/integration/cli/test_cli_sync.py
+++ b/tests/integration/cli/test_cli_sync.py
@@ -22,7 +22,7 @@ class _FailingProfileAnki:
         raise AnkiConnectionError("Connection reset by peer")
 
 
-def test_run_ma_warns_for_untracked_anki_decks(world, caplog):
+def test_run_fa_warns_for_untracked_anki_decks(world, caplog):
     world.add_anki_note(
         deck_name="AnkiOnlyDeck",
         fields={"Question": "remote", "Answer": "remote"},
@@ -30,18 +30,18 @@ def test_run_ma_warns_for_untracked_anki_decks(world, caplog):
     )
 
     with caplog.at_level(logging.WARNING):
-        world.run_ma()
+        world.run_fa()
 
     assert "untracked Anki deck(s)" in caplog.text
     assert "AnkiOnlyDeck" in caplog.text
     world.assert_anki_note(deck_name="AnkiOnlyDeck", note_key="remote-key")
 
 
-def test_run_ma_has_no_untracked_warning_for_declared_collection(world, caplog):
+def test_run_fa_has_no_untracked_warning_for_declared_collection(world, caplog):
     world.write_deck("DeclaredDeck", "Q: local\nA: answer")
 
     with caplog.at_level(logging.WARNING):
-        world.run_ma()
+        world.run_fa()
 
     assert "untracked Anki deck(s)" not in caplog.text
     world.assert_anki_note(
@@ -52,7 +52,7 @@ def test_run_ma_has_no_untracked_warning_for_declared_collection(world, caplog):
     assert world.extract_note_keys("DeclaredDeck")
 
 
-def test_run_ma_warns_for_keyless_anki_notes_it_protects(world, caplog):
+def test_run_fa_warns_for_keyless_anki_notes_it_protects(world, caplog):
     world.write_qa_deck("ProtectDeck", [("managed", "local", "managed-key")])
     keyless_id = world.add_anki_note(
         deck_name="ProtectDeck",
@@ -60,26 +60,29 @@ def test_run_ma_warns_for_keyless_anki_notes_it_protects(world, caplog):
     )
 
     with caplog.at_level(logging.WARNING):
-        world.run_ma()
+        world.run_fa()
 
-    assert "Protected 1 keyless Anki note(s) during import." in caplog.text
+    assert (
+        "Protected 1 keyless Anki note(s) during files -> Anki sync."
+        in caplog.text
+    )
     assert "ProtectDeck" in caplog.text
     assert keyless_id in world.mock_anki.notes
 
 
-def test_run_am_warns_for_keyless_markdown_notes_it_protects(world, caplog):
+def test_run_af_warns_for_keyless_markdown_notes_it_protects(world, caplog):
     world.write_deck("DraftDeck", "Q: draft\nA: keep me")
 
     with caplog.at_level(logging.WARNING):
-        world.run_am()
+        world.run_af()
 
     assert "Protected 1 local markdown note(s)" in caplog.text
     assert "DraftDeck" in caplog.text
-    assert "Use 'ankiops ma'" in caplog.text
+    assert "Use 'ankiops fa'" in caplog.text
     world.assert_deck_contains("DraftDeck", "Q: draft")
 
 
-def test_run_ma_logs_import_errors_with_actionable_details(world, caplog):
+def test_run_fa_logs_sync_errors_with_actionable_details(world, caplog):
     world.write_deck(
         "Rhetorik",
         (
@@ -96,22 +99,22 @@ def test_run_ma_logs_import_errors_with_actionable_details(world, caplog):
     )
 
     with caplog.at_level(logging.ERROR):
-        world.run_ma()
+        world.run_fa()
 
-    assert "Import errors:" in caplog.text
+    assert "Files -> Anki errors:" in caplog.text
     assert "Rhetorik" in caplog.text
     assert "field names differ" in caplog.text
     assert "Review and resolve errors above" in caplog.text
 
 
-def test_run_ma_auto_commit_snapshots_declared_state_before_sync_mutates_media(
+def test_run_fa_auto_commit_snapshots_declared_state_before_sync_mutates_media(
     world,
 ):
     world.init_git()
     world.write_deck("MediaDeck", "Q: prompt\nA: ![img](media/img.png)")
     world.write_media("img.png", b"image-content")
 
-    world.run_ma(no_auto_commit=False)
+    world.run_fa(no_auto_commit=False)
 
     committed = subprocess.run(
         ["git", "show", "HEAD:MediaDeck.md"],
@@ -128,7 +131,7 @@ def test_run_ma_auto_commit_snapshots_declared_state_before_sync_mutates_media(
     assert "<!-- note_key:" in working
 
 
-def test_run_am_auto_commit_snapshots_markdown_before_export_updates(world):
+def test_run_af_auto_commit_snapshots_markdown_before_export_updates(world):
     world.write_deck(
         "ExportDeck",
         "<!-- note_key: key-1 -->\nQ: prompt\nA: committed answer",
@@ -145,7 +148,7 @@ def test_run_am_auto_commit_snapshots_markdown_before_export_updates(world):
         "<!-- note_key: key-1 -->\nQ: prompt\nA: local draft",
     )
 
-    world.run_am(no_auto_commit=False)
+    world.run_af(no_auto_commit=False)
 
     committed = subprocess.run(
         ["git", "show", "HEAD:ExportDeck.md"],
@@ -160,19 +163,19 @@ def test_run_am_auto_commit_snapshots_markdown_before_export_updates(world):
     assert "A: Anki answer" in working
 
 
-def test_run_ma_logs_real_media_status(world, caplog):
+def test_run_fa_logs_real_media_status(world, caplog):
     world.write_deck("MediaDeck", "Q: prompt\nA: ![img](media/img.png)")
     world.write_media("img.png", b"image-content")
 
     with caplog.at_level(logging.INFO):
-        world.run_ma()
+        world.run_fa()
 
     assert "Media: 1 files checked" in caplog.text
     assert "1 hashed" in caplog.text
     assert "1 synced" in caplog.text
 
 
-def test_run_ma_reuses_note_type_sync_cache_on_second_run(world, caplog):
+def test_run_fa_reuses_note_type_sync_cache_on_second_run(world, caplog):
     for path in world.note_types_dir.iterdir():
         if path.is_dir() and path.name != "AnkiOpsQA":
             shutil.rmtree(path)
@@ -180,7 +183,7 @@ def test_run_ma_reuses_note_type_sync_cache_on_second_run(world, caplog):
     world.write_deck("CachedTypesDeck", "Q: prompt\nA: answer")
 
     with caplog.at_level(logging.INFO):
-        world.run_ma()
+        world.run_fa()
 
     assert "Note types: 1 synced" in caplog.text
 
@@ -188,7 +191,7 @@ def test_run_ma_reuses_note_type_sync_cache_on_second_run(world, caplog):
     caplog.clear()
 
     with caplog.at_level(logging.INFO):
-        world.run_ma()
+        world.run_fa()
 
     note_type_diff_actions = {
         "modelFieldAdd",
@@ -214,7 +217,7 @@ def test_run_ma_reuses_note_type_sync_cache_on_second_run(world, caplog):
     ]
 
 
-def test_run_am_logs_missing_anki_media_summary(world, caplog):
+def test_run_af_logs_missing_anki_media_summary(world, caplog):
     world.write_deck(
         "MediaDeck",
         "<!-- note_key: key-1 -->\nQ: prompt\nA: ![missing](media/missing.png)",
@@ -227,7 +230,7 @@ def test_run_am_logs_missing_anki_media_summary(world, caplog):
     world.seed_db_link("key-1", note_id)
 
     with caplog.at_level(logging.INFO):
-        world.run_am()
+        world.run_af()
 
     assert "Media: 1 files checked" in caplog.text
     assert "0 pulled, 1 missing in Anki" in caplog.text
@@ -493,7 +496,7 @@ def test_run_fix_image_widths_can_skip_snapshot_and_logs_sync_reminder(
 
     snapshot_mock.assert_not_called()
     assert "Only Markdown files were edited" in caplog.text
-    assert "ankiops ma" in caplog.text
+    assert "ankiops fa" in caplog.text
 
 
 def test_run_fix_image_widths_uses_broad_snapshot_with_shared_sources(tmp_path):

--- a/tests/support/sync_world.py
+++ b/tests/support/sync_world.py
@@ -10,8 +10,8 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from ankiops.anki import Anki
-from ankiops.cli_commands import run_am as run_cli_am
-from ankiops.cli_commands import run_ma as run_cli_ma
+from ankiops.cli_commands import run_af as run_cli_af
+from ankiops.cli_commands import run_fa as run_cli_fa
 from ankiops.collection import (
     ANKIOPS_DB,
     LOCAL_MEDIA_DIR,
@@ -110,7 +110,7 @@ class SyncWorld:
 
         return sync_all_media_from_anki(self.anki, self.root, db)
 
-    def run_ma(self, *, no_auto_commit: bool = True) -> None:
+    def run_fa(self, *, no_auto_commit: bool = True) -> None:
         args = SimpleNamespace(no_auto_commit=no_auto_commit)
         with (
             patch("ankiops.cli_commands.connect_or_exit", return_value=self.anki),
@@ -119,9 +119,9 @@ class SyncWorld:
                 return_value=self.root,
             ),
         ):
-            run_cli_ma(args)
+            run_cli_fa(args)
 
-    def run_am(self, *, no_auto_commit: bool = True) -> None:
+    def run_af(self, *, no_auto_commit: bool = True) -> None:
         args = SimpleNamespace(no_auto_commit=no_auto_commit)
         with (
             patch("ankiops.cli_commands.connect_or_exit", return_value=self.anki),
@@ -130,7 +130,7 @@ class SyncWorld:
                 return_value=self.root,
             ),
         ):
-            run_cli_am(args)
+            run_cli_af(args)
 
     def deck_path(self, deck_name: str) -> Path:
         safe = deck_name_to_file_stem(deck_name)

--- a/tests/unit/test_shared_commands.py
+++ b/tests/unit/test_shared_commands.py
@@ -245,7 +245,7 @@ def test_create_rejects_missing_note_keys_before_file_mutations(
         "Missing note_keys for 1 note. "
         "note_keys are stable IDs AnkiOps needs to match notes across "
         "collections without duplicates. "
-        "Fix: run 'ankiops ma' to assign them."
+        "Fix: run 'ankiops fa' to assign them."
     )
     assert "explicit note_key" not in message
     assert "Deck.md note" not in message
@@ -620,7 +620,7 @@ def test_submit_rejects_keyless_notes_without_mutating_files(
         "Missing note_keys for 1 note. "
         "note_keys are stable IDs AnkiOps needs to match notes across "
         "collections without duplicates. "
-        "Fix: run 'ankiops ma' to assign them."
+        "Fix: run 'ankiops fa' to assign them."
     )
     assert "explicit note_key" not in message
     assert "Deck.md note" not in message


### PR DESCRIPTION
## Summary
- Rename the Anki sync commands and aliases from markdown-oriented names to file-oriented names
- Update README, CLI help, add-on labels, logs, errors, and tutorial text to match the new terminology
- Refresh integration and unit tests to cover the renamed commands and messages

## Testing
- Unit and integration tests updated to cover the renamed CLI handlers and user-facing output
- Not run (not requested)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a pure rename of the two main sync CLI commands: `anki-to-markdown`/`am` → `anki-to-files`/`af` and `markdown-to-anki`/`ma` → `files-to-anki`/`fa`. There are no functional changes — only symbol renames, log/error message rewording, and documentation updates.

- **CLI & add-on**: `cli.py` subparsers, `toolbar.py` button labels/IDs, and the welcome screen are all updated to the new names.
- **Messages & docs**: Log lines, warning text, error strings, README, tutorial, and `docs/git_operations.md` are consistently updated to the new terminology.
- **Tests**: Integration and unit test names and inline string assertions updated to match the renamed commands and messages.

<h3>Confidence Score: 4/5</h3>

Safe to merge — no logic or data changes, only a rename of CLI command names and their associated labels, messages, and documentation.

All 15 changed files are purely cosmetic: command strings, log messages, test names, and docs. The rename is applied consistently across the CLI parser, add-on toolbar, shared commands, error messages, tutorial, and tests. The only residual inconsistency is a single log warning inside run_af that still says "import them" after the rename retired that term.

ankiops/cli_commands.py — one stale "import" verb in a user-visible warning message.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ankiops/cli_commands.py | Renamed run_am→run_af and run_ma→run_fa; updated all log/warning messages. One stale "import" verb remains in the run_af warning. |
| ankiops/cli.py | Subparsers, aliases, help text, and welcome screen updated from am/ma to af/fa and anki-to-markdown/markdown-to-anki to anki-to-files/files-to-anki throughout. |
| anki_addon/toolbar.py | Toolbar button cmd names, labels, tips, and ids updated from am/ma to af/fa; Anki UI reset trigger updated from "ma" to "fa". |
| tests/support/sync_world.py | Helper methods run_am/run_ma renamed to run_af/run_fa with matching import aliases; all test call sites updated. |
| tests/integration/cli/test_cli_sync.py | Test function names and log-message assertions updated to match renamed commands; coverage is unchanged. |
| README.md | All CLI command references updated from am/ma to af/fa; quick-start steps, FAQ, and addon description aligned with new terminology. |
| docs/git_operations.md | Snapshot action names updated from "export"/"import" to "anki-to-files"/"files-to-anki" in examples and the reference table. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI as ankiops CLI
    participant Anki
    participant Files as Local Files

    Note over CLI: ankiops fa (files-to-anki)
    User->>CLI: ankiops fa
    CLI->>Files: read Markdown decks + note types
    CLI->>Anki: apply changes (sync)
    Anki-->>CLI: result
    CLI-->>User: "Files -> Anki: N decks with M notes"

    Note over CLI: ankiops af (anki-to-files)
    User->>CLI: ankiops af
    CLI->>Anki: read notes + media
    CLI->>Files: write Markdown decks
    Files-->>CLI: result
    CLI-->>User: "Anki -> files: N decks with M notes"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Rename sync commands to files"](https://github.com/visserle/ankiops/commit/f9af98d0c2b90d1df4104b517652006effc09cb6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37492039)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->