### PR TITLE
Fix shared Git history and submission workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ AnkiOps is a bidirectional bridge between Anki and your filesystem. Each deck be
 ## Advantages
 
 - **User-friendly**: Edit Anki decks as highly readable Markdown files
-- **Full Anki support**: Two-way synchronization of notes, note types, decks and media between Anki and the filesystem
+- **Full Anki support**: Two-way sync of notes, note types, decks and media files
 - **Customization**: Define your own note types and card templates
 - **Performance**: Sync thousands of notes in under a second
 - **Collaboration**: Share decks on GitHub and collaborate with others
@@ -117,22 +117,23 @@ Every Anki note managed by AnkiOps has an additional field called `AnkiOps Key` 
 
 AnkiOps has two sync commands:
 
-| Command | Direction | Use it when |
-| --- | --- | --- |
-| `ankiops fa` | Files to Anki | After editing Markdown decks, media, or note types. |
-| `ankiops af` | Anki to files | After editing notes, tags, or decks in Anki. |
+- `ankiops fa` (files to anki): After editing Markdown decks, media, or note types, and
+- `ankiops af` (anki to files): After editing notes, tags, or decks in Anki.
 
 Both sync operations can create update, move, and delete managed notes, and handle all media and note types. Before syncing, an automatic Git snapshot is created.
 
 ### Add-On
 
-For basic usage, you can use AnkiOps without the add-on. One feature of the add-on are the toolbar buttons for `af` and `fa`:
+For basic usage, you can use AnkiOps without the add-on. The add-on enables AnkiOpsConnect, which AnkiOps needs for operations related to sharing. If you do not want to install the add-on, you can use AnkiOps with AnkiConnect (AnkiOpsConnect is twice as fast though). 
+
+
+
+Another feature of the add-on are the toolbar buttons for `af` and `fa`:
 
 ![alt text](toolbar.png)
 
-Furthermore, it enables AnkiOpsConnect, which AnkiOps needs for operations related to sharing. 
 
-If you do not want to install the add-on, you can use AnkiOps with AnkiConnect (AnkiOpsConnect is twice as fast though). To install it, download the folder and put it in your Anki add-ons directory.
+To install the add-on, download the folder and put it in your Anki add-ons directory.
 
 ## How To Get Started
 
@@ -140,6 +141,7 @@ If you do not want to install the add-on, you can use AnkiOps with AnkiConnect (
 
 ```bash
 pipx install ankiops
+# or
 uv tool install ankiops
 ```
 
@@ -222,15 +224,20 @@ ankiops shared update owner/psychology-deck --to-anki
 Submit local shared edits:
 
 ```bash
+ankiops shared status owner/psychology-deck
 ankiops shared submit owner/psychology-deck --from-anki \
-  --message "Clarify attention terminology"
+  --message "Clarify attention terminology" --commit
 ```
 
-The optional message becomes the Git commit subject and pull request title. When
-you omit it, AnkiOps uses `Update shared deck owner/psychology-deck`. Submitting
-an unchanged source creates no branch or pull request. With the GitHub CLI
-available, AnkiOps opens a pull request; otherwise it pushes the branch and tells
-you how to open one manually.
+`shared status` shows dirty shared and private files, compares committed shared
+history with GitHub, and explains exactly what `submit` will do. `submit` never
+commits dirty shared files unless you explicitly pass `--commit`; you can instead
+commit them yourself first. The optional message becomes the pull request title
+and, with `--commit`, the Git commit subject. When you omit it, AnkiOps uses
+`Update shared deck owner/psychology-deck`. Submitting an unchanged source
+creates no branch or pull request. With the GitHub CLI available, AnkiOps opens
+a pull request; otherwise it pushes the branch and tells you how to open one
+manually.
 
 Shared-source Git history created by older experimental AnkiOps versions is not
 compatible with this workflow. Recreate or re-add those sources before updating
@@ -277,7 +284,8 @@ Shared deck tools:
 - `ankiops shared create <deck> <owner>/<repo> [--public|--private]`
 - `ankiops shared add <owner>/<repo>`
 - `ankiops shared update [owner/repo] [--to-anki]`
-- `ankiops shared submit <owner>/<repo> [--from-anki] [-m|--message text]`
+- `ankiops shared status <owner>/<repo>`
+- `ankiops shared submit <owner>/<repo> [--from-anki] [--commit] [-m|--message text]`
 - `ankiops shared list`
 
 ## Contributing

--- a/ankiops/cli.py
+++ b/ankiops/cli.py
@@ -34,6 +34,13 @@ def _non_negative_int(value: str) -> int:
     return parsed
 
 
+def _single_line_text(value: str) -> str:
+    parsed = value.strip()
+    if not parsed or "\n" in parsed or "\r" in parsed:
+        raise argparse.ArgumentTypeError("must be a non-empty single line")
+    return parsed
+
+
 def _get_cli_version() -> str:
     try:
         return version("ankiops")
@@ -253,7 +260,28 @@ def main():
         action="store_true",
         help="Run Anki -> files before preparing the submission",
     )
+    shared_submit.add_argument(
+        "--message",
+        "-m",
+        type=_single_line_text,
+        help="Pull request title; also the commit message with --commit",
+    )
+    shared_submit.add_argument(
+        "--commit",
+        action="store_true",
+        help="Commit dirty shared files before preparing the pull request",
+    )
     shared_submit.set_defaults(handler=run_shared)
+
+    shared_status = shared_subparsers.add_parser(
+        "status",
+        help="Show local changes, remote state, and the next submit action",
+    )
+    shared_status.add_argument(
+        "repo",
+        help="GitHub repo as owner/repo (letters, digits, hyphens)",
+    )
+    shared_status.set_defaults(handler=run_shared)
 
     shared_list = shared_subparsers.add_parser(
         "list",
@@ -316,14 +344,8 @@ def main():
         print(
             "  ankiops init --tutorial                      # Initialize with tutorial"
         )
-        print(
-            "  ankiops af                                   "
-            "# Sync Anki to files"
-        )
-        print(
-            "  ankiops fa                                   "
-            "# Sync files to Anki"
-        )
+        print("  ankiops af                                   # Sync Anki to files")
+        print("  ankiops fa                                   # Sync files to Anki")
         print(
             "  ankiops serialize -o my-deck.json            "
             "# Serialize collection to file"

--- a/ankiops/cli_commands.py
+++ b/ankiops/cli_commands.py
@@ -483,7 +483,7 @@ def run_note_type(args):
 def run_shared(args):
     try:
         if getattr(args, "shared_command", None) == "submit" and args.from_anki:
-            run_af(SimpleNamespace(no_auto_commit=False))
+            run_af(SimpleNamespace(no_auto_commit=True))
         run_shared_impl(args)
         if getattr(args, "shared_command", None) == "update" and args.to_anki:
             run_fa(SimpleNamespace(no_auto_commit=False))

--- a/ankiops/git.py
+++ b/ankiops/git.py
@@ -23,7 +23,7 @@ class CollectionGit:
         args: list[str],
         *,
         check: bool = True,
-    ) -> subprocess.CompletedProcess:
+    ) -> subprocess.CompletedProcess[str]:
         logger.debug("git %s", " ".join(args))
         return subprocess.run(
             ["git", *args],
@@ -68,6 +68,12 @@ class CollectionGit:
     def refresh_index(self) -> None:
         self.run(["update-index", "-q", "--refresh"], check=False)
 
+    def status_lines(self, pathspec: list[str]) -> list[str]:
+        result = self.run(
+            ["status", "--short", "--untracked-files=all", "--", *pathspec]
+        )
+        return result.stdout.splitlines()
+
     def tracked(self, rel_path: str) -> bool:
         return (
             self.run(
@@ -77,13 +83,15 @@ class CollectionGit:
             == 0
         )
 
-    def commit_paths(self, paths: list[Path], message: str) -> None:
+    def commit_paths(self, paths: list[Path], message: str) -> bool:
         rel_paths = self._tracked_or_existing_paths(paths)
         if not rel_paths:
-            return
+            return False
         self.run(["add", "-A", "--", *rel_paths])
         if self.cached_diff_exists(rel_paths):
             self.run(["commit", "-m", message, "--", *rel_paths])
+            return True
+        return False
 
     def commit_create_move(
         self,
@@ -130,24 +138,133 @@ class CollectionGit:
             self.run(["rm", "-r", "--cached", "--ignore-unmatch", "--", *paths])
 
     def subtree_add(self, source: DeckSource) -> None:
-        self._run_subtree(source, "add")
-
-    def subtree_pull(self, source: DeckSource) -> None:
-        self._run_subtree(source, "pull")
-
-    def subtree_split(self, source: DeckSource) -> str:
-        branch = f"ankiops-{source.source_id.replace('/', '-')}-{uuid4().hex[:8]}"
-        self.run(
-            [
-                "subtree",
-                "split",
-                "--prefix",
-                self.source_prefix(source),
-                "-b",
-                branch,
-            ],
+        self._run_subtree(
+            source,
+            "add",
+            f"AnkiOps: add {source.source_id} from GitHub",
         )
+
+    def subtree_pull(self, source: DeckSource) -> bool:
+        old_head = self.head()
+        stashed = self._stash_non_source_changes(source)
+        try:
+            self._run_subtree(
+                source,
+                "pull",
+                f"AnkiOps: update {source.source_id} from GitHub",
+            )
+        finally:
+            if stashed:
+                self.run(["stash", "pop", "--index", "stash@{0}"])
+        return self.head() != old_head
+
+    def split_subtree(self, source: DeckSource) -> str:
+        result = self.run(["subtree", "split", "--prefix", self.source_prefix(source)])
+        split_sha = result.stdout.strip()
+        if not split_sha:
+            raise ValueError(f"Could not split {source.source_id}")
+        return split_sha
+
+    def create_temp_branch(self, source: DeckSource, commit_sha: str) -> str:
+        branch = f"ankiops-{source.source_id.replace('/', '-')}-{uuid4().hex[:8]}"
+        self.run(["branch", branch, commit_sha])
         return branch
+
+    def fetch_source_head(self, source: DeckSource) -> str:
+        if source.github_url is None:
+            raise ValueError(f"Cannot derive GitHub URL for {source.display_name}")
+        self.run(["fetch", source.github_url, SHARED_BRANCH])
+        return self.run(["rev-parse", "FETCH_HEAD"]).stdout.strip()
+
+    def has_subtree_metadata(self, source: DeckSource) -> bool:
+        prefix = self.source_prefix(source)
+        result = self.run(
+            [
+                "log",
+                "-1",
+                "--format=%B",
+                f"--grep=^git-subtree-dir: {prefix}/*$",
+                "HEAD",
+            ],
+            check=False,
+        )
+        if result.returncode != 0:
+            return False
+        trailers = {}
+        for line in result.stdout.splitlines():
+            key, separator, value = line.partition(":")
+            if separator and key in {"git-subtree-mainline", "git-subtree-split"}:
+                trailers[key] = value.strip()
+        if set(trailers) != {"git-subtree-mainline", "git-subtree-split"}:
+            return False
+        return all(
+            self.run(["cat-file", "-e", f"{sha}^{{commit}}"], check=False).returncode
+            == 0
+            for sha in trailers.values()
+        )
+
+    def is_ancestor(self, ancestor: str, descendant: str) -> bool:
+        result = self.run(
+            ["merge-base", "--is-ancestor", ancestor, descendant],
+            check=False,
+        )
+        if result.returncode not in (0, 1):
+            result.check_returncode()
+        return result.returncode == 0
+
+    def has_common_ancestor(self, left: str, right: str) -> bool:
+        result = self.run(["merge-base", left, right], check=False)
+        if result.returncode not in (0, 1):
+            result.check_returncode()
+        return result.returncode == 0
+
+    def trees_equal(self, left: str, right: str) -> bool:
+        left_tree = self.run(["rev-parse", f"{left}^{{tree}}"]).stdout.strip()
+        right_tree = self.run(["rev-parse", f"{right}^{{tree}}"]).stdout.strip()
+        return left_tree == right_tree
+
+    def rejoin_subtree(
+        self,
+        source: DeckSource,
+        split_sha: str,
+        subject: str,
+    ) -> None:
+        head = self.head()
+        if head is None:
+            raise ValueError("Cannot rejoin a subtree without a git commit.")
+
+        prefix = self.source_prefix(source)
+        source_tree = self.run(["rev-parse", f"{head}:{prefix}"]).stdout.strip()
+        split_tree = self.run(["rev-parse", f"{split_sha}^{{tree}}"]).stdout.strip()
+        if source_tree != split_tree:
+            raise ValueError(
+                f"Cannot rejoin {source.source_id}: split tree does not match "
+                "the shared source."
+            )
+
+        head_tree = self.run(["rev-parse", f"{head}^{{tree}}"]).stdout.strip()
+        trailers = "\n".join(
+            [
+                f"git-subtree-dir: {prefix}",
+                f"git-subtree-mainline: {head}",
+                f"git-subtree-split: {split_sha}",
+            ]
+        )
+        commit = self.run(
+            [
+                "commit-tree",
+                head_tree,
+                "-p",
+                head,
+                "-p",
+                split_sha,
+                "-m",
+                subject,
+                "-m",
+                trailers,
+            ]
+        ).stdout.strip()
+        self.run(["update-ref", "-m", subject, "HEAD", commit, head])
 
     def remote_exists(self, url: str) -> bool:
         return self.run(["ls-remote", url], check=False).returncode == 0
@@ -159,7 +276,7 @@ class CollectionGit:
         target_ref: str,
         *,
         check: bool = True,
-    ) -> subprocess.CompletedProcess:
+    ) -> subprocess.CompletedProcess[str]:
         return self.run(["push", url, f"{source_ref}:{target_ref}"], check=check)
 
     def source_prefix(self, source: DeckSource) -> str:
@@ -180,7 +297,7 @@ class CollectionGit:
                 seen.add(rel_path)
         return rel_paths
 
-    def _run_subtree(self, source: DeckSource, action: str) -> None:
+    def _run_subtree(self, source: DeckSource, action: str, message: str) -> None:
         if source.github_url is None:
             raise ValueError(f"Cannot derive GitHub URL for {source.display_name}")
         self.refresh_index()
@@ -190,10 +307,33 @@ class CollectionGit:
                 action,
                 "--prefix",
                 self.source_prefix(source),
+                "--message",
+                message,
                 source.github_url,
                 SHARED_BRANCH,
             ],
         )
+
+    def _stash_non_source_changes(self, source: DeckSource) -> bool:
+        prefix = self.source_prefix(source)
+        pathspec = [".", f":(exclude){prefix}", f":(exclude){prefix}/**"]
+        status = self.run(
+            ["status", "--porcelain=v1", "--untracked-files=all", "--", *pathspec]
+        )
+        if not status.stdout:
+            return False
+        self.run(
+            [
+                "stash",
+                "push",
+                "--include-untracked",
+                "--message",
+                f"AnkiOps: preserve private changes while updating {source.source_id}",
+                "--",
+                *pathspec,
+            ]
+        )
+        return True
 
 
 def git_snapshot(

--- a/ankiops/shared/__init__.py
+++ b/ankiops/shared/__init__.py
@@ -5,6 +5,7 @@ from ankiops.shared.commands import (
     run_add,
     run_create,
     run_list,
+    run_status,
     run_submit,
     run_update,
 )
@@ -15,5 +16,6 @@ __all__ = [
     "run_create",
     "run_update",
     "run_list",
+    "run_status",
     "run_add",
 ]

--- a/ankiops/shared/commands.py
+++ b/ankiops/shared/commands.py
@@ -83,6 +83,30 @@ def _ensure_submittable_note_keys(source: DeckSource) -> None:
         raise ValueError(format_missing_note_keys_error(len(missing)))
 
 
+def _ensure_compatible_history(repo: CollectionGit, source: DeckSource) -> None:
+    if not repo.has_subtree_metadata(source):
+        raise ValueError(
+            f"Shared source {source.source_id} has incompatible git history. "
+            "Recreate or re-add it with this AnkiOps version."
+        )
+
+
+def _remote_state(repo: CollectionGit, source: DeckSource) -> tuple[str, str, str]:
+    remote_head = repo.fetch_source_head(source)
+    split_sha = repo.split_subtree(source)
+    if split_sha == remote_head:
+        return remote_head, split_sha, "current"
+    if repo.is_ancestor(split_sha, remote_head):
+        return remote_head, split_sha, "remote_ahead"
+    if repo.trees_equal(split_sha, remote_head):
+        return remote_head, split_sha, "same_tree"
+    if repo.is_ancestor(remote_head, split_sha):
+        return remote_head, split_sha, "local_ahead"
+    if repo.has_common_ancestor(split_sha, remote_head):
+        return remote_head, split_sha, "diverged"
+    return remote_head, split_sha, "incompatible"
+
+
 def run_create(args) -> None:
     collection_dir = require_collection_dir()
     source = _source_for_slug(collection_dir, args.repo)
@@ -134,8 +158,15 @@ def run_update(args) -> None:
         logger.info("No shared sources found.")
         return
     for source in targets:
-        repo.subtree_pull(source)
-        logger.info("Updated %s", source.source_id)
+        _ensure_compatible_history(repo, source)
+    for source in targets:
+        if repo.subtree_pull(source):
+            logger.info("Updated %s", source.source_id)
+        else:
+            logger.info(
+                "%s is already up to date.",
+                source.github_slug or source.source_id,
+            )
 
 
 def run_submit(args) -> None:
@@ -146,12 +177,108 @@ def run_submit(args) -> None:
     if not source.root.exists():
         raise ValueError(f"Unknown shared source: {source.source_id}")
     _ensure_submittable_note_keys(source)
-    repo.commit_paths(
-        [source.root],
-        f"AnkiOps: submit {source.source_id}",
+    _ensure_compatible_history(repo, source)
+    title = getattr(args, "message", None) or f"Update shared deck {args.repo}"
+    shared_changes = repo.status_lines([repo.source_prefix(source)])
+    if shared_changes and not getattr(args, "commit", False):
+        raise ValueError(
+            f"Shared source {args.repo} has uncommitted changes. Review them with "
+            f"'ankiops shared status {args.repo}', commit them yourself, or re-run "
+            "with '--commit'."
+        )
+    if shared_changes:
+        repo.commit_paths(
+            [source.root],
+            f"AnkiOps: {title}",
+        )
+    _remote_head, split_sha, remote_state = _remote_state(repo, source)
+    if remote_state in {"current", "remote_ahead", "same_tree"}:
+        logger.info("No shared changes to submit for %s.", args.repo)
+        return
+    if remote_state == "incompatible":
+        raise ValueError(
+            f"Shared source {source.source_id} has incompatible git history. "
+            "Recreate or re-add it with this AnkiOps version."
+        )
+    repo.rejoin_subtree(
+        source,
+        split_sha,
+        f"AnkiOps: record submission history for {source.source_id}",
     )
-    branch = repo.subtree_split(source)
-    open_pr_if_possible(repo, source, branch)
+    branch = repo.create_temp_branch(source, split_sha)
+    pushed = open_pr_if_possible(repo, source, branch, title=title)
+    if pushed:
+        repo.delete_branch_if_exists(branch)
+
+
+def run_status(args) -> None:
+    collection_dir = require_collection_dir()
+    repo = CollectionGit(collection_dir)
+    source = _source_for_slug(collection_dir, args.repo)
+    repo.ensure_repo("Shared commands require a git-backed collection.")
+    if not source.root.exists():
+        raise ValueError(f"Unknown shared source: {source.source_id}")
+    _ensure_compatible_history(repo, source)
+
+    prefix = repo.source_prefix(source)
+    shared_changes = repo.status_lines([prefix])
+    private_changes = repo.status_lines(
+        [".", f":(exclude){prefix}", f":(exclude){prefix}/**"]
+    )
+    _remote_head, _split_sha, remote_state = _remote_state(repo, source)
+
+    logger.info("Shared source: %s", args.repo)
+    _log_status_changes("Shared changes", shared_changes)
+    _log_status_changes("Private changes", private_changes, preserved=True)
+    logger.info("Remote: %s", _remote_status_message(remote_state))
+    logger.info(
+        "Submit: %s",
+        _submit_status_message(args.repo, shared_changes, remote_state),
+    )
+
+
+def _log_status_changes(
+    label: str,
+    changes: list[str],
+    *,
+    preserved: bool = False,
+) -> None:
+    suffix = " (preserved)" if preserved and changes else ""
+    logger.info("%s: %d%s", label, len(changes), suffix)
+    for change in changes:
+        logger.info("  %s", change)
+
+
+def _remote_status_message(state: str) -> str:
+    return {
+        "current": "Committed shared state matches GitHub main.",
+        "remote_ahead": "GitHub main is ahead of the committed shared state.",
+        "same_tree": "Committed shared content matches GitHub main; history differs.",
+        "local_ahead": "Committed shared state has changes not on GitHub main.",
+        "diverged": "Committed shared state and GitHub main have both advanced.",
+        "incompatible": (
+            "Committed shared history has no common ancestor with GitHub main."
+        ),
+    }[state]
+
+
+def _submit_status_message(
+    slug: str,
+    shared_changes: list[str],
+    remote_state: str,
+) -> str:
+    if shared_changes:
+        return (
+            "blocked by uncommitted shared files; commit them yourself or run "
+            f"'ankiops shared submit {slug} --commit'."
+        )
+    if remote_state in {"current", "same_tree"}:
+        return "no-op; there are no shared changes to submit."
+    if remote_state == "remote_ahead":
+        return f"no-op; run 'ankiops shared update {slug}' to receive GitHub changes."
+    if remote_state in {"local_ahead", "diverged"}:
+        return "will open a pull request."
+    return "blocked by incompatible history; recreate or re-add this source."
 
 
 def run_list(args) -> None:
@@ -181,6 +308,8 @@ def run(args) -> None:
             run_update(args)
         case "submit":
             run_submit(args)
+        case "status":
+            run_status(args)
         case "list":
             run_list(args)
         case _:

--- a/ankiops/shared/create.py
+++ b/ankiops/shared/create.py
@@ -61,9 +61,17 @@ def create_shared_deck(
             source_paths=[rendered.source_path for rendered in plan.files],
             message=f"AnkiOps: create {source.source_id} from {deck}",
         )
-        branch = repo.subtree_split(source)
+        split_sha = repo.split_subtree(source)
+        repo.rejoin_subtree(
+            source,
+            split_sha,
+            f"AnkiOps: initialize subtree history for {source.source_id}",
+        )
+        branch = repo.create_temp_branch(source, split_sha)
         if source.github_url:
             repo.push_ref(source.github_url, branch, SHARED_BRANCH)
+        repo.delete_branch_if_exists(branch)
+        branch = None
     except Exception:
         _cleanup_failed_create(repo, plan, initial_head=initial_head, branch=branch)
         raise

--- a/ankiops/shared/hosting.py
+++ b/ankiops/shared/hosting.py
@@ -89,17 +89,16 @@ def ensure_create_repo(
     _create_github_repo(repo, source, public=public)
 
 
-def open_pr_if_possible(repo: CollectionGit, source: DeckSource, branch: str) -> None:
+def open_pr_if_possible(
+    repo: CollectionGit,
+    source: DeckSource,
+    branch: str,
+    *,
+    title: str,
+) -> bool:
     if source.github_url is None:
         logger.info("Prepared branch %s. Push it and open a PR manually.", branch)
-        return
-    if shutil.which("gh") is None:
-        logger.info(
-            "Prepared branch %s. Push it to %s and open a PR manually.",
-            branch,
-            source.github_url,
-        )
-        return
+        return False
     push = repo.push_ref(source.github_url, branch, branch, check=False)
     if push.returncode != 0:
         logger.info(
@@ -108,7 +107,15 @@ def open_pr_if_possible(repo: CollectionGit, source: DeckSource, branch: str) ->
             source.github_url,
         )
         logger.debug(push.stderr)
-        return
+        return False
+
+    if shutil.which("gh") is None:
+        logger.info(
+            "Pushed branch %s to %s. Open a PR manually.",
+            branch,
+            source.github_url,
+        )
+        return True
 
     gh = subprocess.run(
         [
@@ -121,7 +128,10 @@ def open_pr_if_possible(repo: CollectionGit, source: DeckSource, branch: str) ->
             branch,
             "--base",
             SHARED_BRANCH,
-            "--fill",
+            "--title",
+            title,
+            "--body",
+            f"Submitted by AnkiOps from {source.source_id}.",
         ],
         cwd=repo.collection_dir,
         text=True,
@@ -133,3 +143,4 @@ def open_pr_if_possible(repo: CollectionGit, source: DeckSource, branch: str) ->
     else:
         logger.info("Pushed branch %s. Open the PR manually.", branch)
         logger.debug(gh.stderr)
+    return True

--- a/docs/git_operations.md
+++ b/docs/git_operations.md
@@ -73,10 +73,10 @@ Important behavior:
 Each command accepts `--no-auto-commit` / `-n`, except that LLM only accepts it
 with `<task> --run`.
 
-`ankiops shared update --to-anki` runs `ankiops fa` after updating. `ankiops
-shared submit --from-anki` runs `ankiops af` before preparing the submission.
-Until shared-aware scoping exists, those nested snapshots use the broad fallback
-when shared sources are present.
+`ankiops shared update --to-anki` runs `ankiops fa` after updating and currently
+uses the broad snapshot fallback when shared sources are present. `ankiops shared
+submit --from-anki` runs `ankiops af` with auto-commit disabled; only an explicit
+`shared submit --commit` may create the submission commit.
 
 ## Other Git operations
 
@@ -86,7 +86,8 @@ when shared sources are present.
 | `ankiops shared create <deck> <owner>/<repo>` | Requires a Git-backed collection, checks for staged changes, optionally checks or creates the GitHub repo, commits the deck move into `shared/<owner>/<repo>`, splits that subtree to a temporary branch, and pushes it to `main` on the target repo. |
 | `ankiops shared add <owner>/<repo>` | Requires a Git-backed collection and runs `git subtree add` for `https://github.com/<owner>/<repo>.git` at `shared/<owner>/<repo>` from branch `main`. |
 | `ankiops shared update [owner/repo]` | Requires a Git-backed collection and runs `git subtree pull` for one shared source, or every known shared source when the repo is omitted. |
-| `ankiops shared submit <owner>/<repo>` | Requires a Git-backed collection, commits changes under `shared/<owner>/<repo>`, splits that subtree to a temporary branch, pushes that branch when possible, and opens a PR with `gh` when available. |
+| `ankiops shared status <owner>/<repo>` | Shows shared and private working-tree changes, fetches remote `main`, compares committed subtree history, and explains what `submit` will do. |
+| `ankiops shared submit <owner>/<repo>` | Requires shared changes to be committed unless `--commit` is explicit, splits and rejoins the subtree history, pushes a temporary branch when changes exist, and opens a PR with `gh` when available. |
 
 ## Shared details
 
@@ -122,12 +123,24 @@ git diff --cached --quiet
 git commit -m "AnkiOps: create shared/<owner>/<repo> from <deck>"
 ```
 
-Then it pushes the subtree:
+Then it splits the subtree, records a metadata-only history join, and pushes the
+split commit:
 
 ```text
-git subtree split --prefix shared/<owner>/<repo> -b ankiops-shared-<owner>-<repo>-<id>
+git subtree split --prefix shared/<owner>/<repo>
+git commit-tree <HEAD-tree> -p HEAD -p <split-sha> \
+  -m "AnkiOps: initialize subtree history for shared/<owner>/<repo>" \
+  -m "<git-subtree trailers>"
+git update-ref HEAD <rejoin-commit> <old-head>
+git branch ankiops-shared-<owner>-<repo>-<id> <split-sha>
 git push https://github.com/<owner>/<repo>.git <branch>:main
+git branch -D <branch>
 ```
+
+The rejoin commit has the same tree as its first parent. It records the split as
+its second parent and adds `git-subtree-dir`, `git-subtree-mainline`, and
+`git-subtree-split` trailers. This preserves remote ancestry without staging or
+committing unrelated working-tree changes.
 
 If create fails after creating a commit or temporary branch, AnkiOps attempts to
 roll back with the appropriate subset of:
@@ -147,7 +160,9 @@ git rm -r --cached --ignore-unmatch -- <paths>
 ```text
 git rev-parse --git-dir
 git update-index -q --refresh
-git subtree add --prefix shared/<owner>/<repo> https://github.com/<owner>/<repo>.git main
+git subtree add --prefix shared/<owner>/<repo> \
+  --message "AnkiOps: add shared/<owner>/<repo> from GitHub" \
+  https://github.com/<owner>/<repo>.git main
 ```
 
 ### `shared update`
@@ -157,26 +172,72 @@ git subtree add --prefix shared/<owner>/<repo> https://github.com/<owner>/<repo>
 ```text
 git rev-parse --git-dir
 git update-index -q --refresh
-git subtree pull --prefix shared/<owner>/<repo> https://github.com/<owner>/<repo>.git main
+git subtree pull --prefix shared/<owner>/<repo> \
+  --message "AnkiOps: update shared/<owner>/<repo> from GitHub" \
+  https://github.com/<owner>/<repo>.git main
 ```
+
+When the pull creates no commit, AnkiOps reports that the source is already up
+to date. Because `git subtree pull` rejects any dirty worktree, AnkiOps
+temporarily stashes changes outside the shared prefix and restores their exact
+staged and unstaged state with `git stash pop --index`. Existing stashes are
+left untouched; dirty files inside the shared prefix still block the pull.
+
+### `shared status`
+
+`status` is read-only with respect to collection files and history. It shows
+short Git status lines for the selected shared prefix and for private paths,
+fetches GitHub `main`, and classifies the committed shared state as current,
+remote-ahead, local-ahead, same-content, diverged, or incompatible. Its final
+line states whether `submit` will stop, do nothing, or open a pull request.
 
 ### `shared submit`
 
-`submit` commits local shared source changes, creates a subtree branch, and
-tries to prepare a pull request:
+`submit` accepts `-m` / `--message`. The message becomes the pull request title;
+with `--commit`, the collection commit receives an `AnkiOps:` prefix. Without
+the option, the title is `Update shared deck <owner>/<repo>`.
+
+Dirty shared files stop submission without changing history. Commit them
+yourself, or pass `--commit` to give AnkiOps explicit permission to run:
 
 ```text
-git rev-parse --git-dir
 git add -A -- shared/<owner>/<repo>
 git diff --cached --quiet -- shared/<owner>/<repo>
-git commit -m "AnkiOps: submit shared/<owner>/<repo>" -- shared/<owner>/<repo>
-git subtree split --prefix shared/<owner>/<repo> -b ankiops-shared-<owner>-<repo>-<id>
-git push https://github.com/<owner>/<repo>.git <branch>:<branch>
-gh pr create --repo <owner>/<repo> --head <branch> --base main --fill
+git commit -m "AnkiOps: <message>" -- shared/<owner>/<repo>
 ```
 
-If `gh` is not installed, or if the push fails, AnkiOps leaves the branch name in
-the log so the user can push it and open a PR manually.
+AnkiOps then fetches remote `main` and splits the subtree without creating a
+branch:
+
+```text
+git fetch https://github.com/<owner>/<repo>.git main
+git subtree split --prefix shared/<owner>/<repo>
+```
+
+If the split is already an ancestor of remote `main`, or both trees are equal,
+the command reports that there are no changes and stops. Otherwise it requires
+a common ancestor, records a metadata-only rejoin commit, and publishes the
+split:
+
+```text
+git commit-tree <HEAD-tree> -p HEAD -p <split-sha> \
+  -m "AnkiOps: record submission history for shared/<owner>/<repo>" \
+  -m "<git-subtree trailers>"
+git update-ref HEAD <rejoin-commit> <old-head>
+git branch ankiops-shared-<owner>-<repo>-<id> <split-sha>
+git push https://github.com/<owner>/<repo>.git <branch>:<branch>
+gh pr create --repo <owner>/<repo> --head <branch> --base main \
+  --title "<message>" --body "Submitted by AnkiOps from shared/<owner>/<repo>."
+git branch -D <branch>
+```
+
+The local temporary branch is removed after a successful push. A failed push
+keeps it for manual recovery. When `gh` is unavailable or PR creation fails, the
+successfully pushed remote branch remains available for creating the PR by hand.
+
+Shared sources created by older experimental AnkiOps versions do not have the
+required ancestry metadata. Update and submit reject them with instructions to
+recreate or re-add the source; there is no automatic migration.
 
 ## Commands that do not run Git
 

--- a/tests/integration/cli/test_cli_sync.py
+++ b/tests/integration/cli/test_cli_sync.py
@@ -12,7 +12,12 @@ import pytest
 
 from ankiops.anki_rpc import AnkiConnectionError
 from ankiops.cli import main
-from ankiops.cli_commands import run_deserialize, run_fix_image_widths, run_serialize
+from ankiops.cli_commands import (
+    run_deserialize,
+    run_fix_image_widths,
+    run_serialize,
+    run_shared,
+)
 from ankiops.image_widths import ImageWidthFixResult
 from tests.support.deck_files import DeckFileHarness
 
@@ -62,10 +67,7 @@ def test_run_fa_warns_for_keyless_anki_notes_it_protects(world, caplog):
     with caplog.at_level(logging.WARNING):
         world.run_fa()
 
-    assert (
-        "Protected 1 keyless Anki note(s) during files -> Anki sync."
-        in caplog.text
-    )
+    assert "Protected 1 keyless Anki note(s) during files -> Anki sync." in caplog.text
     assert "ProtectDeck" in caplog.text
     assert keyless_id in world.mock_anki.notes
 
@@ -303,6 +305,80 @@ def test_cli_shared_create_accepts_public_visibility_flag():
     assert captured[0].deck == "Deck"
     assert captured[0].repo == "owner/repo"
     assert captured[0].public is True
+
+
+def test_cli_shared_submit_accepts_custom_message():
+    captured = []
+
+    with (
+        patch(
+            "ankiops.cli_commands.run_shared_impl",
+            side_effect=lambda args: captured.append(args),
+        ),
+        patch(
+            "sys.argv",
+            [
+                "ankiops",
+                "shared",
+                "submit",
+                "owner/repo",
+                "--message",
+                "  Clarify shared history  ",
+                "--commit",
+            ],
+        ),
+    ):
+        main()
+
+    assert captured[0].message == "Clarify shared history"
+    assert captured[0].commit is True
+
+
+def test_cli_shared_status_accepts_repo():
+    captured = []
+
+    with (
+        patch(
+            "ankiops.cli_commands.run_shared_impl",
+            side_effect=lambda args: captured.append(args),
+        ),
+        patch(
+            "sys.argv",
+            ["ankiops", "shared", "status", "owner/repo"],
+        ),
+    ):
+        main()
+
+    assert captured[0].shared_command == "status"
+    assert captured[0].repo == "owner/repo"
+
+
+def test_shared_submit_from_anki_does_not_auto_commit():
+    args = SimpleNamespace(shared_command="submit", from_anki=True)
+
+    with (
+        patch("ankiops.cli_commands.run_af") as run_af,
+        patch("ankiops.cli_commands.run_shared_impl"),
+    ):
+        run_shared(args)
+
+    assert run_af.call_args.args[0].no_auto_commit is True
+
+
+@pytest.mark.parametrize("message", ["   ", "line one\nline two"])
+def test_cli_shared_submit_rejects_invalid_message(message):
+    with (
+        patch("ankiops.cli_commands.run_shared_impl") as run_shared,
+        patch(
+            "sys.argv",
+            ["ankiops", "shared", "submit", "owner/repo", "--message", message],
+        ),
+        pytest.raises(SystemExit) as excinfo,
+    ):
+        main()
+
+    assert excinfo.value.code == 2
+    run_shared.assert_not_called()
 
 
 def test_cli_init_exits_cleanly_on_anki_connection_error(caplog):

--- a/tests/integration/shared/test_git_workflow.py
+++ b/tests/integration/shared/test_git_workflow.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+
+from ankiops.deck_sources import DeckSource
+from ankiops.git import CollectionGit
+from ankiops.shared import run_submit, run_update
+from tests.support.deck_files import DeckFileHarness
+
+
+def _git(cwd, *args):
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+
+def _configure_git(cwd, name):
+    _git(cwd, "config", "user.name", name)
+    _git(cwd, "config", "user.email", f"{name.lower()}@example.invalid")
+
+
+def _replace(path, old, new):
+    content = path.read_text(encoding="utf-8").replace(old, new)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_two_rounds_of_concurrent_shared_collaboration(tmp_path, monkeypatch):
+    collection = tmp_path / "collection"
+    shared_root = collection / "shared" / "owner" / "repo"
+    DeckFileHarness().eject_default_note_types(shared_root / "note_types")
+    (shared_root / "Deck.md").write_text(
+        "<!-- note_key: deck-key -->\n"
+        "<!-- note_type: shared/owner/repo/AnkiOpsQA -->\n"
+        "Q: root\nA: deck\n",
+        encoding="utf-8",
+    )
+    (shared_root / "Child.md").write_text(
+        "<!-- note_key: child-key -->\n"
+        "<!-- note_type: shared/owner/repo/AnkiOpsQA -->\n"
+        "Q: child\nA: deck\n",
+        encoding="utf-8",
+    )
+    private = collection / "Private.md"
+    private.write_text("private baseline\n", encoding="utf-8")
+    _git(collection, "init", "-b", "main")
+    _configure_git(collection, "Collector")
+    _git(collection, "add", "-A")
+    _git(collection, "commit", "-m", "Initialize collection")
+
+    source = DeckSource.shared(collection, "owner", "repo")
+    repo = CollectionGit(collection)
+    initial_split = repo.split_subtree(source)
+    repo.rejoin_subtree(
+        source,
+        initial_split,
+        "AnkiOps: initialize subtree history for shared/owner/repo",
+    )
+    remote = tmp_path / "remote.git"
+    subprocess.run(
+        ["git", "init", "--bare", "--initial-branch=main", remote],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    repo.push_ref(str(remote), initial_split, "refs/heads/main")
+
+    collaborator = tmp_path / "collaborator"
+    _git(tmp_path, "clone", remote, collaborator)
+    _configure_git(collaborator, "Collaborator")
+    monkeypatch.setattr(
+        "ankiops.deck_sources.DeckSource.github_url",
+        property(lambda _source: str(remote)),
+    )
+    monkeypatch.setattr(
+        "ankiops.shared.commands.require_collection_dir",
+        lambda: collection,
+    )
+    submitted = []
+
+    def push_submission(repo, _source, branch, *, title):
+        sha = repo.run(["rev-parse", branch]).stdout.strip()
+        repo.push_ref(str(remote), branch, f"refs/heads/{branch}")
+        submitted.append((branch, sha, title))
+        return True
+
+    monkeypatch.setattr(
+        "ankiops.shared.commands.open_pr_if_possible",
+        push_submission,
+    )
+
+    for round_number in (1, 2):
+        old_child = "A: deck" if round_number == 1 else "A: remote round 1"
+        _replace(
+            collaborator / "Child.md",
+            old_child,
+            f"A: remote round {round_number}",
+        )
+        _git(collaborator, "add", "Child.md")
+        _git(
+            collaborator,
+            "commit",
+            "-m",
+            f"Child: collaborator round {round_number}",
+        )
+        _git(collaborator, "push", "origin", "main")
+        collaboration_base = _git(collaborator, "rev-parse", "HEAD^").stdout.strip()
+
+        old_root = "A: deck" if round_number == 1 else "A: local round 1"
+        _replace(
+            shared_root / "Deck.md",
+            old_root,
+            f"A: local round {round_number}",
+        )
+        private.write_text(
+            f"private round {round_number}\n",
+            encoding="utf-8",
+        )
+        _git(collection, "add", "Private.md")
+
+        run_submit(
+            SimpleNamespace(
+                repo="owner/repo",
+                message=f"Clarify shared history round {round_number}",
+                commit=True,
+            )
+        )
+
+        branch, split_sha, title = submitted[-1]
+        assert title == f"Clarify shared history round {round_number}"
+        assert repo.run(["branch", "--list", branch]).stdout == ""
+        assert _git(collection, "status", "--short").stdout == "M  Private.md\n"
+        _git(collaborator, "fetch", "origin", branch)
+        assert (
+            _git(collaborator, "merge-base", "main", f"origin/{branch}").stdout.strip()
+            == collaboration_base
+        )
+        remote_split = _git(
+            collaborator,
+            "rev-parse",
+            f"origin/{branch}",
+        ).stdout.strip()
+        assert remote_split == split_sha
+        _git(
+            collaborator,
+            "merge",
+            "--no-ff",
+            f"origin/{branch}",
+            "-m",
+            f"Merge local round {round_number}",
+        )
+        _git(collaborator, "push", "origin", "main")
+
+        private.write_text(
+            f"private round {round_number}\nunstaged private detail\n",
+            encoding="utf-8",
+        )
+        private_status = _git(collection, "status", "--short").stdout
+        private_index = _git(collection, "show", ":Private.md").stdout
+        private_worktree = private.read_bytes()
+        run_update(SimpleNamespace(repo="owner/repo"))
+        assert _git(collection, "status", "--short").stdout == private_status
+        assert _git(collection, "show", ":Private.md").stdout == private_index
+        assert private.read_bytes() == private_worktree
+        _git(
+            collection,
+            "commit",
+            "-m",
+            f"Private: round {round_number}",
+            "--",
+            "Private.md",
+        )
+        remote_head = _git(collaborator, "rev-parse", "HEAD").stdout.strip()
+        assert (
+            repo.run(
+                [
+                    "rev-parse",
+                    "HEAD:shared/owner/repo",
+                ]
+            ).stdout.strip()
+            == repo.run(["rev-parse", f"{remote_head}^{{tree}}"]).stdout.strip()
+        )
+
+    submission_count = len(submitted)
+    head = repo.head()
+    run_submit(SimpleNamespace(repo="owner/repo", message=None))
+    assert len(submitted) == submission_count
+    assert repo.head() == head
+    subjects = repo.run(
+        ["log", "--first-parent", "--format=%s", "-7"]
+    ).stdout.splitlines()
+    assert "AnkiOps: update shared/owner/repo from GitHub" in subjects
+    assert "AnkiOps: record submission history for shared/owner/repo" in subjects
+    assert "Private: round 2" in subjects

--- a/tests/unit/test_shared_commands.py
+++ b/tests/unit/test_shared_commands.py
@@ -9,10 +9,11 @@ import pytest
 from ankiops.deck_sources import DeckSource
 from ankiops.git import CollectionGit
 from ankiops.markdown import NOTE_SEPARATOR
-from ankiops.shared import run_create, run_list, run_submit
+from ankiops.shared import commands as shared_commands
+from ankiops.shared import run_create, run_list, run_submit, run_update
 from ankiops.shared.commands import _parse_slug
 from ankiops.shared.create import _unlink_created_source_files
-from ankiops.shared.hosting import ensure_create_repo
+from ankiops.shared.hosting import ensure_create_repo, open_pr_if_possible
 from tests.support.deck_files import DeckFileHarness
 
 
@@ -66,6 +67,39 @@ def _commit_all(collection_dir, message="root"):
         check=True,
         capture_output=True,
     )
+
+
+def _setup_shared_source_with_remote(tmp_path):
+    collection_dir = _setup_collection(tmp_path / "collection")
+    shared_root = collection_dir / "shared" / "owner" / "repo"
+    DeckFileHarness().eject_default_note_types(shared_root / "note_types")
+    (shared_root / "Deck.md").write_text(
+        "<!-- note_key: key-1 -->\n"
+        "<!-- note_type: shared/owner/repo/AnkiOpsQA -->\n"
+        "Q: local\nA: deck\n",
+        encoding="utf-8",
+    )
+    (collection_dir / "Private.md").write_text("original\n", encoding="utf-8")
+    (collection_dir / "Unstaged.md").write_text("original\n", encoding="utf-8")
+    _init_git_repo(collection_dir)
+    _commit_all(collection_dir)
+
+    source = DeckSource.shared(collection_dir, "owner", "repo")
+    repo = CollectionGit(collection_dir)
+    split_sha = repo.split_subtree(source)
+    repo.rejoin_subtree(
+        source,
+        split_sha,
+        "AnkiOps: initialize subtree history for shared/owner/repo",
+    )
+    remote = tmp_path / "remote.git"
+    subprocess.run(
+        ["git", "init", "--bare", "--initial-branch=main", remote],
+        check=True,
+        capture_output=True,
+    )
+    repo.push_ref(str(remote), split_sha, "refs/heads/main")
+    return collection_dir, source, repo, remote
 
 
 @pytest.mark.parametrize(
@@ -155,6 +189,23 @@ def test_create_unsynced_deck_moves_files_media_and_note_types(tmp_path, monkeyp
     assert _git_status(collection_dir) == ""
     assert pushed[0][1] == "https://github.com/owner/repo.git"
     assert pushed[0][3] == "main"
+    message = subprocess.run(
+        ["git", "show", "-s", "--format=%B", "HEAD"],
+        cwd=collection_dir,
+        text=True,
+        capture_output=True,
+        check=True,
+    ).stdout
+    assert "AnkiOps: initialize subtree history for shared/owner/repo" in message
+    assert "git-subtree-dir: shared/owner/repo" in message
+    branches = subprocess.run(
+        ["git", "branch", "--list", "ankiops-shared-owner-repo-*"],
+        cwd=collection_dir,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    assert branches.stdout == ""
 
 
 def test_create_missing_repo_blocks_before_anki_or_file_mutations(
@@ -359,7 +410,7 @@ def test_create_subtree_split_failure_rolls_back_create_commit(
         lambda *_args, **_kwargs: None,
     )
     monkeypatch.setattr(
-        "ankiops.shared.create.CollectionGit.subtree_split",
+        "ankiops.shared.create.CollectionGit.split_subtree",
         lambda *_args: (_ for _ in ()).throw(ValueError("split failed")),
     )
 
@@ -395,11 +446,14 @@ def test_create_push_failure_rolls_back_create_commit_and_temp_branch(
         lambda *_args, **_kwargs: None,
     )
 
-    def fake_split(repo, _source):
+    def fake_branch(repo, _source, _commit_sha):
         subprocess.run(["git", "branch", branch], cwd=repo.collection_dir, check=True)
         return branch
 
-    monkeypatch.setattr("ankiops.shared.create.CollectionGit.subtree_split", fake_split)
+    monkeypatch.setattr(
+        "ankiops.shared.create.CollectionGit.create_temp_branch",
+        fake_branch,
+    )
 
     monkeypatch.setattr(
         "ankiops.shared.create.CollectionGit.push_ref",
@@ -439,7 +493,7 @@ def test_git_commit_paths_ignores_missing_untracked_source_path(tmp_path):
     target.parent.mkdir(parents=True)
     target.write_text("Q: moved\nA: deck\n", encoding="utf-8")
 
-    CollectionGit(tmp_path).commit_paths(
+    committed = CollectionGit(tmp_path).commit_paths(
         [target, tmp_path / "Segeln.md"],
         "create",
     )
@@ -452,6 +506,8 @@ def test_git_commit_paths_ignores_missing_untracked_source_path(tmp_path):
         check=True,
     )
     assert status.stdout == ""
+    assert committed is True
+    assert CollectionGit(tmp_path).commit_paths([target], "no-op") is False
 
 
 def test_git_commit_create_stages_source_removal_before_unlink(tmp_path):
@@ -503,6 +559,65 @@ def test_git_commit_create_stages_source_removal_before_unlink(tmp_path):
         check=True,
     )
     assert status.stdout == ""
+
+
+def test_rejoin_subtree_preserves_private_changes_and_records_metadata(tmp_path):
+    _init_git_repo(tmp_path)
+    source = DeckSource.shared(tmp_path, "owner", "repo")
+    source.root.mkdir(parents=True)
+    (source.root / "Deck.md").write_text("Q: shared\nA: deck\n", encoding="utf-8")
+    private = tmp_path / "Private.md"
+    private.write_text("original\n", encoding="utf-8")
+    unstaged = tmp_path / "Unstaged.md"
+    unstaged.write_text("original\n", encoding="utf-8")
+    _commit_all(tmp_path)
+
+    repo = CollectionGit(tmp_path)
+    split_sha = repo.split_subtree(source)
+    old_head = _git_head(tmp_path)
+    old_tree = repo.run(["rev-parse", "HEAD^{tree}"]).stdout.strip()
+
+    private.write_text("staged\n", encoding="utf-8")
+    subprocess.run(["git", "add", "Private.md"], cwd=tmp_path, check=True)
+    unstaged.write_text("unstaged\n", encoding="utf-8")
+    old_status = _git_status(tmp_path)
+
+    repo.rejoin_subtree(
+        source,
+        split_sha,
+        "AnkiOps: initialize subtree history for shared/owner/repo",
+    )
+
+    new_head = _git_head(tmp_path)
+    assert new_head != old_head
+    assert repo.run(["rev-parse", "HEAD^{tree}"]).stdout.strip() == old_tree
+    assert repo.run(["rev-parse", "HEAD^1"]).stdout.strip() == old_head
+    assert repo.run(["rev-parse", "HEAD^2"]).stdout.strip() == split_sha
+    message = repo.run(["show", "-s", "--format=%B", "HEAD"]).stdout
+    assert "git-subtree-dir: shared/owner/repo" in message
+    assert f"git-subtree-mainline: {old_head}" in message
+    assert f"git-subtree-split: {split_sha}" in message
+    assert _git_status(tmp_path) == old_status
+
+
+def test_rejoin_subtree_rejects_a_split_with_different_content(tmp_path):
+    _init_git_repo(tmp_path)
+    source = DeckSource.shared(tmp_path, "owner", "repo")
+    source.root.mkdir(parents=True)
+    deck = source.root / "Deck.md"
+    deck.write_text("Q: original\nA: deck\n", encoding="utf-8")
+    _commit_all(tmp_path)
+    repo = CollectionGit(tmp_path)
+    stale_split = repo.split_subtree(source)
+
+    deck.write_text("Q: changed\nA: deck\n", encoding="utf-8")
+    repo.commit_paths([deck], "change shared deck")
+    current_head = _git_head(tmp_path)
+
+    with pytest.raises(ValueError, match="split tree does not match"):
+        repo.rejoin_subtree(source, stale_split, "rejoin")
+
+    assert _git_head(tmp_path) == current_head
 
 
 def test_ensure_create_repo_without_gh_prints_manual_create_command(
@@ -569,6 +684,47 @@ def test_ensure_create_repo_creates_missing_public_repo_with_gh(
     assert calls == [(tmp_path, "owner/repo", True)]
 
 
+def test_open_pr_uses_explicit_title_and_reports_success(tmp_path, monkeypatch):
+    source = DeckSource.shared(tmp_path, "owner", "repo")
+    repo = CollectionGit(tmp_path)
+    monkeypatch.setattr("ankiops.shared.hosting.shutil.which", lambda _name: "/bin/gh")
+    monkeypatch.setattr(
+        "ankiops.git.CollectionGit.push_ref",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0, "", ""),
+    )
+    calls = []
+
+    def fake_run(args, **kwargs):
+        calls.append((args, kwargs))
+        return subprocess.CompletedProcess(args, 0, "https://example.test/pr/1\n", "")
+
+    monkeypatch.setattr("ankiops.shared.hosting.subprocess.run", fake_run)
+
+    pushed = open_pr_if_possible(
+        repo,
+        source,
+        "submission-branch",
+        title="Clarify shared history",
+    )
+
+    assert pushed is True
+    assert calls[0][0] == [
+        "gh",
+        "pr",
+        "create",
+        "--repo",
+        "owner/repo",
+        "--head",
+        "submission-branch",
+        "--base",
+        "main",
+        "--title",
+        "Clarify shared history",
+        "--body",
+        "Submitted by AnkiOps from shared/owner/repo.",
+    ]
+
+
 def test_create_rejects_duplicate_note_keys(tmp_path, monkeypatch):
     collection_dir = _setup_collection(tmp_path)
     deck = collection_dir / "Deck.md"
@@ -628,67 +784,403 @@ def test_submit_rejects_keyless_notes_without_mutating_files(
     assert _git_status(collection_dir) == ""
 
 
+def test_submit_with_no_shared_changes_creates_no_branch_or_pr(
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    collection_dir, _source, repo, remote = _setup_shared_source_with_remote(tmp_path)
+    initial_head = _git_head(collection_dir)
+
+    monkeypatch.setattr(
+        "ankiops.deck_sources.DeckSource.github_url",
+        property(lambda _source: str(remote)),
+    )
+    monkeypatch.setattr(
+        "ankiops.shared.commands.require_collection_dir",
+        lambda: collection_dir,
+    )
+    monkeypatch.setattr(
+        "ankiops.shared.commands.open_pr_if_possible",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("unexpected PR")
+        ),
+    )
+
+    with caplog.at_level(logging.INFO, logger="ankiops.shared.commands"):
+        run_submit(SimpleNamespace(repo="owner/repo", message=None))
+
+    assert _git_head(collection_dir) == initial_head
+    assert "No shared changes to submit for owner/repo." in caplog.text
+    assert repo.run(["branch", "--list", "ankiops-shared-*"]).stdout == ""
+
+
+def test_submit_requires_explicit_commit_for_dirty_shared_changes(
+    tmp_path,
+    monkeypatch,
+):
+    collection_dir, source, repo, remote = _setup_shared_source_with_remote(tmp_path)
+    deck = source.root / "Deck.md"
+    deck.write_text(deck.read_text() + "E: clarified\n", encoding="utf-8")
+    initial_head = repo.head()
+    monkeypatch.setattr(
+        "ankiops.deck_sources.DeckSource.github_url",
+        property(lambda _source: str(remote)),
+    )
+    monkeypatch.setattr(
+        "ankiops.shared.commands.require_collection_dir",
+        lambda: collection_dir,
+    )
+
+    with pytest.raises(ValueError, match="--commit"):
+        run_submit(SimpleNamespace(repo="owner/repo", message=None, commit=False))
+
+    assert repo.head() == initial_head
+    assert "Deck.md" in _git_status(collection_dir)
+
+
+def test_shared_status_reports_changes_remote_state_and_submit_action(
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    collection_dir, source, _repo, remote = _setup_shared_source_with_remote(tmp_path)
+    deck = source.root / "Deck.md"
+    deck.write_text(deck.read_text() + "E: clarified\n", encoding="utf-8")
+    (collection_dir / "Private.md").write_text("private draft\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "ankiops.deck_sources.DeckSource.github_url",
+        property(lambda _source: str(remote)),
+    )
+    monkeypatch.setattr(
+        "ankiops.shared.commands.require_collection_dir",
+        lambda: collection_dir,
+    )
+
+    with caplog.at_level(logging.INFO, logger="ankiops.shared.commands"):
+        shared_commands.run_status(SimpleNamespace(repo="owner/repo"))
+
+    assert "Shared changes: 1" in caplog.text
+    assert "Deck.md" in caplog.text
+    assert "Private changes: 1 (preserved)" in caplog.text
+    assert "Private.md" in caplog.text
+    assert "Committed shared state matches GitHub main." in caplog.text
+    assert "Submit: blocked" in caplog.text
+    assert "--commit" in caplog.text
+
+
+def test_shared_status_reports_precommitted_changes_will_open_pr(
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    collection_dir, source, repo, remote = _setup_shared_source_with_remote(tmp_path)
+    deck = source.root / "Deck.md"
+    deck.write_text(deck.read_text() + "E: precommitted\n", encoding="utf-8")
+    repo.commit_paths([deck], "Clarify shared deck")
+    monkeypatch.setattr(
+        "ankiops.deck_sources.DeckSource.github_url",
+        property(lambda _source: str(remote)),
+    )
+    monkeypatch.setattr(
+        "ankiops.shared.commands.require_collection_dir",
+        lambda: collection_dir,
+    )
+
+    with caplog.at_level(logging.INFO, logger="ankiops.shared.commands"):
+        shared_commands.run_status(SimpleNamespace(repo="owner/repo"))
+
+    assert "Shared changes: 0" in caplog.text
+    assert "has changes not on GitHub main" in caplog.text
+    assert "Submit: will open a pull request." in caplog.text
+
+
+def test_submit_preserves_private_changes_and_uses_custom_message(
+    tmp_path,
+    monkeypatch,
+):
+    collection_dir, source, repo, remote = _setup_shared_source_with_remote(tmp_path)
+    deck = source.root / "Deck.md"
+    private = collection_dir / "Private.md"
+    unstaged = collection_dir / "Unstaged.md"
+
+    deck.write_text(deck.read_text() + "E: clarified\n", encoding="utf-8")
+    private.write_text("staged\n", encoding="utf-8")
+    subprocess.run(["git", "add", "Private.md"], cwd=collection_dir, check=True)
+    unstaged.write_text("unstaged\n", encoding="utf-8")
+    expected_private_status = "M  Private.md\n M Unstaged.md\n"
+
+    monkeypatch.setattr(
+        "ankiops.deck_sources.DeckSource.github_url",
+        property(lambda _source: str(remote)),
+    )
+    monkeypatch.setattr(
+        "ankiops.shared.commands.require_collection_dir",
+        lambda: collection_dir,
+    )
+    submitted = []
+
+    def fake_open_pr(repo, source, branch, *, title):
+        branch_sha = repo.run(["rev-parse", branch]).stdout.strip()
+        submitted.append((branch, title, branch_sha))
+        return True
+
+    monkeypatch.setattr("ankiops.shared.commands.open_pr_if_possible", fake_open_pr)
+
+    run_submit(
+        SimpleNamespace(
+            repo="owner/repo",
+            message="Clarify shared history",
+            commit=True,
+        )
+    )
+
+    assert submitted[0][1] == "Clarify shared history"
+    remote_head = repo.run(["rev-parse", "FETCH_HEAD"]).stdout.strip()
+    assert repo.is_ancestor(remote_head, submitted[0][2])
+    assert _git_status(collection_dir) == expected_private_status
+    assert repo.run(["branch", "--list", submitted[0][0]]).stdout == ""
+    subjects = repo.run(
+        ["log", "--first-parent", "--format=%s", "-2"]
+    ).stdout.splitlines()
+    assert subjects == [
+        "AnkiOps: record submission history for shared/owner/repo",
+        "AnkiOps: Clarify shared history",
+    ]
+
+
+def test_submit_retains_local_branch_when_push_fails(tmp_path, monkeypatch):
+    collection_dir, source, repo, remote = _setup_shared_source_with_remote(tmp_path)
+    deck = source.root / "Deck.md"
+    deck.write_text(deck.read_text() + "E: changed\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "ankiops.deck_sources.DeckSource.github_url",
+        property(lambda _source: str(remote)),
+    )
+    monkeypatch.setattr(
+        "ankiops.shared.commands.require_collection_dir",
+        lambda: collection_dir,
+    )
+    submitted = []
+
+    def fake_open_pr(_repo, _source, branch, *, title):
+        submitted.append((branch, title))
+        return False
+
+    monkeypatch.setattr("ankiops.shared.commands.open_pr_if_possible", fake_open_pr)
+
+    run_submit(SimpleNamespace(repo="owner/repo", message=None, commit=True))
+
+    branch, title = submitted[0]
+    assert title == "Update shared deck owner/repo"
+    assert repo.run(["branch", "--list", branch]).stdout.strip().endswith(branch)
+
+
+def test_submit_is_noop_when_only_remote_has_advanced(tmp_path, monkeypatch):
+    collection_dir, _source, repo, remote = _setup_shared_source_with_remote(tmp_path)
+    collaborator = tmp_path / "collaborator"
+    subprocess.run(
+        ["git", "clone", remote, collaborator],
+        check=True,
+        capture_output=True,
+    )
+    _configure = [
+        ("user.name", "Collaborator"),
+        ("user.email", "collaborator@example.invalid"),
+    ]
+    for key, value in _configure:
+        subprocess.run(
+            ["git", "config", key, value],
+            cwd=collaborator,
+            check=True,
+        )
+    deck = collaborator / "Deck.md"
+    deck.write_text(deck.read_text() + "E: remote\n", encoding="utf-8")
+    subprocess.run(["git", "add", "Deck.md"], cwd=collaborator, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Remote edit"],
+        cwd=collaborator,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "push", "origin", "main"],
+        cwd=collaborator,
+        check=True,
+        capture_output=True,
+    )
+    initial_head = repo.head()
+    monkeypatch.setattr(
+        "ankiops.deck_sources.DeckSource.github_url",
+        property(lambda _source: str(remote)),
+    )
+    monkeypatch.setattr(
+        "ankiops.shared.commands.require_collection_dir",
+        lambda: collection_dir,
+    )
+    monkeypatch.setattr(
+        "ankiops.shared.commands.open_pr_if_possible",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("unexpected PR")
+        ),
+    )
+
+    run_submit(SimpleNamespace(repo="owner/repo", message=None))
+
+    assert repo.head() == initial_head
+
+
+def test_submit_is_noop_when_divergent_history_has_same_tree(tmp_path, monkeypatch):
+    collection_dir, source, repo, remote = _setup_shared_source_with_remote(tmp_path)
+    deck = source.root / "Deck.md"
+    original = deck.read_text(encoding="utf-8")
+    deck.write_text(original + "E: temporary\n", encoding="utf-8")
+    repo.commit_paths([deck], "Temporary shared edit")
+    deck.write_text(original, encoding="utf-8")
+    repo.commit_paths([deck], "Revert temporary shared edit")
+    initial_head = repo.head()
+    monkeypatch.setattr(
+        "ankiops.deck_sources.DeckSource.github_url",
+        property(lambda _source: str(remote)),
+    )
+    monkeypatch.setattr(
+        "ankiops.shared.commands.require_collection_dir",
+        lambda: collection_dir,
+    )
+    monkeypatch.setattr(
+        "ankiops.shared.commands.open_pr_if_possible",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("unexpected PR")
+        ),
+    )
+
+    run_submit(SimpleNamespace(repo="owner/repo", message=None))
+
+    assert repo.head() == initial_head
+
+
+def test_submit_includes_precommitted_shared_edits(tmp_path, monkeypatch):
+    collection_dir, source, repo, remote = _setup_shared_source_with_remote(tmp_path)
+    deck = source.root / "Deck.md"
+    deck.write_text(deck.read_text() + "E: precommitted\n", encoding="utf-8")
+    repo.commit_paths([deck], "Manual shared edit")
+    monkeypatch.setattr(
+        "ankiops.deck_sources.DeckSource.github_url",
+        property(lambda _source: str(remote)),
+    )
+    monkeypatch.setattr(
+        "ankiops.shared.commands.require_collection_dir",
+        lambda: collection_dir,
+    )
+    submitted = []
+
+    def fake_open_pr(_repo, _source, branch, *, title):
+        submitted.append((branch, title))
+        return True
+
+    monkeypatch.setattr("ankiops.shared.commands.open_pr_if_possible", fake_open_pr)
+
+    run_submit(SimpleNamespace(repo="owner/repo", message=None))
+
+    assert len(submitted) == 1
+    assert repo.run(["branch", "--list", submitted[0][0]]).stdout == ""
+
+
+def test_update_reports_when_shared_source_is_already_current(
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    collection_dir, _source, _repo, remote = _setup_shared_source_with_remote(tmp_path)
+    initial_head = _git_head(collection_dir)
+    monkeypatch.setattr(
+        "ankiops.deck_sources.DeckSource.github_url",
+        property(lambda _source: str(remote)),
+    )
+    monkeypatch.setattr(
+        "ankiops.shared.commands.require_collection_dir",
+        lambda: collection_dir,
+    )
+
+    with caplog.at_level(logging.INFO, logger="ankiops.shared.commands"):
+        run_update(SimpleNamespace(repo="owner/repo"))
+
+    assert _git_head(collection_dir) == initial_head
+    assert "owner/repo is already up to date." in caplog.text
+
+
+@pytest.mark.parametrize("command", ["update", "submit"])
+def test_shared_commands_reject_sources_without_subtree_metadata(
+    tmp_path,
+    monkeypatch,
+    command,
+):
+    collection_dir = _setup_collection(tmp_path)
+    shared_root = collection_dir / "shared" / "owner" / "repo"
+    DeckFileHarness().eject_default_note_types(shared_root / "note_types")
+    (shared_root / "Deck.md").write_text(
+        "<!-- note_key: key-1 -->\n"
+        "<!-- note_type: shared/owner/repo/AnkiOpsQA -->\n"
+        "Q: local\nA: deck\n",
+        encoding="utf-8",
+    )
+    _init_git_repo(collection_dir)
+    _commit_all(collection_dir)
+    monkeypatch.setattr(
+        "ankiops.shared.commands.require_collection_dir",
+        lambda: collection_dir,
+    )
+
+    args = SimpleNamespace(repo="owner/repo", message=None)
+    with pytest.raises(ValueError, match="Recreate or re-add"):
+        if command == "update":
+            run_update(args)
+        else:
+            run_submit(args)
+
+
 def test_subtree_commands_use_shared_prefix_and_github_url(tmp_path, monkeypatch):
     source = DeckSource.shared(tmp_path, "owner", "repo")
     calls = []
 
     def fake_run(repo, args, *, check=True):
         calls.append((repo.collection_dir, args, check))
-        return subprocess.CompletedProcess(["git", *args], 0, "", "")
+        stdout = ""
+        if args == ["rev-parse", "--verify", "HEAD"]:
+            stdout = "head-sha\n"
+        elif args[:2] == ["subtree", "split"]:
+            stdout = "split-sha\n"
+        return subprocess.CompletedProcess(["git", *args], 0, stdout, "")
 
     monkeypatch.setattr("ankiops.git.CollectionGit.run", fake_run)
 
     repo = CollectionGit(tmp_path)
     repo.subtree_add(source)
-    repo.subtree_pull(source)
-    branch = repo.subtree_split(source)
+    assert repo.subtree_pull(source) is False
+    split_sha = repo.split_subtree(source)
+    branch = repo.create_temp_branch(source, split_sha)
 
     assert branch.startswith("ankiops-shared-owner-repo-")
-    assert calls[:4] == [
-        (
-            tmp_path,
-            ["update-index", "-q", "--refresh"],
-            False,
-        ),
-        (
-            tmp_path,
-            [
-                "subtree",
-                "add",
-                "--prefix",
-                "shared/owner/repo",
-                "https://github.com/owner/repo.git",
-                "main",
-            ],
-            True,
-        ),
-        (
-            tmp_path,
-            ["update-index", "-q", "--refresh"],
-            False,
-        ),
-        (
-            tmp_path,
-            [
-                "subtree",
-                "pull",
-                "--prefix",
-                "shared/owner/repo",
-                "https://github.com/owner/repo.git",
-                "main",
-            ],
-            True,
-        ),
-    ]
-    assert calls[4] == (
-        tmp_path,
-        [
-            "subtree",
-            "split",
-            "--prefix",
-            "shared/owner/repo",
-            "-b",
-            branch,
-        ],
-        True,
-    )
+    commands = [args for _cwd, args, _check in calls]
+    assert [
+        "subtree",
+        "add",
+        "--prefix",
+        "shared/owner/repo",
+        "--message",
+        "AnkiOps: add shared/owner/repo from GitHub",
+        "https://github.com/owner/repo.git",
+        "main",
+    ] in commands
+    assert [
+        "subtree",
+        "pull",
+        "--prefix",
+        "shared/owner/repo",
+        "--message",
+        "AnkiOps: update shared/owner/repo from GitHub",
+        "https://github.com/owner/repo.git",
+        "main",
+    ] in commands
+    assert ["subtree", "split", "--prefix", "shared/owner/repo"] in commands
+    assert ["branch", branch, "split-sha"] in commands


### PR DESCRIPTION
## Summary
- preserve real subtree ancestry with metadata-backed history joins
- add explicit shared submit commit consent and shared status diagnostics
- keep dirty private decks isolated across submit and update
- create native mergeable PRs with readable history and no-op handling

## Verification
- 487 tests pass
- Ruff and changed-file formatting pass
- three live GitHub/Anki collaboration rounds completed, including interleaved af/fa syncs

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the shared deck Git workflow. The main changes are:

- Preserves subtree ancestry with metadata-backed split and rejoin commits.
- Adds `shared status` diagnostics for local changes and remote state.
- Requires explicit `--commit` consent before submitting dirty shared files.
- Keeps private deck changes isolated during shared submit and update flows.
- Creates mergeable shared PR branches with no-op handling.

<h3>Confidence Score: 5/5</h3>

This PR appears safe to merge with low risk.

The shared Git, CLI, and hosting changes are cohesive and covered by targeted unit tests plus an integration collaboration workflow. No verified correctness or security issues were found.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the submit-workflow-02-after run to confirm how shared status diagnostics are reported.
- Observed that a dirty shared Deck.md submission without --commit raises an explicit consent error and leaves HEAD unchanged and the file dirty.
- Verified that --commit -m 'Clarify shared history' creates an AnkiOps commit, pushes a remote branch, and the remote base check succeeds.
- Observed that a no-change repeat submit intercepts a new PR branch and changes HEAD, showing the no-op contract failure.
- Compared update isolation before and after; the base run failed with RUN\_UPDATE\_RESULT=exception and dirty private files, with recorded calls showing run\_af and run\_shared\_impl behavior.
- Compared update isolation after run; the head run succeeded, private files updated to remote content, and recorded calls show run\_af and run\_shared\_impl were executed as submit.
- Noted that the update isolation artifacts include the exact harness and verbose command outputs used during the runs.
- Compared history-joins before and after; the before artifact shows API surface 'subtree\_split' and compatibility accepted for old history.
- After artifact shows a merge-style rejoin with specific parent trees and a rejection due to incompatible git history.

<a href="https://app.greptile.com/trex/runs/12970082/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| ankiops/git.py | Adds shared status helpers, metadata-backed subtree split/rejoin operations, remote comparison helpers, and private-change stashing for subtree pulls. |
| ankiops/shared/commands.py | Implements shared history compatibility checks, remote state classification, explicit submit commit handling, status diagnostics, and no-op submit behavior. |
| ankiops/shared/create.py | Records subtree metadata after shared deck creation and cleans up temporary split branches. |
| ankiops/shared/hosting.py | Pushes submit branches before optionally creating GitHub PRs with explicit titles and reports whether push succeeded. |
| tests/integration/shared/test_git_workflow.py | Adds an end-to-end collaboration test for repeated remote/local shared edits, PR branches, and private change preservation. |
| tests/unit/test_shared_commands.py | Expands unit coverage for subtree metadata joins, dirty shared change blocking, status messaging, updates, and PR creation behavior. |


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant CLI as ankiops shared
participant Git as CollectionGit
participant Remote as GitHub main
participant PR as PR helper

User->>CLI: shared status / submit owner/repo
CLI->>Git: verify subtree metadata
CLI->>Git: inspect shared/private status
Git->>Remote: fetch main
CLI->>Git: split subtree and classify remote state
alt submit with dirty shared files and --commit
    CLI->>Git: commit shared prefix only
else dirty shared files without --commit
    CLI-->>User: block with explicit commit guidance
end
alt local shared changes exist
    CLI->>Git: create metadata rejoin commit
    CLI->>Git: create temp branch at split
    CLI->>PR: push branch and create/open PR when possible
    PR-->>CLI: pushed status
    CLI->>Git: delete local temp branch after successful push
else no submit changes
    CLI-->>User: no-op status
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant CLI as ankiops shared
participant Git as CollectionGit
participant Remote as GitHub main
participant PR as PR helper

User->>CLI: shared status / submit owner/repo
CLI->>Git: verify subtree metadata
CLI->>Git: inspect shared/private status
Git->>Remote: fetch main
CLI->>Git: split subtree and classify remote state
alt submit with dirty shared files and --commit
    CLI->>Git: commit shared prefix only
else dirty shared files without --commit
    CLI-->>User: block with explicit commit guidance
end
alt local shared changes exist
    CLI->>Git: create metadata rejoin commit
    CLI->>Git: create temp branch at split
    CLI->>PR: push branch and create/open PR when possible
    PR-->>CLI: pushed status
    CLI->>Git: delete local temp branch after successful push
else no submit changes
    CLI-->>User: no-op status
end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Repeat submit with no shared changes still creates a PR branch and history commit**

   - **Bug**
     - After a successful `shared submit --commit -m 'Clarify shared history'`, re-running `shared submit owner/repo` without modifying shared files should be a no-op. The executed head harness shows the opposite: `open_pr_if_possible` is called again for a new branch (`ankiops-shared-owner-repo-cf896461`), `submit_noop_exit=0`, and `noop_head_changed True submitted_count_changed True`. The git log then contains another `AnkiOps: record submission history for shared/owner/repo` commit. This violates the requested unchanged/same-tree no-op behavior and would open redundant PRs for an already-submitted tree.
   - **Cause**
     - `run_submit` computes `_remote_state` before `repo.rejoin_subtree(...)`, pushes a split commit that is not present on remote `main`, and then the repeat run still compares the local split against unchanged remote `main`. Because the already-submitted branch was not merged into remote `main`, `_remote_state` remains submit-worthy and does not classify the repeated same-tree submission as a no-op.
   - **Fix**
     - Teach submit to recognize already-submitted/same-tree state before creating a new branch, e.g. compare the current subtree split tree against existing submission branch refs or record submitted split state locally after rejoin, and return without `rejoin_subtree`/`create_temp_branch`/`open_pr_if_possible` when the exact split/tree has already been submitted and no shared paths changed.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Refine Anki import flow and deck handlin..."](https://github.com/visserle/ankiops/commit/4b5ae204955e0598505fc82db9d28729fc5048ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41201765)</sub>

<!-- /greptile_comment -->