### PR TITLE
Include deleted deck files in automatic sync snapshots

### DIFF
--- a/ankiops/cli_commands.py
+++ b/ankiops/cli_commands.py
@@ -18,10 +18,11 @@ from ankiops.collection import (
 from ankiops.console import clickable_path, connect_or_exit
 from ankiops.deck_sources import (
     DeckSource,
+    RESERVED_MARKDOWN_FILES,
     discover_deck_sources,
     load_note_types_for_sources,
 )
-from ankiops.git import git_snapshot
+from ankiops.git import CollectionGit, git_snapshot
 from ankiops.image_widths import fix_image_widths_collection
 from ankiops.interchange import (
     apply_deserialization_plan,
@@ -83,7 +84,50 @@ def _snapshot_paths(
 
 
 def _local_markdown_paths(collection_dir: Path) -> list[Path]:
-    return DeckSource.local(collection_dir).deck_files()
+    paths = DeckSource.local(collection_dir).deck_files()
+    paths.extend(_deleted_local_markdown_paths(collection_dir))
+    return _unique_paths(paths)
+
+
+def _deleted_local_markdown_paths(collection_dir: Path) -> list[Path]:
+    try:
+        result = CollectionGit(collection_dir).run(
+            ["ls-files", "-z", "--deleted"],
+            check=False,
+        )
+    except FileNotFoundError:
+        return []
+    if result.returncode != 0:
+        return []
+
+    paths = []
+    for rel_path in result.stdout.split("\0"):
+        if not rel_path:
+            continue
+        path = collection_dir / rel_path
+        if _is_local_markdown_deck_path(collection_dir, path):
+            paths.append(path)
+    return paths
+
+
+def _is_local_markdown_deck_path(collection_dir: Path, path: Path) -> bool:
+    return (
+        path.parent == collection_dir
+        and path.suffix == ".md"
+        and path.name.upper() not in RESERVED_MARKDOWN_FILES
+        and "___" not in path.stem
+    )
+
+
+def _unique_paths(paths: Sequence[Path]) -> list[Path]:
+    unique = []
+    seen = set()
+    for path in paths:
+        if path in seen:
+            continue
+        unique.append(path)
+        seen.add(path)
+    return unique
 
 
 def run_init(args):

--- a/ankiops/cli_commands.py
+++ b/ankiops/cli_commands.py
@@ -120,14 +120,7 @@ def _is_local_markdown_deck_path(collection_dir: Path, path: Path) -> bool:
 
 
 def _unique_paths(paths: Sequence[Path]) -> list[Path]:
-    unique = []
-    seen = set()
-    for path in paths:
-        if path in seen:
-            continue
-        unique.append(path)
-        seen.add(path)
-    return unique
+    return list(dict.fromkeys(paths))
 
 
 def run_init(args):

--- a/docs/deleted-deck-git-snapshot-bug.md
+++ b/docs/deleted-deck-git-snapshot-bug.md
@@ -1,0 +1,49 @@
+# Deleted Deck Git Snapshot Bug
+
+Date: 2026-06-16
+Status: Reported before fix
+
+## Summary
+
+Deleted Markdown deck files are not included in automatic pre-sync Git snapshot
+commits for syncs between Anki and the filesystem.
+
+## Impact
+
+When a tracked deck file is deleted locally before a sync, `ankiops af` or
+`ankiops fa` can create a snapshot commit that omits the deletion. The following
+sync operation may recreate or otherwise mutate deck files, leaving the Git
+history without the user's explicit deck deletion.
+
+## Expected Behavior
+
+Automatic sync snapshots should include deletions of tracked Markdown deck
+files in the sync scope, matching the documented behavior in
+`docs/git_operations.md`: deleted tracked files inside the scope are included.
+
+## Observed Cause
+
+The sync CLI builds its snapshot scope from `DeckSource.local(...).deck_files()`.
+That helper discovers only Markdown files that currently exist on disk. A deck
+file that has already been deleted is absent from the scoped path list before
+`git_snapshot()` runs, so Git never receives that deleted path as a pathspec.
+
+The lower-level `git_snapshot()` implementation already handles deleted tracked
+paths when the caller supplies the deleted path explicitly; the failure is in
+the sync snapshot scope construction.
+
+## Reproduction Plan
+
+1. Create and commit `DeletedDeck.md` in a temporary AnkiOps collection.
+2. Delete `DeletedDeck.md` from the working tree.
+3. Run a sync command with automatic snapshots enabled.
+4. Inspect the generated snapshot commit.
+
+The snapshot commit should contain `D DeletedDeck.md`. Current behavior is
+expected to omit that deletion.
+
+## Fix Direction
+
+Make sync snapshot path discovery include tracked root Markdown deck files even
+when they no longer exist on disk, while preserving the current exclusions for
+reserved Markdown files and unrelated non-deck files.

--- a/tests/integration/cli/test_cli_sync.py
+++ b/tests/integration/cli/test_cli_sync.py
@@ -163,6 +163,32 @@ def test_run_af_auto_commit_snapshots_markdown_before_export_updates(world):
     assert "A: Anki answer" in working
 
 
+def test_run_fa_auto_commit_snapshots_deleted_markdown_deck_file(world):
+    world.write_deck("DeletedDeck", "Q: prompt\nA: answer")
+    world.init_git()
+    world.deck_path("DeletedDeck").unlink()
+
+    world.run_fa(no_auto_commit=False)
+
+    subject = subprocess.run(
+        ["git", "log", "-1", "--format=%s"],
+        cwd=world.root,
+        text=True,
+        capture_output=True,
+        check=True,
+    ).stdout.strip()
+    committed_paths = subprocess.run(
+        ["git", "show", "--name-status", "--format=", "HEAD"],
+        cwd=world.root,
+        text=True,
+        capture_output=True,
+        check=True,
+    ).stdout
+
+    assert subject == "AnkiOps: snapshot before files-to-anki"
+    assert "D\tDeletedDeck.md" in committed_paths
+
+
 def test_run_fa_logs_real_media_status(world, caplog):
     world.write_deck("MediaDeck", "Q: prompt\nA: ![img](media/img.png)")
     world.write_media("img.png", b"image-content")

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "ankiops"
-version = "0.6.1"
+version = "0.6.4"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary
- Include deleted tracked root Markdown deck files when building automatic sync snapshot pathspecs.
- Preserve existing exclusions for reserved Markdown files and non-deck files.
- Add integration coverage for the `fa` flow when a deck file has been deleted before sync.

## Testing
- Integration test added for snapshotting a deleted Markdown deck file during `fa`.
- Not run (not requested)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where tracked Markdown deck files that were deleted before a sync operation were omitted from the automatic pre-sync Git snapshot, potentially leaving the deletion unrecorded in history. The fix queries `git ls-files --deleted` at snapshot time and merges those paths into the existing scope before the snapshot is taken.

- `_deleted_local_markdown_paths` runs `git ls-files -z --deleted` in the collection directory, filters results through the same root/suffix/reserved/`___`-separator checks used by `deck_files()`, and returns the matched paths. Error cases (no git binary, non-zero exit) silently return an empty list so sync is never blocked.
- A new integration test covers the `fa` flow: write a deck, commit it, delete the file, run `fa` with auto-commit, and assert the snapshot commit contains `D	DeletedDeck.md`.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change is narrowly scoped to snapshot path discovery, never blocks sync on failure, and is covered by a green integration test.

The fix is minimal and targeted: one new git query, two small helpers, and a filter that mirrors the existing deck_files() logic. All failure paths (git not found, non-zero exit, empty repo) return early without affecting sync. The _tracked_or_existing_paths gating in git_snapshot means deleted paths flow correctly through to a staged deletion commit.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ankiops/cli_commands.py | Adds _deleted_local_markdown_paths and _is_local_markdown_deck_path helpers; _local_markdown_paths now merges live and deleted paths before snapshot. Logic is correct, error handling is thorough, and the filter mirrors existing deck_files() semantics. |
| tests/integration/cli/test_cli_sync.py | Adds test_run_fa_auto_commit_snapshots_deleted_markdown_deck_file which exercises the deletion-snapshot path end-to-end. Test setup and assertions are correct. |
| docs/deleted-deck-git-snapshot-bug.md | New bug-report document describing root cause, expected behaviour, and fix direction. Documentation only, no code impact. |
| uv.lock | Version bump from 0.6.1 to 0.6.4; lock file regenerated. No dependency changes visible in the diff. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CLI as run_fa / run_af
    participant LMP as _local_markdown_paths
    participant DFS as DeckSource.deck_files()
    participant DLM as _deleted_local_markdown_paths
    participant GIT as CollectionGit (git ls-files -z --deleted)
    participant SNAP as git_snapshot

    CLI->>LMP: collection_dir
    LMP->>DFS: "glob *.md (existing files)"
    DFS-->>LMP: [ExistingDeck.md, ...]
    LMP->>DLM: collection_dir
    DLM->>GIT: ls-files -z --deleted
    GIT-->>DLM: DeletedDeck.md\0...
    DLM-->>LMP: [DeletedDeck.md] (filtered)
    LMP-->>CLI: unique([ExistingDeck.md, ..., DeletedDeck.md])
    CLI->>SNAP: paths (existing + deleted + media)
    SNAP->>SNAP: _tracked_or_existing_paths (includes deleted tracked files)
    SNAP->>SNAP: git add -A -- paths (stages deletion)
    SNAP->>SNAP: git commit (snapshot with D DeletedDeck.md)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CLI as run_fa / run_af
    participant LMP as _local_markdown_paths
    participant DFS as DeckSource.deck_files()
    participant DLM as _deleted_local_markdown_paths
    participant GIT as CollectionGit (git ls-files -z --deleted)
    participant SNAP as git_snapshot

    CLI->>LMP: collection_dir
    LMP->>DFS: "glob *.md (existing files)"
    DFS-->>LMP: [ExistingDeck.md, ...]
    LMP->>DLM: collection_dir
    DLM->>GIT: ls-files -z --deleted
    GIT-->>DLM: DeletedDeck.md\0...
    DLM-->>LMP: [DeletedDeck.md] (filtered)
    LMP-->>CLI: unique([ExistingDeck.md, ..., DeletedDeck.md])
    CLI->>SNAP: paths (existing + deleted + media)
    SNAP->>SNAP: _tracked_or_existing_paths (includes deleted tracked files)
    SNAP->>SNAP: git add -A -- paths (stages deletion)
    SNAP->>SNAP: git commit (snapshot with D DeletedDeck.md)
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Update ankiops/cli\_commands.py"](https://github.com/visserle/ankiops/commit/667003770e95e34345fe68e65c4315a86b16bc64) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37961087)</sub>

<!-- /greptile_comment -->