### PR TITLE
improve md file handling

### DIFF
--- a/ankiops/cli_commands.py
+++ b/ankiops/cli_commands.py
@@ -16,7 +16,11 @@ from ankiops.collection import (
     require_collection_dir,
 )
 from ankiops.console import clickable_path, connect_or_exit
-from ankiops.deck_sources import discover_deck_sources, load_note_types_for_sources
+from ankiops.deck_sources import (
+    DeckSource,
+    discover_deck_sources,
+    load_note_types_for_sources,
+)
 from ankiops.git import git_snapshot
 from ankiops.image_widths import fix_image_widths_collection
 from ankiops.interchange import (
@@ -79,7 +83,7 @@ def _snapshot_paths(
 
 
 def _local_markdown_paths(collection_dir: Path) -> list[Path]:
-    return sorted(collection_dir.glob("*.md"))
+    return DeckSource.local(collection_dir).deck_files()
 
 
 def run_init(args):

--- a/ankiops/collection.py
+++ b/ankiops/collection.py
@@ -49,6 +49,11 @@ def sanitize_filename(deck_name: str) -> str:
 
 def deck_name_to_file_stem(deck_name: str) -> str:
     """Encode an Anki deck name to a reversible Markdown filename stem."""
+    if "_::" in deck_name or "::_" in deck_name:
+        raise ValueError(
+            f"Ambiguous deck name '{deck_name}': do not place '_' next to "
+            "the '::' subdeck separator."
+        )
     return (
         deck_name.replace("%", "%25")
         .replace("__", "%5F%5F")

--- a/ankiops/deck_sources.py
+++ b/ankiops/deck_sources.py
@@ -10,11 +10,15 @@ from ankiops.note_types import NoteType, load_note_types
 
 SHARED_DIR = "shared"
 SHARED_BRANCH = "main"
-RESERVED_SHARED_MARKDOWN = {
-    "README.md",
-    "README.markdown",
-    "LICENSE.md",
-    "CHANGELOG.md",
+RESERVED_MARKDOWN_FILES = {
+    "CHANGELOG.MD",
+    "CODE_OF_CONDUCT.MD",
+    "CONTRIBUTING.MD",
+    "FUNDING.MD",
+    "LICENSE.MD",
+    "README.MD",
+    "SECURITY.MD",
+    "SUPPORT.MD",
 }
 
 
@@ -76,23 +80,24 @@ class DeckSource:
         prefix = f"{self.source_id}/"
         return name[len(prefix) :] if name.startswith(prefix) else name
 
+    def deck_files(self) -> list[Path]:
+        files = []
+        for path in sorted(self.root.glob("*.md")):
+            if path.name.upper() in RESERVED_MARKDOWN_FILES:
+                continue
+            if "___" in path.stem:
+                raise ValueError(
+                    f"Ambiguous deck filename '{path.name}': do not place '_' "
+                    "next to the '__' subdeck separator."
+                )
+            files.append(path)
+        return files
+
 
 @dataclass(frozen=True)
 class SourceNoteTypes:
     source: DeckSource
     note_types: list[NoteType]
-
-
-def is_reserved_shared_markdown(path: Path) -> bool:
-    name = path.name
-    return name in RESERVED_SHARED_MARKDOWN or name.startswith("_")
-
-
-def deck_files_for_source(source: DeckSource) -> list[Path]:
-    files = sorted(source.root.glob("*.md"))
-    if not source.is_shared:
-        return files
-    return [path for path in files if not is_reserved_shared_markdown(path)]
 
 
 def discover_deck_sources(

--- a/ankiops/interchange.py
+++ b/ankiops/interchange.py
@@ -18,7 +18,6 @@ from ankiops.collection import (
 from ankiops.console import clickable_path
 from ankiops.deck_sources import (
     DeckSource,
-    deck_files_for_source,
     discover_deck_sources,
     load_note_types_for_source,
 )
@@ -145,7 +144,7 @@ def _parse_sources(
     parsed_decks: list[_ParsedDeck] = []
     for source in sources:
         configs = load_note_types_for_source(source)
-        for md_file in deck_files_for_source(source):
+        for md_file in source.deck_files():
             try:
                 parsed = read_deck_file(
                     md_file,

--- a/ankiops/markdown.py
+++ b/ankiops/markdown.py
@@ -7,6 +7,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
+from ankiops.deck_sources import DeckSource
 from ankiops.note_types import (
     ANKIOPS_KEY_FIELD,
     NoteType,
@@ -275,8 +276,6 @@ def write_deck_file(file_path: Path, content: str) -> None:
 
 
 def find_deck_files(directory: Path) -> list[Path]:
-    from ankiops.deck_sources import DeckSource
-
     return DeckSource.local(directory).deck_files()
 
 

--- a/ankiops/markdown.py
+++ b/ankiops/markdown.py
@@ -275,7 +275,9 @@ def write_deck_file(file_path: Path, content: str) -> None:
 
 
 def find_deck_files(directory: Path) -> list[Path]:
-    return sorted(directory.glob("*.md"), key=lambda path: path.name)
+    from ankiops.deck_sources import DeckSource
+
+    return DeckSource.local(directory).deck_files()
 
 
 def render_notes_to_markdown(

--- a/ankiops/media.py
+++ b/ankiops/media.py
@@ -13,7 +13,6 @@ from ankiops.collection import LOCAL_MEDIA_DIR
 from ankiops.console import clickable_path
 from ankiops.deck_sources import (
     DeckSource,
-    deck_files_for_source,
     discover_deck_sources,
 )
 from ankiops.sync.report import Change, ChangeType, SyncReport
@@ -84,7 +83,12 @@ def calculate_blake3(file_path: Path) -> str:
     return hash_state.hexdigest(length=4)
 
 
-def update_references(directory: Path, rename_map: dict[str, str]) -> int:
+def update_references(
+    directory: Path,
+    rename_map: dict[str, str],
+    *,
+    md_files: list[Path] | None = None,
+) -> int:
     if not rename_map:
         return 0
 
@@ -123,7 +127,9 @@ def update_references(directory: Path, rename_map: dict[str, str]) -> int:
             new_path = f"<{new_path}>"
         return f"{opener}{new_path}{suffix}"
 
-    for md_file in directory.glob("*.md"):
+    if md_files is None:
+        md_files = DeckSource.local(directory).deck_files()
+    for md_file in md_files:
         content = md_file.read_text(encoding="utf-8")
         new_content = pattern.sub(replace_callback, content)
         if new_content != content:
@@ -142,10 +148,8 @@ def _collect_referenced_media(
     prune_cache: bool = True,
 ) -> set[str]:
     resolved_cache_root = cache_root or collection_dir
-    md_files = md_files or sorted(
-        collection_dir.glob("*.md"),
-        key=lambda path: path.name,
-    )
+    if md_files is None:
+        md_files = DeckSource.local(collection_dir).deck_files()
     md_keys = [
         _markdown_cache_key(resolved_cache_root, md_file) for md_file in md_files
     ]
@@ -307,7 +311,7 @@ def hash_and_update_references(
 
     # 3. Update Markdown files in bulk
     if rename_map:
-        count = update_references(collection_dir, rename_map)
+        count = update_references(collection_dir, rename_map, md_files=md_files)
         logger.debug(f"Updated {count} markdown files with {len(rename_map)} renames")
         # 4. Re-collect now-correctly-hashed active references
         final_referenced = _collect_referenced_media(
@@ -523,7 +527,7 @@ def _prune_media_cache_for_sources(
     md_keys = [
         _markdown_cache_key(collection_dir, md_file)
         for source in sources
-        for md_file in deck_files_for_source(source)
+        for md_file in source.deck_files()
     ]
     pruned = db_port.prune_markdown_media_cache(md_keys)
     if pruned:
@@ -545,7 +549,7 @@ def sync_all_media_to_anki(
             source.root,
             db_port,
             cache_root=collection_dir,
-            md_files=deck_files_for_source(source),
+            md_files=source.deck_files(),
             prune_cache=False,
         )
         _combine_media_result(combined, source_result)
@@ -567,7 +571,7 @@ def sync_all_media_from_anki(
             source.root,
             db_port,
             cache_root=collection_dir,
-            md_files=deck_files_for_source(source),
+            md_files=source.deck_files(),
             prune_cache=False,
         )
         _combine_media_result(combined, source_result)

--- a/ankiops/shared/commands.py
+++ b/ankiops/shared/commands.py
@@ -12,7 +12,6 @@ from ankiops.collection import require_collection_dir
 from ankiops.console import clickable_path
 from ankiops.deck_sources import (
     DeckSource,
-    deck_files_for_source,
     discover_deck_sources,
     load_note_types_for_source,
 )
@@ -74,7 +73,7 @@ def _ensure_submittable_note_keys(source: DeckSource) -> None:
     configs = load_note_types_for_source(source)
     missing: list[str] = []
 
-    for md_file in deck_files_for_source(source):
+    for md_file in source.deck_files():
         parsed = read_deck_file(md_file, note_types=configs, context_root=source.root)
         for index, note in enumerate(parsed.notes, start=1):
             if not note.note_key:

--- a/ankiops/shared/create.py
+++ b/ankiops/shared/create.py
@@ -102,7 +102,8 @@ def _selected_deck_files(collection_dir: Path, deck: str) -> list[Path]:
     deck_filter = deck.strip()
     subdeck_scope = f"{deck_filter}::"
     files = []
-    for md_file in sorted(collection_dir.glob("*.md")):
+    local_source = DeckSource.local(collection_dir)
+    for md_file in local_source.deck_files():
         deck_name = file_stem_to_deck_name(md_file.stem)
         if deck_name == deck_filter or deck_name.startswith(subdeck_scope):
             files.append(md_file)

--- a/ankiops/sync/from_anki.py
+++ b/ankiops/sync/from_anki.py
@@ -10,7 +10,6 @@ from ankiops.collection import (
 )
 from ankiops.deck_sources import (
     DeckSource,
-    deck_files_for_source,
     discover_deck_sources,
     load_note_types_for_sources,
 )
@@ -591,7 +590,7 @@ def sync_collection_from_anki(
         file_map_by_deck_name: dict[str, tuple[DeckSource, Path]] = {}
         deck_conflicts: list[str] = []
         for source in sources:
-            for md_file in deck_files_for_source(source):
+            for md_file in source.deck_files():
                 md_files.append(md_file)
                 source_by_file[md_file] = source
                 deck_name = file_stem_to_deck_name(md_file.stem)

--- a/ankiops/sync/to_anki.py
+++ b/ankiops/sync/to_anki.py
@@ -8,7 +8,6 @@ from ankiops.anki import Anki
 from ankiops.collection import file_stem_to_deck_name
 from ankiops.deck_sources import (
     DeckSource,
-    deck_files_for_source,
     discover_deck_sources,
     load_note_types_for_sources,
 )
@@ -55,7 +54,7 @@ def _load_source_deck_files(
 
     source_deck_files: list[_SourceDeckFile] = []
     for source_types in source_note_types:
-        for deck_path in deck_files_for_source(source_types.source):
+        for deck_path in source_types.source.deck_files():
             source_deck_files.append(
                 _SourceDeckFile(
                     source=source_types.source,

--- a/tests/integration/media/test_media_sync.py
+++ b/tests/integration/media/test_media_sync.py
@@ -86,6 +86,30 @@ def test_sync_all_media_to_anki_resolves_media_relative_to_each_source(tmp_path)
     )
 
 
+def test_sync_media_to_anki_does_not_rewrite_readme_references(tmp_path):
+    media_dir = tmp_path / LOCAL_MEDIA_DIR
+    media_dir.mkdir()
+    (media_dir / "image.png").write_bytes(b"deck image")
+    (tmp_path / "Deck.md").write_text(
+        "Q: Deck\nA: ![img](media/image.png)", encoding="utf-8"
+    )
+    (tmp_path / "README.md").write_text(
+        "# Docs\n\n![img](media/image.png)", encoding="utf-8"
+    )
+
+    anki_media_dir = tmp_path / "anki_media"
+    anki_media_dir.mkdir()
+    anki = _FakeMediaAnki(anki_media_dir)
+
+    result = _sync_to_anki(tmp_path, anki)
+
+    deck_content = (tmp_path / "Deck.md").read_text(encoding="utf-8")
+    readme_content = (tmp_path / "README.md").read_text(encoding="utf-8")
+    assert result.checked == 1
+    assert "image_" in deck_content
+    assert "media/image.png" in readme_content
+
+
 def test_sync_media_to_anki_handles_markdown_html_audio_and_external_refs(tmp_path):
     media_dir = tmp_path / LOCAL_MEDIA_DIR
     media_dir.mkdir()

--- a/tests/integration/serialization/test_collection_serializer.py
+++ b/tests/integration/serialization/test_collection_serializer.py
@@ -120,6 +120,10 @@ def test_serialize_includes_shared_sources_and_ignores_reserved_docs(
     collection, fs, monkeypatch
 ):
     _set_collection_paths(monkeypatch, collection)
+    (collection / "README.md").write_text(
+        "Q: local docs\nA: local docs",
+        encoding="utf-8",
+    )
     shared_root = collection / "shared" / "owner" / "repo"
     fs.eject_default_note_types(shared_root / "note_types")
     (shared_root / "README.md").write_text("# docs", encoding="utf-8")
@@ -138,8 +142,10 @@ def test_serialize_includes_shared_sources_and_ignores_reserved_docs(
 
     decks = {(deck["source"], deck["name"]): deck for deck in result["decks"]}
     assert ("local", "TestDeck") in decks
+    assert ("local", "README") not in decks
     assert ("shared/owner/repo", "Shared") in decks
     assert ("shared/owner/repo", "README") not in decks
+    assert ("shared/owner/repo", "_draft") in decks
     shared_note = decks[("shared/owner/repo", "Shared")]["notes"][0]
     assert shared_note["note_type"] == "shared/owner/repo/AnkiOpsQA"
 

--- a/tests/integration/serialization/test_image_widths_collection.py
+++ b/tests/integration/serialization/test_image_widths_collection.py
@@ -110,6 +110,31 @@ def test_fix_image_widths_collection_rewrites_shared_deck(tmp_path):
     assert "{width=404}" not in shared_file.read_text(encoding="utf-8")
 
 
+def test_fix_image_widths_collection_ignores_readme_docs(tmp_path):
+    note_types_dir = _make_collection(tmp_path)
+    deck_file = _write_qa_deck(
+        tmp_path,
+        "Deck",
+        "![a](a.png){width=400}\n![b](b.png){width=404}",
+    )
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "Q: Docs\nA: ![a](a.png){width=400}\n![b](b.png){width=404}",
+        encoding="utf-8",
+    )
+
+    result = fix_image_widths_collection(
+        tmp_path,
+        width=500,
+        tolerance=5,
+        note_types_dir=note_types_dir,
+    )
+
+    assert result.decks_checked == 1
+    assert "{width=500}" in deck_file.read_text(encoding="utf-8")
+    assert "{width=404}" in readme.read_text(encoding="utf-8")
+
+
 def test_fix_image_widths_collection_updates_unkeyed_notes(tmp_path):
     note_types_dir = _make_collection(tmp_path)
     deck_file = tmp_path / "Broken.md"

--- a/tests/integration/sync/test_sync_matrix_import.py
+++ b/tests/integration/sync/test_sync_matrix_import.py
@@ -83,6 +83,28 @@ def test_imp_fresh_create_002_creates_note_with_tags(world):
         assert content.index("<!-- note_type:") < content.index("<!-- tags:")
 
 
+def test_imp_fresh_create_003_ignores_readme_docs(world):
+    """Import should not treat README docs as decks."""
+    world.write_qa_deck("FreshDeck", [("Fresh Q", "Fresh A", None)])
+    (world.root / "README.md").write_text(
+        "Q: Docs Q\nA: Docs A",
+        encoding="utf-8",
+    )
+
+    with world.db_session() as db:
+        result = world.sync_import(db)
+
+        assert_summary(
+            result.summary, created=1, updated=0, moved=0, deleted=0, errors=0
+        )
+        deck_names = {
+            world.mock_anki.cards[card_id]["deckName"]
+            for note in world.mock_anki.notes.values()
+            for card_id in note["cards"]
+        }
+        assert deck_names == {"FreshDeck"}
+
+
 def test_imp_fresh_create_004_assigns_keys_to_duplicate_first_line_notes(world):
     """Import should key repeated prompts without merging their note blocks."""
     world.write_qa_deck(

--- a/tests/unit/domain/test_deck_filename_mapping.py
+++ b/tests/unit/domain/test_deck_filename_mapping.py
@@ -1,3 +1,5 @@
+import pytest
+
 from ankiops.collection import deck_name_to_file_stem, file_stem_to_deck_name
 
 
@@ -36,3 +38,9 @@ def test_path_separators_are_roundtrip_safe():
 
     assert stem == "A%2FB%5CC"
     assert file_stem_to_deck_name(stem) == deck_name
+
+
+@pytest.mark.parametrize("deck_name", ["A_::B", "A::_B", "A_::_B"])
+def test_underscores_adjacent_to_subdeck_separator_are_rejected(deck_name):
+    with pytest.raises(ValueError, match="Ambiguous deck name"):
+        deck_name_to_file_stem(deck_name)

--- a/tests/unit/domain/test_sources.py
+++ b/tests/unit/domain/test_sources.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import pytest
+
 from ankiops.deck_sources import (
     DeckSource,
-    deck_files_for_source,
     discover_deck_sources,
     load_note_types_for_source,
 )
@@ -25,29 +26,35 @@ def test_discover_deck_sources_includes_local_and_shared(tmp_path):
     assert sources[2].github_url == "https://github.com/owner/repo.git"
 
 
-def test_shared_markdown_files_ignore_reserved_docs(tmp_path):
-    source = DeckSource.shared(tmp_path, "owner", "repo")
-    source.root.mkdir(parents=True)
-    (source.root / "Deck.md").write_text("Q: a\nA: b", encoding="utf-8")
-    (source.root / "README.md").write_text("# docs", encoding="utf-8")
-    (source.root / "LICENSE.md").write_text("# license", encoding="utf-8")
-    (source.root / "CHANGELOG.md").write_text("# changes", encoding="utf-8")
-    (source.root / "_draft.md").write_text("Q: x\nA: y", encoding="utf-8")
+def test_markdown_files_ignore_reserved_docs_in_all_sources(tmp_path):
+    local_source = DeckSource.local(tmp_path)
+    shared_source = DeckSource.shared(tmp_path, "owner", "repo")
+    shared_source.root.mkdir(parents=True)
 
-    assert [path.name for path in deck_files_for_source(source)] == ["Deck.md"]
+    for root in [local_source.root, shared_source.root]:
+        (root / "Deck.md").write_text("Q: a\nA: b", encoding="utf-8")
+        (root / "README.md").write_text("# docs", encoding="utf-8")
+        (root / "LICENSE.md").write_text("# license", encoding="utf-8")
+        (root / "CHANGELOG.md").write_text("# changes", encoding="utf-8")
+        (root / "CONTRIBUTING.md").write_text("# contributing", encoding="utf-8")
+        (root / "_draft.md").write_text("Q: x\nA: y", encoding="utf-8")
 
-
-def test_reserved_markdown_names_are_not_ignored_in_local_root(tmp_path):
-    source = DeckSource.local(tmp_path)
-    for name in ["README.md", "LICENSE.md", "CHANGELOG.md", "_draft.md"]:
-        (tmp_path / name).write_text("Q: local\nA: deck", encoding="utf-8")
-
-    assert [path.name for path in deck_files_for_source(source)] == [
-        "CHANGELOG.md",
-        "LICENSE.md",
-        "README.md",
+    assert [path.name for path in local_source.deck_files()] == [
+        "Deck.md",
         "_draft.md",
     ]
+    assert [path.name for path in shared_source.deck_files()] == [
+        "Deck.md",
+        "_draft.md",
+    ]
+
+
+def test_ambiguous_deck_file_names_raise(tmp_path):
+    source = DeckSource.local(tmp_path)
+    (tmp_path / "a___b.md").write_text("Q: local\nA: deck", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Ambiguous deck filename 'a___b.md'"):
+        source.deck_files()
 
 
 def test_shared_configs_are_scoped_by_source(tmp_path):


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR consolidates all Markdown file discovery behind `DeckSource.deck_files()`, replacing a mix of bare `glob("*.md")` calls and the removed `deck_files_for_source` helper. It also adds case-insensitive filtering of well-known repository docs (`README`, `LICENSE`, `CONTRIBUTING`, etc.) for every source type, not just shared ones, and introduces a guard in `deck_name_to_file_stem` that rejects deck names where `_` is adjacent to the `::` subdeck separator.

- **`DeckSource.deck_files()`** now applies a uniform reserved-file list (case-insensitive) and an ambiguous-stem check (`___`) to both local and shared sources; shared sources no longer silently suppress `_`-prefixed deck files.
- **`deck_name_to_file_stem`** gains an explicit pre-encoding guard for `_::` / `::_` patterns, backed by new parametrized unit tests.
- Media sync, image-width fixes, interchange parser, and CLI path helpers are all updated to use the new method; integration tests cover the new README-exclusion behaviour end-to-end.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the unhandled error path in the export loop.

The refactor is well-tested and the reserved-file filtering and ambiguous-stem detection both work correctly for new collections. The risk is that `deck_name_to_file_stem` now raises `ValueError` for deck names like `Spanish::_Notes` — previously those encoded and decoded with a correct roundtrip — and that call at `from_anki.py:623` has no error handling. Any user upgrading with such a deck name in Anki will have their entire export aborted rather than just that one deck flagged.

ankiops/sync/from_anki.py (line 623) and ankiops/collection.py (the new guard in `deck_name_to_file_stem`) warrant a second look together to decide whether the export loop should catch and report per-deck errors rather than aborting on the first bad name.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| ankiops/deck_sources.py | Replaces `deck_files_for_source` + `is_reserved_shared_markdown` with `DeckSource.deck_files()`. Reserved file filtering (case-insensitive `.MD` set) now applies uniformly to all sources; `_`-prefixed files are no longer silently excluded from shared sources. |
| ankiops/collection.py | Adds pre-encoding validation to `deck_name_to_file_stem` to reject deck names with `_` adjacent to `::`. Guard is correct but raises ValueError that is not caught at all call sites. |
| ankiops/sync/from_anki.py | Updates `deck_files_for_source` callsite to `source.deck_files()`. The newly-propagated ValueError from `deck_name_to_file_stem` at line 623 is not caught, allowing a single problematic deck name to abort the entire export. |
| ankiops/media.py | Replaces raw glob fallbacks with `DeckSource.local().deck_files()` in `update_references` and `_collect_referenced_media`; adds `md_files` keyword arg to `update_references`. Logic is clean. |
| ankiops/markdown.py | Moves top-level import of `DeckSource` (previously lazy) and delegates `find_deck_files` to `DeckSource.local().deck_files()`. |
| tests/unit/domain/test_sources.py | Rewrites source tests to cover both local and shared sources uniformly; replaces deleted `deck_files_for_source` tests with `deck_files()` equivalents and adds ambiguous-filename error assertion. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[DeckSource.deck_files] --> B{Reserved filename?}
    B -- yes --> C[Skip file]
    B -- no --> D{Triple underscore in stem?}
    D -- yes --> E[raise ValueError]
    D -- no --> F[Include file]

    G[deck_name_to_file_stem] --> H{Underscore adjacent to separator?}
    H -- yes --> I[raise ValueError]
    H -- no --> J[Encode to file stem]

    K[from_anki.py export loop] --> L[deck_name_to_file_stem per Anki deck]
    L --> M{ValueError raised?}
    M -- yes --> N[Entire export aborts - no try/except]
    M -- no --> O[Write .md file]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `ankiops/sync/from_anki.py`, line 623 ([link](https://github.com/visserle/ankiops/blob/fbe41f7d34b1952627584e376accc1f6bccf0ec6/ankiops/sync/from_anki.py#L623)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Unhandled ValueError aborts entire export for one bad deck name**

   `deck_name_to_file_stem` now raises `ValueError` for any deck whose name contains `_::` or `::_` (e.g. `Spanish::_Notes`). This call has no surrounding `try/except`, so if a user's Anki collection contains even one deck with that naming pattern, the entire `sync_collection_from_anki` run aborts — no decks are exported at all. Before this PR, `Spanish::_Notes` was encoded to `Spanish___Notes.md` and decoded back to `Spanish::_Notes` with a correct roundtrip, so long-standing users may hit this unexpectedly after upgrading.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["small fix"](https://github.com/visserle/ankiops/commit/fbe41f7d34b1952627584e376accc1f6bccf0ec6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37496799)</sub>

<!-- /greptile_comment -->