### PR TITLE
Refactor CLI command orchestration

### DIFF
--- a/ankiops/cli.py
+++ b/ankiops/cli.py
@@ -5,17 +5,19 @@ from importlib.metadata import PackageNotFoundError, version
 from ankiops.anki_rpc import AnkiConnectionError
 from ankiops.cli_commands import (
     run_af,
+    run_af_command,
     run_deserialize,
     run_fa,
+    run_fa_command,
     run_fix_image_widths,
     run_init,
-    run_llm,
-    run_note_type,
     run_serialize,
-    run_shared,
 )
 from ankiops.console import configure_logging
-from ankiops.llm.commands import configure_llm_parser
+from ankiops.llm.commands import configure_llm_parser, run_llm
+from ankiops.note_types_command import run as run_note_type
+from ankiops.shared import SharedSyncHooks
+from ankiops.shared import run as run_shared
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +41,16 @@ def _get_cli_version() -> str:
         return version("ankiops")
     except PackageNotFoundError:
         return "unknown"
+
+
+def run_shared_cli(args) -> None:
+    run_shared(
+        args,
+        sync_hooks=SharedSyncHooks(
+            from_anki=lambda: run_af_command(no_auto_commit=False),
+            to_anki=lambda: run_fa_command(no_auto_commit=False),
+        ),
+    )
 
 
 def main():
@@ -212,7 +224,7 @@ def main():
         help="Create the GitHub repo as private when it does not exist (default)",
     )
     shared_create.set_defaults(public=False)
-    shared_create.set_defaults(handler=run_shared)
+    shared_create.set_defaults(handler=run_shared_cli)
 
     shared_add = shared_subparsers.add_parser(
         "add",
@@ -222,7 +234,7 @@ def main():
         "repo",
         help="GitHub repo as owner/repo (letters, digits, hyphens)",
     )
-    shared_add.set_defaults(handler=run_shared)
+    shared_add.set_defaults(handler=run_shared_cli)
 
     shared_update = shared_subparsers.add_parser(
         "update",
@@ -238,7 +250,7 @@ def main():
         action="store_true",
         help="Run files -> Anki after updating files",
     )
-    shared_update.set_defaults(handler=run_shared)
+    shared_update.set_defaults(handler=run_shared_cli)
 
     shared_submit = shared_subparsers.add_parser(
         "submit",
@@ -253,13 +265,13 @@ def main():
         action="store_true",
         help="Run Anki -> files before preparing the submission",
     )
-    shared_submit.set_defaults(handler=run_shared)
+    shared_submit.set_defaults(handler=run_shared_cli)
 
     shared_list = shared_subparsers.add_parser(
         "list",
         help="Show known shared sources",
     )
-    shared_list.set_defaults(handler=run_shared)
+    shared_list.set_defaults(handler=run_shared_cli)
 
     note_types_parser = subparsers.add_parser(
         "note-types",

--- a/ankiops/cli_commands.py
+++ b/ankiops/cli_commands.py
@@ -1,8 +1,5 @@
 import logging
-import subprocess
-from collections.abc import Sequence
 from pathlib import Path
-from types import SimpleNamespace
 
 from rich.markup import escape as rich_escape
 
@@ -11,38 +8,31 @@ from ankiops.collection import (
     NOTE_TYPES_DIR,
     create_tutorial,
     deck_name_to_file_stem,
-    file_stem_to_deck_name,
     initialize_collection,
     require_collection_dir,
 )
 from ankiops.console import clickable_path, connect_or_exit
 from ankiops.deck_sources import (
-    DeckSource,
-    RESERVED_MARKDOWN_FILES,
     discover_deck_sources,
     load_note_types_for_sources,
 )
-from ankiops.git import CollectionGit, git_snapshot
-from ankiops.image_widths import fix_image_widths_collection
+from ankiops.git import (
+    git_snapshot,
+    local_markdown_snapshot_paths,
+    snapshot_scope_paths,
+)
+from ankiops.image_widths import fix_image_widths_collection, plan_image_width_fix
 from ankiops.interchange import (
     apply_deserialization_plan,
     plan_deserialize_from_file,
     serialize_to_file,
 )
-from ankiops.llm.commands import run_llm as run_llm_impl
-from ankiops.llm.execution import run_task
-from ankiops.llm.jobs import list_jobs as list_llm_jobs
-from ankiops.llm.jobs import show_job
-from ankiops.llm.planning import plan_task
-from ankiops.llm.tasks import load_llm_task_catalog
 from ankiops.media import (
     format_media_status,
     sync_all_media_from_anki,
     sync_all_media_to_anki,
 )
 from ankiops.note_types import sync_note_type_configs
-from ankiops.note_types_command import run as run_note_type_impl
-from ankiops.shared import run as run_shared_impl
 from ankiops.sync.from_anki import sync_collection_from_anki
 from ankiops.sync.report import CollectionReport
 from ankiops.sync.state import SyncState
@@ -64,65 +54,6 @@ def sync_note_types(anki_port, collection_dir, note_types_dir, db_port):
     return sync_note_type_configs(anki_port, configs, sync_state=db_port)
 
 
-def _has_shared_sources(collection_dir: Path) -> bool:
-    sources = discover_deck_sources(
-        collection_dir,
-        note_types_dir=collection_dir / NOTE_TYPES_DIR,
-    )
-    return any(source.is_shared for source in sources)
-
-
-def _snapshot_paths(
-    collection_dir: Path,
-    scoped_paths: Sequence[Path],
-    *,
-    has_shared_scope: bool = False,
-) -> list[Path]:
-    if has_shared_scope or _has_shared_sources(collection_dir):
-        return [collection_dir]
-    return list(scoped_paths)
-
-
-def _local_markdown_paths(collection_dir: Path) -> list[Path]:
-    paths = DeckSource.local(collection_dir).deck_files()
-    paths.extend(_deleted_local_markdown_paths(collection_dir))
-    return _unique_paths(paths)
-
-
-def _deleted_local_markdown_paths(collection_dir: Path) -> list[Path]:
-    try:
-        result = CollectionGit(collection_dir).run(
-            ["ls-files", "-z", "--deleted"],
-            check=False,
-        )
-    except FileNotFoundError:
-        return []
-    if result.returncode != 0:
-        return []
-
-    paths = []
-    for rel_path in result.stdout.split("\0"):
-        if not rel_path:
-            continue
-        path = collection_dir / rel_path
-        if _is_local_markdown_deck_path(collection_dir, path):
-            paths.append(path)
-    return paths
-
-
-def _is_local_markdown_deck_path(collection_dir: Path, path: Path) -> bool:
-    return (
-        path.parent == collection_dir
-        and path.suffix == ".md"
-        and path.name.upper() not in RESERVED_MARKDOWN_FILES
-        and "___" not in path.stem
-    )
-
-
-def _unique_paths(paths: Sequence[Path]) -> list[Path]:
-    return list(dict.fromkeys(paths))
-
-
 def run_init(args):
     """Initialize the current directory as an AnkiOps collection."""
     anki = connect_or_exit()
@@ -140,6 +71,10 @@ def run_init(args):
 
 
 def run_af(args):
+    run_af_command(no_auto_commit=args.no_auto_commit)
+
+
+def run_af_command(*, no_auto_commit: bool) -> None:
     """Anki -> files: sync Anki changes into local files."""
     anki = connect_or_exit()
     active_profile = anki.get_active_profile()
@@ -147,15 +82,15 @@ def run_af(args):
     collection_dir = require_collection_dir(active_profile)
     logger.debug(f"Collection directory: {collection_dir}")
 
-    if not args.no_auto_commit:
+    if not no_auto_commit:
         logger.debug("Creating pre-anki-to-files git snapshot")
         git_snapshot(
             collection_dir,
             action="anki-to-files",
-            paths=_snapshot_paths(
+            paths=snapshot_scope_paths(
                 collection_dir,
                 [
-                    *_local_markdown_paths(collection_dir),
+                    *local_markdown_snapshot_paths(collection_dir),
                     collection_dir / LOCAL_MEDIA_DIR,
                 ],
             ),
@@ -236,6 +171,10 @@ def _log_files_to_anki_errors(import_summary: CollectionReport) -> None:
 
 
 def run_fa(args):
+    run_fa_command(no_auto_commit=args.no_auto_commit)
+
+
+def run_fa_command(*, no_auto_commit: bool) -> None:
     """Files -> Anki: sync local file changes into Anki."""
     anki = connect_or_exit()
     active_profile = anki.get_active_profile()
@@ -243,15 +182,15 @@ def run_fa(args):
     collection_dir = require_collection_dir(active_profile)
     logger.debug(f"Collection directory: {collection_dir}")
 
-    if not args.no_auto_commit:
+    if not no_auto_commit:
         logger.debug("Creating pre-files-to-anki git snapshot")
         git_snapshot(
             collection_dir,
             action="files-to-anki",
-            paths=_snapshot_paths(
+            paths=snapshot_scope_paths(
                 collection_dir,
                 [
-                    *_local_markdown_paths(collection_dir),
+                    *local_markdown_snapshot_paths(collection_dir),
                     collection_dir / LOCAL_MEDIA_DIR,
                     collection_dir / NOTE_TYPES_DIR,
                 ],
@@ -384,7 +323,7 @@ def run_deserialize(args):
         git_snapshot(
             collection_dir,
             action="deserializing",
-            paths=_snapshot_paths(
+            paths=snapshot_scope_paths(
                 collection_dir,
                 deserialize_plan.target_paths,
                 has_shared_scope=deserialize_plan.has_shared_sources,
@@ -407,26 +346,22 @@ def run_fix_image_widths(args):
         raise SystemExit(2)
 
     collection_dir = require_collection_dir()
-    selected_paths = _local_markdown_paths(collection_dir)
-    if args.deck:
-        deck_filter = args.deck.strip()
-        subdeck_scope = f"{deck_filter}::"
-        selected_paths = [
-            md_file
-            for md_file in selected_paths
-            if file_stem_to_deck_name(md_file.stem) == deck_filter
-            or (
-                not args.no_subdecks
-                and file_stem_to_deck_name(md_file.stem).startswith(subdeck_scope)
-            )
-        ]
+    plan = plan_image_width_fix(
+        collection_dir,
+        deck=args.deck,
+        no_subdecks=args.no_subdecks,
+    )
 
     if not args.no_auto_commit:
         logger.debug("Creating pre-image-width-fix git snapshot")
         git_snapshot(
             collection_dir,
             action="fixing image widths",
-            paths=_snapshot_paths(collection_dir, selected_paths),
+            paths=snapshot_scope_paths(
+                collection_dir,
+                plan.target_paths,
+                has_shared_scope=plan.has_shared_sources,
+            ),
         )
     else:
         logger.debug("Auto-commit disabled (--no-auto-commit)")
@@ -457,48 +392,3 @@ def run_fix_image_widths(args):
     )
     if result.changed:
         logger.info("Only Markdown files were edited. Run 'ankiops fa' to sync.")
-
-
-def run_llm(args):
-    """Delegates LLM command handling to the LLM CLI module."""
-    run_llm_impl(
-        args,
-        require_collection_dir_fn=require_collection_dir,
-        load_note_type_configs_fn=(
-            lambda note_types_dir: [
-                config
-                for source_config in load_note_types_for_sources(
-                    discover_deck_sources(
-                        note_types_dir.parent,
-                        note_types_dir=note_types_dir,
-                    )
-                )
-                for config in source_config.note_types
-            ]
-        ),
-        load_llm_task_catalog_fn=load_llm_task_catalog,
-        plan_task_fn=plan_task,
-        run_task_fn=run_task,
-        list_jobs_fn=list_llm_jobs,
-        show_job_fn=show_job,
-    )
-
-
-def run_note_type(args):
-    run_note_type_impl(args)
-
-
-def run_shared(args):
-    try:
-        if getattr(args, "shared_command", None) == "submit" and args.from_anki:
-            run_af(SimpleNamespace(no_auto_commit=False))
-        run_shared_impl(args)
-        if getattr(args, "shared_command", None) == "update" and args.to_anki:
-            run_fa(SimpleNamespace(no_auto_commit=False))
-    except ValueError as error:
-        logger.error(str(error))
-        raise SystemExit(1) from error
-    except subprocess.CalledProcessError as error:
-        output = ((error.stdout or "") + (error.stderr or "")).strip()
-        logger.error(output or f"git command failed with exit {error.returncode}")
-        raise SystemExit(1) from error

--- a/ankiops/collection.py
+++ b/ankiops/collection.py
@@ -68,6 +68,21 @@ def file_stem_to_deck_name(file_stem: str) -> str:
     return unquote(file_stem.replace("__", "::"))
 
 
+def deck_name_in_scope(
+    deck_name: str,
+    *,
+    deck: str | None,
+    no_subdecks: bool,
+) -> bool:
+    """Return whether `deck_name` is selected by a deck/subdeck scope."""
+    deck_filter = deck.strip() if isinstance(deck, str) else None
+    if deck_filter is None:
+        return True
+    if no_subdecks:
+        return deck_name == deck_filter
+    return deck_name == deck_filter or deck_name.startswith(f"{deck_filter}::")
+
+
 def get_collection_dir() -> Path:
     """Get the collection directory path."""
     pyproject = Path.cwd() / "pyproject.toml"

--- a/ankiops/deck_sources.py
+++ b/ankiops/deck_sources.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass, replace
 from pathlib import Path
 
-from ankiops.collection import NOTE_TYPES_DIR
+from ankiops.collection import (
+    NOTE_TYPES_DIR,
+    deck_name_in_scope,
+    file_stem_to_deck_name,
+)
 from ankiops.note_types import NoteType, load_note_types
 
 SHARED_DIR = "shared"
@@ -93,6 +97,25 @@ class DeckSource:
             files.append(path)
         return files
 
+    def deck_name_for_path(self, path: Path) -> str:
+        return file_stem_to_deck_name(path.stem)
+
+    def deck_files_in_scope(
+        self,
+        *,
+        deck: str | None = None,
+        no_subdecks: bool = False,
+    ) -> list[Path]:
+        return [
+            path
+            for path in self.deck_files()
+            if deck_name_in_scope(
+                self.deck_name_for_path(path),
+                deck=deck,
+                no_subdecks=no_subdecks,
+            )
+        ]
+
 
 @dataclass(frozen=True)
 class SourceNoteTypes:
@@ -120,6 +143,15 @@ def discover_deck_sources(
                 DeckSource.shared(collection_dir, owner_dir.name, repo_dir.name)
             )
     return sources
+
+
+def is_local_markdown_deck_path(collection_dir: Path, path: Path) -> bool:
+    return (
+        path.parent == collection_dir
+        and path.suffix == ".md"
+        and path.name.upper() not in RESERVED_MARKDOWN_FILES
+        and "___" not in path.stem
+    )
 
 
 def load_note_types_for_source(source: DeckSource) -> list[NoteType]:

--- a/ankiops/git.py
+++ b/ankiops/git.py
@@ -9,7 +9,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from uuid import uuid4
 
-from ankiops.deck_sources import SHARED_BRANCH, DeckSource
+from ankiops.collection import NOTE_TYPES_DIR
+from ankiops.deck_sources import (
+    SHARED_BRANCH,
+    DeckSource,
+    discover_deck_sources,
+    is_local_markdown_deck_path,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +82,16 @@ class CollectionGit:
             ).returncode
             == 0
         )
+
+    def deleted_tracked_paths(self) -> list[Path]:
+        result = self.run(["ls-files", "-z", "--deleted"], check=False)
+        if result.returncode != 0:
+            return []
+        return [
+            self.collection_dir / rel_path
+            for rel_path in result.stdout.split("\0")
+            if rel_path
+        ]
 
     def commit_paths(self, paths: list[Path], message: str) -> None:
         rel_paths = self._tracked_or_existing_paths(paths)
@@ -241,3 +257,42 @@ def git_snapshot(
     except FileNotFoundError:
         logger.debug("Git not found, skipping auto-commit")
         return False
+
+
+def local_markdown_snapshot_paths(collection_dir: Path) -> list[Path]:
+    """Return local Markdown deck paths, including deleted tracked deck files."""
+    paths = DeckSource.local(collection_dir).deck_files()
+    try:
+        deleted_paths = CollectionGit(collection_dir).deleted_tracked_paths()
+    except FileNotFoundError:
+        deleted_paths = []
+    paths.extend(
+        path
+        for path in deleted_paths
+        if is_local_markdown_deck_path(collection_dir, path)
+    )
+    return _unique_paths(paths)
+
+
+def snapshot_scope_paths(
+    collection_dir: Path,
+    scoped_paths: Sequence[Path],
+    *,
+    has_shared_scope: bool = False,
+) -> list[Path]:
+    """Return scoped snapshot paths, using broad fallback for shared sources."""
+    if has_shared_scope or _has_shared_sources(collection_dir):
+        return [collection_dir]
+    return list(scoped_paths)
+
+
+def _has_shared_sources(collection_dir: Path) -> bool:
+    sources = discover_deck_sources(
+        collection_dir,
+        note_types_dir=collection_dir / NOTE_TYPES_DIR,
+    )
+    return any(source.is_shared for source in sources)
+
+
+def _unique_paths(paths: Sequence[Path]) -> list[Path]:
+    return list(dict.fromkeys(paths))

--- a/ankiops/image_widths.py
+++ b/ankiops/image_widths.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from ankiops.collection import NOTE_TYPES_DIR
+from ankiops.deck_sources import discover_deck_sources
 from ankiops.interchange import deserialize, serialize
 
 logger = logging.getLogger(__name__)
@@ -33,6 +34,37 @@ class ImageWidthFixResult:
     @property
     def changed(self) -> bool:
         return self.images_changed > 0
+
+
+@dataclass(frozen=True)
+class ImageWidthFixPlan:
+    """Filesystem scope for a fix-image-widths run."""
+
+    target_paths: tuple[Path, ...]
+    has_shared_sources: bool
+
+
+def plan_image_width_fix(
+    collection_dir: Path,
+    *,
+    deck: str | None = None,
+    no_subdecks: bool = False,
+    note_types_dir: Path | None = None,
+) -> ImageWidthFixPlan:
+    resolved_note_types_dir = note_types_dir or (collection_dir / NOTE_TYPES_DIR)
+    sources = discover_deck_sources(
+        collection_dir,
+        note_types_dir=resolved_note_types_dir,
+    )
+    target_paths = tuple(
+        path
+        for source in sources
+        for path in source.deck_files_in_scope(deck=deck, no_subdecks=no_subdecks)
+    )
+    return ImageWidthFixPlan(
+        target_paths=target_paths,
+        has_shared_sources=any(source.is_shared for source in sources),
+    )
 
 
 def _replacement_with_width(match: re.Match[str], width: int) -> str:

--- a/ankiops/interchange.py
+++ b/ankiops/interchange.py
@@ -11,6 +11,7 @@ from typing import Any, cast
 from ankiops.collection import (
     ANKIOPS_DB,
     NOTE_TYPES_DIR,
+    deck_name_in_scope,
     deck_name_to_file_stem,
     file_stem_to_deck_name,
     get_collection_dir,
@@ -91,9 +92,9 @@ def serialize(
     filtered_decks = [
         parsed_deck
         for parsed_deck in parsed_decks
-        if _deck_matches_filter(
+        if deck_name_in_scope(
             parsed_deck.deck_name,
-            deck_filter=deck_filter,
+            deck=deck_filter,
             no_subdecks=no_subdecks,
         )
     ]
@@ -219,19 +220,6 @@ def _display_source_path(collection_dir: Path, source: DeckSource, path: Path) -
         except ValueError:
             return str(path)
     return f"{_source_name(source)}:{relative}"
-
-
-def _deck_matches_filter(
-    deck_name: str,
-    *,
-    deck_filter: str | None,
-    no_subdecks: bool,
-) -> bool:
-    if deck_filter is None:
-        return True
-    if no_subdecks:
-        return deck_name == deck_filter
-    return deck_name == deck_filter or deck_name.startswith(f"{deck_filter}::")
 
 
 def serialize_to_file(

--- a/ankiops/shared/__init__.py
+++ b/ankiops/shared/__init__.py
@@ -1,6 +1,7 @@
 """GitHub-native shared support for AnkiOps."""
 
 from ankiops.shared.commands import (
+    SharedSyncHooks,
     run,
     run_add,
     run_create,
@@ -10,6 +11,7 @@ from ankiops.shared.commands import (
 )
 
 __all__ = [
+    "SharedSyncHooks",
     "run",
     "run_submit",
     "run_create",

--- a/ankiops/shared/commands.py
+++ b/ankiops/shared/commands.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import logging
 import re
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 
 from rich.markup import escape as rich_escape
@@ -26,6 +29,12 @@ logger = logging.getLogger(__name__)
 _SAFE_SLUG_PART_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$")
 _GITHUB_OWNER_MAX_LENGTH = 39
 _GITHUB_REPO_MAX_LENGTH = 100
+
+
+@dataclass(frozen=True)
+class SharedSyncHooks:
+    from_anki: Callable[[], None]
+    to_anki: Callable[[], None]
 
 
 def _parse_slug(slug: str) -> tuple[str, str]:
@@ -171,17 +180,40 @@ def run_list(args) -> None:
         )
 
 
-def run(args) -> None:
-    match args.shared_command:
-        case "create":
-            run_create(args)
-        case "add":
-            run_add(args)
-        case "update":
-            run_update(args)
-        case "submit":
-            run_submit(args)
-        case "list":
-            run_list(args)
-        case _:
-            raise SystemExit(2)
+def run(args, *, sync_hooks: SharedSyncHooks | None = None) -> None:
+    try:
+        command = getattr(args, "shared_command", None)
+        needs_from_anki = command == "submit" and getattr(args, "from_anki", False)
+        needs_to_anki = command == "update" and getattr(args, "to_anki", False)
+        if sync_hooks is None:
+            if needs_from_anki:
+                raise ValueError("--from-anki is only available from the CLI")
+            if needs_to_anki:
+                raise ValueError("--to-anki is only available from the CLI")
+
+        if needs_from_anki and sync_hooks is not None:
+            sync_hooks.from_anki()
+
+        match command:
+            case "create":
+                run_create(args)
+            case "add":
+                run_add(args)
+            case "update":
+                run_update(args)
+            case "submit":
+                run_submit(args)
+            case "list":
+                run_list(args)
+            case _:
+                raise SystemExit(2)
+
+        if needs_to_anki and sync_hooks is not None:
+            sync_hooks.to_anki()
+    except ValueError as error:
+        logger.error(str(error))
+        raise SystemExit(1) from error
+    except subprocess.CalledProcessError as error:
+        output = ((error.stdout or "") + (error.stderr or "")).strip()
+        logger.error(output or f"git command failed with exit {error.returncode}")
+        raise SystemExit(1) from error

--- a/ankiops/shared/create.py
+++ b/ankiops/shared/create.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import yaml
 
-from ankiops.collection import LOCAL_MEDIA_DIR, NOTE_TYPES_DIR, file_stem_to_deck_name
+from ankiops.collection import LOCAL_MEDIA_DIR, NOTE_TYPES_DIR
 from ankiops.deck_sources import SHARED_BRANCH, DeckSource
 from ankiops.git import CollectionGit
 from ankiops.markdown import DeckFile, read_deck_file, render_notes_to_markdown
@@ -99,14 +99,8 @@ def _remove_create_source_root(plan: _CreatePlan) -> None:
 
 
 def _selected_deck_files(collection_dir: Path, deck: str) -> list[Path]:
-    deck_filter = deck.strip()
-    subdeck_scope = f"{deck_filter}::"
-    files = []
     local_source = DeckSource.local(collection_dir)
-    for md_file in local_source.deck_files():
-        deck_name = file_stem_to_deck_name(md_file.stem)
-        if deck_name == deck_filter or deck_name.startswith(subdeck_scope):
-            files.append(md_file)
+    files = local_source.deck_files_in_scope(deck=deck, no_subdecks=False)
     if not files:
         raise ValueError(f"No local deck files found for '{deck}'")
     return files

--- a/docs/git_operations.md
+++ b/docs/git_operations.md
@@ -5,8 +5,8 @@ command line. It covers automatic snapshots, collection initialization, and the
 GitHub-facing shared workflow.
 
 The implementation lives mainly in `ankiops/git.py`, with call sites in
-`ankiops/init.py`, `ankiops/cli.py`, `ankiops/llm/runner.py`, and
-`ankiops/shared/`.
+`ankiops/collection.py`, `ankiops/cli_commands.py`, `ankiops/llm/execution.py`,
+and `ankiops/shared/`.
 
 ## Snapshot convention
 
@@ -30,8 +30,8 @@ Examples:
 
 ## Snapshot Git sequence
 
-Snapshot callers pass an explicit path scope to `git_snapshot`. The scoped
-sequence is:
+Snapshot callers build path scopes with helpers in `ankiops/git.py` and pass
+the resulting explicit scope to `git_snapshot`. The scoped sequence is:
 
 ```text
 git rev-parse --git-dir

--- a/docs/module-architecture-plan.md
+++ b/docs/module-architecture-plan.md
@@ -140,8 +140,8 @@ flowchart LR
 
 ### `cli.py`
 
-Owns argument parsing and command dispatch. It should not contain workflow
-logic.
+Owns argument parsing and command dispatch to the command modules. It should
+not contain workflow logic.
 
 ### `cli_commands.py`
 
@@ -152,13 +152,9 @@ Owns top-level command workflows:
 - Anki to Markdown sync
 - interchange import/export
 - image width normalization
-- LLM command delegation
-- shared-source command delegation
-- note-type command delegation
 
-The specialized `note-types` terminal interaction remains in
-`note_types_command.py`; `cli_commands.py` is the command surface that `cli.py`
-routes to.
+The specialized LLM, shared-source, and note-type terminal interactions remain
+in `llm/commands.py`, `shared/commands.py`, and `note_types_command.py`.
 
 ### `console.py`
 
@@ -491,15 +487,15 @@ the semantic cut. These counts are from the implemented tree after formatting.
 | --- | ---: | ---: | --- |
 | `anki.py` | 539 | 750 | One concrete external-system interface over Anki. |
 | `anki_rpc.py` | 123 | 220 | Raw request transport only. |
-| `cli.py` | 364 | 450 | Parser construction and command dispatch. |
-| `cli_commands.py` | 456 | 650 | Command handlers are workflow glue; split only by command family. |
-| `collection.py` | 262 | 500 | Paths, deck filename mapping, profile guard, initialization. |
+| `cli.py` | 376 | 450 | Parser construction and command dispatch. |
+| `cli_commands.py` | 394 | 650 | Sync, interchange, and maintenance command workflows. |
+| `collection.py` | 282 | 500 | Paths, deck filename mapping, profile guard, initialization. |
 | `console.py` | 137 | 300 | Logging, clickable paths, and connect-or-exit terminal helper. |
-| `deck_sources.py` | 134 | 260 | Local/shared source discovery and scoped note type loading. |
-| `git.py` | 243 | 400 | Concrete collection Git operations. |
+| `deck_sources.py` | 171 | 260 | Local/shared source discovery and scoped note type/deck loading. |
+| `git.py` | 298 | 400 | Concrete collection Git operations and snapshot scoping. |
 | `html_to_markdown.py` | 430 | 550 | Directional conversion from Anki HTML to Markdown. |
-| `image_widths.py` | 194 | 300 | Focused standalone tool. |
-| `interchange.py` | 631 | 850 | One portable format for collections and selected deck trees. |
+| `image_widths.py` | 226 | 300 | Focused standalone tool. |
+| `interchange.py` | 596 | 850 | One portable format for collections and selected deck trees. |
 | `markdown.py` | 424 | 650 | One deep interface for the AnkiOps Markdown deck format. |
 | `markdown_to_html.py` | 147 | 280 | Directional conversion from Markdown to Anki HTML. |
 | `math_delimiters.py` | 87 | 160 | Focused conversion helper. |

--- a/tests/integration/cli/test_cli_sync.py
+++ b/tests/integration/cli/test_cli_sync.py
@@ -290,7 +290,7 @@ def test_cli_shared_create_accepts_public_visibility_flag():
 
     with (
         patch(
-            "ankiops.cli_commands.run_shared_impl",
+            "ankiops.shared.commands.run_create",
             side_effect=lambda args: captured.append(args),
         ),
         patch(

--- a/tests/unit/domain/test_deck_filename_mapping.py
+++ b/tests/unit/domain/test_deck_filename_mapping.py
@@ -1,6 +1,10 @@
 import pytest
 
-from ankiops.collection import deck_name_to_file_stem, file_stem_to_deck_name
+from ankiops.collection import (
+    deck_name_in_scope,
+    deck_name_to_file_stem,
+    file_stem_to_deck_name,
+)
 
 
 def test_subdeck_separator_uses_double_underscore():
@@ -44,3 +48,14 @@ def test_path_separators_are_roundtrip_safe():
 def test_underscores_adjacent_to_subdeck_separator_are_rejected(deck_name):
     with pytest.raises(ValueError, match="Ambiguous deck name"):
         deck_name_to_file_stem(deck_name)
+
+
+def test_deck_name_scope_includes_subdecks_by_default():
+    assert deck_name_in_scope("Parent", deck="Parent", no_subdecks=False)
+    assert deck_name_in_scope("Parent::Child", deck="Parent", no_subdecks=False)
+    assert not deck_name_in_scope("Other", deck="Parent", no_subdecks=False)
+
+
+def test_deck_name_scope_can_exclude_subdecks():
+    assert deck_name_in_scope("Parent", deck="Parent", no_subdecks=True)
+    assert not deck_name_in_scope("Parent::Child", deck="Parent", no_subdecks=True)

--- a/tests/unit/test_git.py
+++ b/tests/unit/test_git.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import subprocess
 
-from ankiops.git import git_snapshot
+from ankiops.git import git_snapshot, local_markdown_snapshot_paths
 
 
 def _init_git_repo(collection_dir):
@@ -134,3 +134,20 @@ def test_git_snapshot_collection_path_keeps_broad_behavior(tmp_path):
     assert "M\tDeck.md" in show
     assert "M\tOther.md" in show
     assert _git_status(tmp_path) == ""
+
+
+def test_local_markdown_snapshot_paths_include_deleted_tracked_decks(tmp_path):
+    _init_git_repo(tmp_path)
+    deck = tmp_path / "Deck.md"
+    readme = tmp_path / "README.md"
+    deck.write_text("old\n", encoding="utf-8")
+    readme.write_text("docs\n", encoding="utf-8")
+    _commit_all(tmp_path, "root")
+
+    deck.unlink()
+    readme.unlink()
+
+    names = {path.name for path in local_markdown_snapshot_paths(tmp_path)}
+
+    assert "Deck.md" in names
+    assert "README.md" not in names

--- a/tests/unit/test_shared_commands.py
+++ b/tests/unit/test_shared_commands.py
@@ -10,7 +10,8 @@ from ankiops.deck_sources import DeckSource
 from ankiops.git import CollectionGit
 from ankiops.markdown import NOTE_SEPARATOR
 from ankiops.shared import run_create, run_list, run_submit
-from ankiops.shared.commands import _parse_slug
+from ankiops.shared.commands import SharedSyncHooks, _parse_slug
+from ankiops.shared.commands import run as run_shared
 from ankiops.shared.create import _unlink_created_source_files
 from ankiops.shared.hosting import ensure_create_repo
 from tests.support.deck_files import DeckFileHarness
@@ -94,6 +95,70 @@ def test_parse_slug_accepts_safe_owner_repo(slug, expected):
 def test_parse_slug_rejects_unsafe_owner_repo(slug):
     with pytest.raises(ValueError, match="Invalid GitHub repo slug"):
         _parse_slug(slug)
+
+
+def test_run_submit_from_anki_uses_hook_before_submit(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "ankiops.shared.commands.run_submit",
+        lambda _args: calls.append("submit"),
+    )
+    hooks = SharedSyncHooks(
+        from_anki=lambda: calls.append("from_anki"),
+        to_anki=lambda: calls.append("to_anki"),
+    )
+
+    run_shared(
+        SimpleNamespace(shared_command="submit", repo="owner/repo", from_anki=True),
+        sync_hooks=hooks,
+    )
+
+    assert calls == ["from_anki", "submit"]
+
+
+def test_run_update_to_anki_uses_hook_after_update(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "ankiops.shared.commands.run_update",
+        lambda _args: calls.append("update"),
+    )
+    hooks = SharedSyncHooks(
+        from_anki=lambda: calls.append("from_anki"),
+        to_anki=lambda: calls.append("to_anki"),
+    )
+
+    run_shared(
+        SimpleNamespace(shared_command="update", repo=None, to_anki=True),
+        sync_hooks=hooks,
+    )
+
+    assert calls == ["update", "to_anki"]
+
+
+@pytest.mark.parametrize(
+    "args, message",
+    [
+        (
+            SimpleNamespace(
+                shared_command="submit",
+                repo="owner/repo",
+                from_anki=True,
+            ),
+            "--from-anki is only available from the CLI",
+        ),
+        (
+            SimpleNamespace(shared_command="update", repo=None, to_anki=True),
+            "--to-anki is only available from the CLI",
+        ),
+    ],
+)
+def test_run_requires_sync_hooks_for_nested_sync(args, message, caplog):
+    with caplog.at_level(logging.ERROR, logger="ankiops.shared.commands"):
+        with pytest.raises(SystemExit) as excinfo:
+            run_shared(args)
+
+    assert excinfo.value.code == 1
+    assert message in caplog.text
 
 
 def test_list_logs_clickable_paths_as_rich_markup(tmp_path, monkeypatch, caplog):


### PR DESCRIPTION
## Summary
- Move shared, note-type, and LLM dispatch out of `cli.py` into their owning modules
- Add reusable sync hooks so shared submit/update can trigger Anki syncs from the CLI
- Extract deck scoping and snapshot-path helpers to reduce duplicated selection logic
- Update docs and tests for the new command flow and path-scoping helpers

## Testing
- Unit tests added for deck-name scope filtering, git snapshot path selection, and shared-command sync hook behavior
- Not run (not requested)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors CLI command orchestration by extracting cross-cutting helpers (`snapshot_scope_paths`, `local_markdown_snapshot_paths`, `deck_name_in_scope`, `deck_files_in_scope`, `is_local_markdown_deck_path`) into their owning modules and pulling `run_shared`, `run_llm`, and `run_note_type` out of `cli_commands.py` into their respective packages. Error handling and Anki sync hooks for shared commands are consolidated inside `shared/commands.py` via the new `SharedSyncHooks` dataclass.

- **Sync hooks** are now injected at the `cli.py` boundary via `run_shared_cli`, making `shared/commands.py` callable from non-CLI contexts without bundling CLI concerns.
- **Scope helpers** (`snapshot_scope_paths`, `local_markdown_snapshot_paths`) are moved from `cli_commands.py` to `git.py`, and a new `plan_image_width_fix` plan-object encapsulates deck selection before the snapshot step in `run_fix_image_widths`.
- **Tests** are added for deck-name scoping, `local_markdown_snapshot_paths` deleted-file inclusion, and sync-hook ordering/guard behaviour.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the changes are a structural refactor with no behaviour changes in the sync, snapshot, or deck-scoping paths.

All logic extracted from cli_commands.py is faithfully reproduced in its new home: snapshot scope helpers land in git.py, deck_name_in_scope in collection.py, and sync-hook dispatch in shared/commands.py. The only finding is a redundant sync_hooks is not None guard that cannot affect runtime behaviour because the earlier ValueError raise makes that branch unreachable. New unit tests cover the hook ordering and guard behaviour directly.

ankiops/shared/commands.py has the minor redundant guard; no other files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ankiops/shared/commands.py | Error handling and Anki sync hooks moved in from cli_commands.py; SharedSyncHooks dataclass added; run() now accepts optional hooks and guards hook-requiring flags without a sync provider. Minor redundant guard detected. |
| ankiops/cli_commands.py | Removed run_llm, run_note_type, run_shared wrappers and private snapshot helpers; introduced run_af_command / run_fa_command as keyword-argument-only variants of the existing run_af / run_fa entry points. |
| ankiops/git.py | Received snapshot_scope_paths, local_markdown_snapshot_paths, _has_shared_sources, and _unique_paths from cli_commands; added CollectionGit.deleted_tracked_paths(). Logic is preserved faithfully. |
| ankiops/image_widths.py | New ImageWidthFixPlan + plan_image_width_fix() extract deck selection out of cli_commands, scoping across all sources (local + shared) via discover_deck_sources. |
| ankiops/collection.py | New deck_name_in_scope() centralises the deck-filter predicate previously duplicated in interchange.py, shared/create.py, and cli_commands.py. |
| ankiops/deck_sources.py | Added DeckSource.deck_name_for_path(), DeckSource.deck_files_in_scope(), and module-level is_local_markdown_deck_path(). All three are straightforward wrappers over existing logic. |
| ankiops/cli.py | New run_shared_cli thin wrapper injects SharedSyncHooks at the CLI boundary; all shared_* parser handlers updated to point at it. |
| tests/unit/test_shared_commands.py | New tests cover from_anki hook ordering, to_anki hook ordering, and the guard that raises SystemExit(1) when sync flags are used without a hook provider. |
| tests/unit/test_git.py | New test verifies local_markdown_snapshot_paths includes deleted tracked deck files while excluding non-deck tracked files like README.md. |
| tests/unit/domain/test_deck_filename_mapping.py | Two new tests cover the deck_name_in_scope predicate for subdeck inclusion and exclusion. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CLI as cli.py
    participant SCI as run_shared_cli
    participant SC as shared/commands.py run()
    participant AF as run_af_command
    participant FA as run_fa_command
    participant SR as run_submit / run_update

    CLI->>SCI: handler(args)
    SCI->>SC: "run(args, sync_hooks=SharedSyncHooks(...))"
    SC->>SC: compute needs_from_anki / needs_to_anki

    alt submit --from-anki
        SC->>AF: sync_hooks.from_anki()
        AF-->>SC: (done)
    end

    SC->>SR: run_submit(args) or run_update(args)
    SR-->>SC: (done)

    alt update --to-anki
        SC->>FA: sync_hooks.to_anki()
        FA-->>SC: (done)
    end

    SC-->>SCI: (done)
    SCI-->>CLI: (done)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CLI as cli.py
    participant SCI as run_shared_cli
    participant SC as shared/commands.py run()
    participant AF as run_af_command
    participant FA as run_fa_command
    participant SR as run_submit / run_update

    CLI->>SCI: handler(args)
    SCI->>SC: "run(args, sync_hooks=SharedSyncHooks(...))"
    SC->>SC: compute needs_from_anki / needs_to_anki

    alt submit --from-anki
        SC->>AF: sync_hooks.from_anki()
        AF-->>SC: (done)
    end

    SC->>SR: run_submit(args) or run_update(args)
    SR-->>SC: (done)

    alt update --to-anki
        SC->>FA: sync_hooks.to_anki()
        FA-->>SC: (done)
    end

    SC-->>SCI: (done)
    SCI-->>CLI: (done)
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Refactor CLI command orchestration"](https://github.com/visserle/ankiops/commit/b62d48a48afd83e81b19f36cf7bc5bb722719118) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37971873)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->