### PR TITLE
Ensure deck exports end with a newline

### DIFF
--- a/ankiops/interchange.py
+++ b/ankiops/interchange.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from ankiops.collection import (
     ANKIOPS_DB,
@@ -24,13 +24,12 @@ from ankiops.deck_sources import (
 )
 from ankiops.markdown import (
     DeckFile,
-    format_note_key_comment,
-    format_note_type_comment,
-    format_tags_comment,
     read_deck_file,
+    render_notes_to_markdown,
+    write_deck_file,
 )
 from ankiops.note_types import NoteType
-from ankiops.notes import normalize_tags
+from ankiops.notes import Note
 
 logger = logging.getLogger(__name__)
 
@@ -341,42 +340,21 @@ def _write_validated_decks(
 
     for deck in decks:
         output_path = _deserialize_target_path(deck)
-
-        lines = []
-        written_notes = 0
-
-        for note in deck.notes:
-            note_key = note["note_key"]
-            note_type = str(note["note_type"])
-            fields = note["fields"]
-            tags = normalize_tags(note["tags"])
-            config = deck.note_types_by_name[note_type]
-
-            if note_key is not None:
-                lines.append(format_note_key_comment(note_key))
-            lines.append(format_note_type_comment(note_type))
-            tag_comment = format_tags_comment(tags)
-            if tag_comment:
-                lines.append(tag_comment)
-
-            for field in config.fields:
-                field_content = fields.get(field.name)
-                if field_content and field.label:
-                    lines.append(f"{field.label} {field_content}")
-            written_notes += 1
-
-            lines.append("")
-            lines.append("---")
-            lines.append("")
-
-        # Remove trailing separator
-        while lines and lines[-1] in ("", "---"):
-            lines.pop()
-
-        content = "\n".join(lines)
+        notes = [
+            Note(
+                note_key=cast(str | None, note["note_key"]),
+                note_type=cast(str, note["note_type"]),
+                fields=cast(dict[str, str], note["fields"]),
+                tags=cast(list[str], note["tags"]),
+            )
+            for note in deck.notes
+        ]
+        content = (
+            render_notes_to_markdown(notes, deck.note_types_by_name) if notes else ""
+        )
+        written_notes = len(notes)
         if overwrite or not output_path.exists():
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            output_path.write_text(content, encoding="utf-8")
+            write_deck_file(output_path, content)
             created_message = (
                 f"  Created {clickable_path(output_path)} ({written_notes} notes)"
             )

--- a/ankiops/markdown.py
+++ b/ankiops/markdown.py
@@ -271,7 +271,13 @@ def read_deck_file(
 
 def write_deck_file(file_path: Path, content: str) -> None:
     file_path.parent.mkdir(parents=True, exist_ok=True)
-    file_path.write_text(content, encoding="utf-8")
+    file_path.write_text(_ensure_final_newline(content), encoding="utf-8")
+
+
+def _ensure_final_newline(content: str) -> str:
+    if content and not content.endswith("\n"):
+        return content + "\n"
+    return content
 
 
 def find_deck_files(directory: Path) -> list[Path]:

--- a/tests/integration/serialization/test_collection_serializer.py
+++ b/tests/integration/serialization/test_collection_serializer.py
@@ -504,6 +504,24 @@ def test_deserialize_accepts_null_note_key(tmp_path, fs):
     assert "Q: Q" in content
 
 
+def test_deserialize_writes_final_newline(tmp_path, fs):
+    note_types_dir = _init_collection(tmp_path, fs)
+
+    deserialize(
+        {"decks": [_serialized_deck(name="NewlineDeck", note_key="nk-newline")]},
+        collection_dir=tmp_path,
+        note_types_dir=note_types_dir,
+        overwrite=True,
+    )
+
+    assert (tmp_path / "NewlineDeck.md").read_text(encoding="utf-8") == (
+        "<!-- note_key: nk-newline -->\n"
+        "<!-- note_type: AnkiOpsQA -->\n"
+        "Q: Q\n"
+        "A: A\n"
+    )
+
+
 def test_deserialize_rejects_shared_source_with_missing_note_types(tmp_path, fs):
     note_types_dir = _init_collection(tmp_path, fs)
     (tmp_path / "shared" / "owner" / "repo").mkdir(parents=True)

--- a/tests/unit/domain/test_markdown_write.py
+++ b/tests/unit/domain/test_markdown_write.py
@@ -1,0 +1,25 @@
+from ankiops.markdown import write_deck_file
+
+
+def test_write_deck_file_adds_final_newline_to_non_empty_content(tmp_path):
+    path = tmp_path / "Deck.md"
+
+    write_deck_file(path, "Q: Question")
+
+    assert path.read_text(encoding="utf-8") == "Q: Question\n"
+
+
+def test_write_deck_file_keeps_existing_final_newline(tmp_path):
+    path = tmp_path / "Deck.md"
+
+    write_deck_file(path, "Q: Question\n")
+
+    assert path.read_text(encoding="utf-8") == "Q: Question\n"
+
+
+def test_write_deck_file_keeps_empty_content_empty(tmp_path):
+    path = tmp_path / "Deck.md"
+
+    write_deck_file(path, "")
+
+    assert path.read_text(encoding="utf-8") == ""


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ensures deck export files always end with a trailing newline, a common POSIX/editor convention. It also refactors `_write_validated_decks` to delegate rendering and writing to `render_notes_to_markdown` and `write_deck_file`, removing duplicated inline logic.

- `_ensure_final_newline` is added to `write_deck_file` as a defensive guard; `render_notes_to_markdown` already appends `"\n"` directly, so the guard is a no-op for normal content but protects future callers passing content without a trailing newline.
- `_write_validated_decks` is simplified by constructing typed `Note` objects via `cast` and delegating to the shared rendering path.
- Unit and integration tests cover the three relevant cases: no trailing newline (gets one added), already has one (unchanged), and empty content (stays empty).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to trailing-newline handling and a clean refactor of the write path.

The newline guard in `write_deck_file` and the `"
"` appended in `render_notes_to_markdown` are consistent and non-overlapping. The `cast` calls in `interchange.py` match the shape of the underlying dicts. All three edge cases (no newline, existing newline, empty content) are covered by the new unit tests, and the integration test locks down the full end-to-end output.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ankiops/markdown.py | Adds `_ensure_final_newline` helper and wires it into `write_deck_file`; `render_notes_to_markdown` already appends `"\n"`, so no double-newline risk. |
| ankiops/interchange.py | Refactors `_write_validated_decks` to use typed `Note` objects with `cast` and delegates rendering/writing to `render_notes_to_markdown` + `write_deck_file`, removing duplicated logic. |
| tests/unit/domain/test_markdown_write.py | New unit tests covering: missing trailing newline, existing trailing newline, and empty content — all correct. |
| tests/integration/serialization/test_collection_serializer.py | Adds an integration test that asserts the full deserialized file content ends with a trailing newline; strict equality check provides good regression coverage. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[_write_validated_decks] --> B{notes empty?}
    B -- yes --> C[content = '']
    B -- no --> D[render_notes_to_markdown]
    D --> E["content = NOTE_SEPARATOR.join(parts) + '\n'"]
    C --> F[write_deck_file]
    E --> F
    F --> G[_ensure_final_newline]
    G --> H{content empty?}
    H -- yes --> I[return '' unchanged]
    H -- no --> J{ends with '\n'?}
    J -- yes --> K[return content unchanged]
    J -- no --> L[return content + '\n']
    I --> M[file_path.write_text]
    K --> M
    L --> M
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Ensure deck exports end with a newline"](https://github.com/visserle/ankiops/commit/39a9b5df07bc2a9677d48d2d7b980283e7955bed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37495111)</sub>

<!-- /greptile_comment -->