### PR TITLE
Consolidate note type loading for collections

### DIFF
--- a/ankiops/cli_commands.py
+++ b/ankiops/cli_commands.py
@@ -1,3 +1,7 @@
+"""CLI command adapters and orchestration for argparse handlers."""
+
+from __future__ import annotations
+
 import logging
 import subprocess
 from collections.abc import Sequence
@@ -17,10 +21,10 @@ from ankiops.collection import (
 )
 from ankiops.console import clickable_path, connect_or_exit
 from ankiops.deck_sources import (
-    DeckSource,
     RESERVED_MARKDOWN_FILES,
+    DeckSource,
     discover_deck_sources,
-    load_note_types_for_sources,
+    load_note_types_for_collection,
 )
 from ankiops.git import CollectionGit, git_snapshot
 from ankiops.image_widths import fix_image_widths_collection
@@ -54,14 +58,12 @@ sync_media_from_anki = sync_all_media_from_anki
 sync_media_to_anki = sync_all_media_to_anki
 
 
-def sync_note_types(anki_port, collection_dir, note_types_dir, db_port):
-    sources = discover_deck_sources(collection_dir, note_types_dir=note_types_dir)
-    configs = [
-        config
-        for source_config in load_note_types_for_sources(sources)
-        for config in source_config.note_types
-    ]
-    return sync_note_type_configs(anki_port, configs, sync_state=db_port)
+def _sync_note_types(anki_port, collection_dir, note_types_dir, db_port):
+    return sync_note_type_configs(
+        anki_port,
+        load_note_types_for_collection(collection_dir, note_types_dir=note_types_dir),
+        sync_state=db_port,
+    )
 
 
 def _has_shared_sources(collection_dir: Path) -> bool:
@@ -86,7 +88,7 @@ def _snapshot_paths(
 def _local_markdown_paths(collection_dir: Path) -> list[Path]:
     paths = DeckSource.local(collection_dir).deck_files()
     paths.extend(_deleted_local_markdown_paths(collection_dir))
-    return _unique_paths(paths)
+    return list(dict.fromkeys(paths))
 
 
 def _deleted_local_markdown_paths(collection_dir: Path) -> list[Path]:
@@ -117,10 +119,6 @@ def _is_local_markdown_deck_path(collection_dir: Path, path: Path) -> bool:
         and path.name.upper() not in RESERVED_MARKDOWN_FILES
         and "___" not in path.stem
     )
-
-
-def _unique_paths(paths: Sequence[Path]) -> list[Path]:
-    return list(dict.fromkeys(paths))
 
 
 def run_init(args):
@@ -271,7 +269,7 @@ def run_fa(args):
         logger.warning(f"Media sync failed: {error}")
 
     logger.debug("Starting note type sync")
-    nt_summary = sync_note_types(anki, collection_dir, note_types_dir, db)
+    nt_summary = _sync_note_types(anki, collection_dir, note_types_dir, db)
     if nt_summary:
         logger.info(f"Note types: {nt_summary}")
 
@@ -460,21 +458,15 @@ def run_fix_image_widths(args):
 
 
 def run_llm(args):
-    """Delegates LLM command handling to the LLM CLI module."""
+    """Delegate LLM command handling to the LLM CLI module."""
     run_llm_impl(
         args,
         require_collection_dir_fn=require_collection_dir,
         load_note_type_configs_fn=(
-            lambda note_types_dir: [
-                config
-                for source_config in load_note_types_for_sources(
-                    discover_deck_sources(
-                        note_types_dir.parent,
-                        note_types_dir=note_types_dir,
-                    )
-                )
-                for config in source_config.note_types
-            ]
+            lambda note_types_dir: load_note_types_for_collection(
+                note_types_dir.parent,
+                note_types_dir=note_types_dir,
+            )
         ),
         load_llm_task_catalog_fn=load_llm_task_catalog,
         plan_task_fn=plan_task,

--- a/ankiops/deck_sources.py
+++ b/ankiops/deck_sources.py
@@ -137,3 +137,18 @@ def load_note_types_for_sources(sources: list[DeckSource]) -> list[SourceNoteTyp
         SourceNoteTypes(source=source, note_types=load_note_types_for_source(source))
         for source in sources
     ]
+
+
+def load_note_types_for_collection(
+    collection_dir: Path,
+    *,
+    note_types_dir: Path | None = None,
+) -> list[NoteType]:
+    """Load all note types for a collection, with shared source names scoped."""
+    return [
+        note_type
+        for source_types in load_note_types_for_sources(
+            discover_deck_sources(collection_dir, note_types_dir=note_types_dir)
+        )
+        for note_type in source_types.note_types
+    ]

--- a/ankiops/llm/commands.py
+++ b/ankiops/llm/commands.py
@@ -30,7 +30,7 @@ from ankiops.collection import (
     file_stem_to_deck_name,
     require_collection_dir,
 )
-from ankiops.deck_sources import discover_deck_sources, load_note_types_for_sources
+from ankiops.deck_sources import load_note_types_for_collection
 
 from .execution import TaskExecutionProgress, run_task
 from .jobs import LlmJobRequestNoteRef, show_job
@@ -461,13 +461,10 @@ def _show_plan(
 
 
 def _load_note_type_configs(note_types_dir: Path) -> list[Any]:
-    collection_dir = note_types_dir.parent
-    sources = discover_deck_sources(collection_dir, note_types_dir=note_types_dir)
-    return [
-        config
-        for source_config in load_note_types_for_sources(sources)
-        for config in source_config.note_types
-    ]
+    return load_note_types_for_collection(
+        note_types_dir.parent,
+        note_types_dir=note_types_dir,
+    )
 
 
 def _normalize_deck_override(value: str | None) -> str | None:

--- a/ankiops/llm/planning.py
+++ b/ankiops/llm/planning.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from ankiops.collection import NOTE_TYPES_DIR, deck_name_to_file_stem
-from ankiops.deck_sources import discover_deck_sources, load_note_types_for_sources
+from ankiops.deck_sources import discover_deck_sources, load_note_types_for_collection
 from ankiops.interchange import serialize
 from ankiops.note_types import ANKIOPS_KEY_FIELD, NoteType
 from ankiops.notes import normalize_tags
@@ -208,15 +208,10 @@ def _load_task(
     collection_dir: Path,
     task_name: str,
 ) -> tuple[TaskConfig, dict[str, NoteType]]:
-    sources = discover_deck_sources(
+    note_type_configs = load_note_types_for_collection(
         collection_dir,
         note_types_dir=collection_dir / NOTE_TYPES_DIR,
     )
-    note_type_configs = [
-        config
-        for source_config in load_note_types_for_sources(sources)
-        for config in source_config.note_types
-    ]
     catalog = load_llm_task_catalog(
         collection_dir,
         note_type_configs=note_type_configs,

--- a/tests/unit/domain/test_sources.py
+++ b/tests/unit/domain/test_sources.py
@@ -5,6 +5,7 @@ import pytest
 from ankiops.deck_sources import (
     DeckSource,
     discover_deck_sources,
+    load_note_types_for_collection,
     load_note_types_for_source,
 )
 from tests.support.deck_files import DeckFileHarness
@@ -65,6 +66,18 @@ def test_shared_configs_are_scoped_by_source(tmp_path):
 
     assert "shared/owner/repo/AnkiOpsQA" in names
     assert "AnkiOpsQA" not in names
+
+
+def test_collection_note_types_include_local_and_scoped_shared_configs(tmp_path):
+    harness = DeckFileHarness()
+    harness.eject_default_note_types(tmp_path / "note_types")
+    shared_source = DeckSource.shared(tmp_path, "owner", "repo")
+    harness.eject_default_note_types(shared_source.note_types_dir)
+
+    names = {config.name for config in load_note_types_for_collection(tmp_path)}
+
+    assert "AnkiOpsQA" in names
+    assert "shared/owner/repo/AnkiOpsQA" in names
 
 
 def test_shared_note_type_names_are_path_like(tmp_path):


### PR DESCRIPTION
## Summary
- Add `load_note_types_for_collection()` to load and flatten note types from all discovered deck sources.
- Update CLI and LLM command paths to use the collection-level helper instead of duplicating source discovery logic.
- Simplify local markdown path deduplication by using insertion-ordered dict keys directly.
- Add coverage for collection note types including both local and scoped shared configs.

## Testing
- Added unit coverage for collection-level note type loading and scoped shared source names.
- Not run (not requested)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts a new `load_note_types_for_collection()` helper in `deck_sources.py` that consolidates the three-step pattern of discover → load per source → flatten that was duplicated across CLI and LLM command paths. The function is then wired in everywhere the flat list was previously assembled manually.

- **`deck_sources.py`**: Adds `load_note_types_for_collection(collection_dir, *, note_types_dir)`, a thin wrapper over `discover_deck_sources` + `load_note_types_for_sources` that returns a flat `list[NoteType]` with shared note types already scoped.
- **`cli_commands.py` / `llm/commands.py` / `llm/planning.py`**: Three independent call sites replaced with the new helper; `sync_note_types` is also made private (`_sync_note_types`) and `_unique_paths` is removed in favor of the inline `list(dict.fromkeys(paths))` idiom.
- **`tests/unit/domain/test_sources.py`**: New test verifying that the collection-level loader returns both unscoped local names and scoped shared names in the same result set.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a pure extraction refactor with no changed logic.

All three duplicate call sites are replaced with an identical one-liner that chains the same two functions in the same order. The new helper in deck_sources.py is a thin wrapper with no new branching. Existing callers of load_note_types_for_sources in sync/to_anki.py and sync/from_anki.py are untouched because they need per-source metadata. The only observable behaviour difference is that sync_note_types is now prefixed with an underscore; it was never exported and has no external callers.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ankiops/deck_sources.py | Adds load_note_types_for_collection(); correctly delegates to existing discover and load helpers — no logic changed. |
| ankiops/cli_commands.py | Removes duplicate discover/load/flatten boilerplate in two places, makes _sync_note_types private, inlines _unique_paths; all call sites verified correct. |
| ankiops/llm/commands.py | _load_note_type_configs simplified to one-liner using the new helper; default fallback path and injected path now produce identical results. |
| ankiops/llm/planning.py | _load_task simplified; discover_deck_sources is retained and still used in snapshot_paths_for_task — no dead import. |
| tests/unit/domain/test_sources.py | New test correctly exercises collection-level loading with both local and shared sources, verifying scoped name format. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["CLI / LLM callers\n(cli_commands, llm/commands, llm/planning)"]
    B["load_note_types_for_collection(collection_dir, note_types_dir?)"]
    C["discover_deck_sources(collection_dir, note_types_dir?)"]
    D["load_note_types_for_sources(sources)"]
    E["load_note_types_for_source(source) x N"]
    F["local NoteTypes (unscoped)"]
    G["shared NoteTypes (scoped: shared/owner/repo/Name)"]
    H["flat list[NoteType]"]

    A --> B
    B --> C
    C --> D
    D --> E
    E --> F
    E --> G
    F --> H
    G --> H
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["CLI / LLM callers\n(cli_commands, llm/commands, llm/planning)"]
    B["load_note_types_for_collection(collection_dir, note_types_dir?)"]
    C["discover_deck_sources(collection_dir, note_types_dir?)"]
    D["load_note_types_for_sources(sources)"]
    E["load_note_types_for_source(source) x N"]
    F["local NoteTypes (unscoped)"]
    G["shared NoteTypes (scoped: shared/owner/repo/Name)"]
    H["flat list[NoteType]"]

    A --> B
    B --> C
    C --> D
    D --> E
    E --> F
    E --> G
    F --> H
    G --> H
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Consolidate note type loading for collec..."](https://github.com/visserle/ankiops/commit/fe61c57c277abeb8c9d0863a78cdcca84a8598c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37984735)</sub>

<!-- /greptile_comment -->