### PR TITLE
Support input files in LLM commands and tasks

### DIFF
--- a/ankiops/llm/commands.py
+++ b/ankiops/llm/commands.py
@@ -385,6 +385,8 @@ def _show_plan(
         logger.info("System prompt file: %s", plan.system_prompt_path)
     if plan.user_prompt_path is not None:
         logger.info("User prompt file: %s", plan.user_prompt_path)
+    if plan.input_file_paths:
+        logger.info("Input files: %s", ", ".join(plan.input_file_paths))
     logger.info("Request defaults: %s", plan.request_defaults)
     logger.info(
         "Discovery: decks_seen=%d decks_matched=%d notes_seen=%d "
@@ -425,6 +427,8 @@ def _show_plan(
         "Cost estimate (assuming number of input tokens equals output tokens): %s",
         plan.format_cost_estimate(),
     )
+    if plan.input_file_paths:
+        logger.info("Cost estimate excludes tokens derived from input files.")
     run_command = f"ankiops llm {plan.task_name} --run"
     if model_override:
         run_command = f"{run_command} --model {model_override}"

--- a/ankiops/llm/execution.py
+++ b/ankiops/llm/execution.py
@@ -285,14 +285,11 @@ class LlmTaskExecutor:
             timeout=60.0,
             max_retries=0,
         )
-        uploaded_file_ids: list[str] = []
         try:
-            await _upload_input_files(
+            input_file_ids = await _upload_input_files(
                 client=client,
                 paths=task.input_files,
-                file_ids=uploaded_file_ids,
             )
-            input_file_ids = tuple(uploaded_file_ids)
             batches = build_candidate_batches(
                 candidates,
                 max_notes_per_request=task.request.max_notes_per_request,
@@ -355,10 +352,7 @@ class LlmTaskExecutor:
                     start(batches[next_index])
                     next_index += 1
         finally:
-            await _finalize_openai_client(
-                client=client,
-                file_ids=tuple(uploaded_file_ids),
-            )
+            await client.close()
 
     async def _process_batch(
         self,
@@ -634,56 +628,21 @@ async def _upload_input_files(
     *,
     client: AsyncOpenAI,
     paths: tuple[Path, ...],
-    file_ids: list[str],
-) -> None:
+) -> tuple[str, ...]:
+    file_ids: list[str] = []
     for path in paths:
         try:
             with path.open("rb") as handle:
                 uploaded = await client.files.create(
                     file=handle,
                     purpose="user_data",
+                    expires_after={"anchor": "created_at", "seconds": 3600},
                 )
             file_id = uploaded.id
         except Exception as error:
             raise RuntimeError(_format_file_upload_error(path, error)) from error
         file_ids.append(file_id)
-
-
-async def _finalize_openai_client(
-    *,
-    client: AsyncOpenAI,
-    file_ids: tuple[str, ...],
-) -> None:
-    async def cleanup() -> None:
-        try:
-            await _delete_uploaded_files(client=client, file_ids=file_ids)
-        finally:
-            await client.close()
-
-    cleanup_task = asyncio.create_task(cleanup())
-    cancellation: asyncio.CancelledError | None = None
-    while not cleanup_task.done():
-        try:
-            await asyncio.shield(cleanup_task)
-        except asyncio.CancelledError as error:
-            cancellation = error
-    await cleanup_task
-    if cancellation is not None:
-        raise cancellation
-
-
-async def _delete_uploaded_files(
-    *,
-    client: AsyncOpenAI,
-    file_ids: tuple[str, ...],
-) -> None:
-    for file_id in file_ids:
-        try:
-            await client.files.delete(file_id)
-        except Exception as error:
-            logger.warning(
-                "Could not delete uploaded OpenAI file %s: %s", file_id, error
-            )
+    return tuple(file_ids)
 
 
 def _format_file_upload_error(path: Path, error: Exception) -> str:

--- a/ankiops/llm/execution.py
+++ b/ankiops/llm/execution.py
@@ -285,7 +285,12 @@ class LlmTaskExecutor:
             timeout=60.0,
             max_retries=0,
         )
+        uploaded_file_ids: tuple[str, ...] = ()
         try:
+            uploaded_file_ids = await _upload_input_files(
+                client=client,
+                paths=task.input_files,
+            )
             batches = build_candidate_batches(
                 candidates,
                 max_notes_per_request=task.request.max_notes_per_request,
@@ -305,6 +310,7 @@ class LlmTaskExecutor:
                         task=task,
                         client=client,
                         batch=batch,
+                        input_file_ids=uploaded_file_ids,
                     )
                 )
                 in_flight[task_handle] = batch
@@ -347,6 +353,10 @@ class LlmTaskExecutor:
                     start(batches[next_index])
                     next_index += 1
         finally:
+            await _delete_uploaded_files(
+                client=client,
+                file_ids=uploaded_file_ids,
+            )
             await client.close()
 
     async def _process_batch(
@@ -357,11 +367,13 @@ class LlmTaskExecutor:
         task: TaskConfig,
         client: AsyncOpenAI,
         batch: EligibleBatch,
+        input_file_ids: tuple[str, ...],
     ) -> _BatchProcessResult:
         result = await _call_openai(
             client=client,
             task=task,
             batch=batch,
+            input_file_ids=input_file_ids,
         )
         if result.parsed_response is None:
             status = (
@@ -617,17 +629,70 @@ def _record_discovery_item(
     )
 
 
+async def _upload_input_files(
+    *,
+    client: AsyncOpenAI,
+    paths: tuple[Path, ...],
+) -> tuple[str, ...]:
+    file_ids: list[str] = []
+    for path in paths:
+        try:
+            with path.open("rb") as handle:
+                uploaded = await client.files.create(
+                    file=handle,
+                    purpose="user_data",
+                )
+            file_id = uploaded.id
+        except Exception as error:
+            await _delete_uploaded_files(client=client, file_ids=tuple(file_ids))
+            raise RuntimeError(_format_file_upload_error(path, error)) from error
+        file_ids.append(file_id)
+    return tuple(file_ids)
+
+
+async def _delete_uploaded_files(
+    *,
+    client: AsyncOpenAI,
+    file_ids: tuple[str, ...],
+) -> None:
+    for file_id in file_ids:
+        try:
+            await client.files.delete(file_id)
+        except Exception as error:
+            logger.warning(
+                "Could not delete uploaded OpenAI file %s: %s", file_id, error
+            )
+
+
+def _format_file_upload_error(path: Path, error: Exception) -> str:
+    if isinstance(error, AuthenticationError):
+        return f"OpenAI authentication failed while uploading '{path.name}': {error}"
+    if isinstance(error, APIConnectionError):
+        return f"OpenAI connection error while uploading '{path.name}': {error}"
+    if isinstance(error, APIStatusError):
+        status_code = getattr(error, "status_code", "unknown")
+        return (
+            f"OpenAI returned HTTP {status_code} while uploading '{path.name}': {error}"
+        )
+    return f"Could not upload input file '{path.name}': {error}"
+
+
 async def _call_openai(
     *,
     client: AsyncOpenAI,
     task: TaskConfig,
     batch: EligibleBatch,
+    input_file_ids: tuple[str, ...],
 ) -> OpenAIResult:
     response_model = build_response_model(
         note_type=batch.note_type,
         payloads=batch.payloads,
     )
-    instructions, user_input = _build_request_content(task=task, batch=batch)
+    instructions, user_input = _build_request_content(
+        task=task,
+        batch=batch,
+        input_file_ids=input_file_ids,
+    )
     request_kwargs: dict[str, Any] = {
         "model": task.model.model_id,
         "instructions": instructions,
@@ -724,7 +789,8 @@ def _build_request_content(
     *,
     task: TaskConfig,
     batch: EligibleBatch,
-) -> tuple[str, str]:
+    input_file_ids: tuple[str, ...],
+) -> tuple[str, str | list[dict[str, Any]]]:
     payload = {
         "user_prompt": task.user_prompt,
         "note_type": batch.note_type,
@@ -733,10 +799,13 @@ def _build_request_content(
             for candidate in batch.candidates
         ],
     }
-    return (
-        task.system_prompt.strip(),
-        json.dumps(payload, ensure_ascii=False),
-    )
+    user_input = json.dumps(payload, ensure_ascii=False)
+    if not input_file_ids:
+        return task.system_prompt.strip(), user_input
+
+    content = [{"type": "input_file", "file_id": file_id} for file_id in input_file_ids]
+    content.append({"type": "input_text", "text": user_input})
+    return task.system_prompt.strip(), [{"role": "user", "content": content}]
 
 
 def _openai_error_result(

--- a/ankiops/llm/execution.py
+++ b/ankiops/llm/execution.py
@@ -644,13 +644,32 @@ async def _upload_input_files(
                 )
             file_id = uploaded.id
         except asyncio.CancelledError:
-            await _delete_uploaded_files(client=client, file_ids=tuple(file_ids))
+            await _delete_uploaded_files_after_cancellation(
+                client=client,
+                file_ids=tuple(file_ids),
+            )
             raise
         except Exception as error:
             await _delete_uploaded_files(client=client, file_ids=tuple(file_ids))
             raise RuntimeError(_format_file_upload_error(path, error)) from error
         file_ids.append(file_id)
     return tuple(file_ids)
+
+
+async def _delete_uploaded_files_after_cancellation(
+    *,
+    client: AsyncOpenAI,
+    file_ids: tuple[str, ...],
+) -> None:
+    cleanup_task = asyncio.create_task(
+        _delete_uploaded_files(client=client, file_ids=file_ids)
+    )
+    while not cleanup_task.done():
+        try:
+            await asyncio.shield(cleanup_task)
+        except asyncio.CancelledError:
+            continue
+    await cleanup_task
 
 
 async def _delete_uploaded_files(

--- a/ankiops/llm/execution.py
+++ b/ankiops/llm/execution.py
@@ -643,6 +643,9 @@ async def _upload_input_files(
                     purpose="user_data",
                 )
             file_id = uploaded.id
+        except asyncio.CancelledError:
+            await _delete_uploaded_files(client=client, file_ids=tuple(file_ids))
+            raise
         except Exception as error:
             await _delete_uploaded_files(client=client, file_ids=tuple(file_ids))
             raise RuntimeError(_format_file_upload_error(path, error)) from error

--- a/ankiops/llm/execution.py
+++ b/ankiops/llm/execution.py
@@ -285,12 +285,14 @@ class LlmTaskExecutor:
             timeout=60.0,
             max_retries=0,
         )
-        uploaded_file_ids: tuple[str, ...] = ()
+        uploaded_file_ids: list[str] = []
         try:
-            uploaded_file_ids = await _upload_input_files(
+            await _upload_input_files(
                 client=client,
                 paths=task.input_files,
+                file_ids=uploaded_file_ids,
             )
+            input_file_ids = tuple(uploaded_file_ids)
             batches = build_candidate_batches(
                 candidates,
                 max_notes_per_request=task.request.max_notes_per_request,
@@ -310,7 +312,7 @@ class LlmTaskExecutor:
                         task=task,
                         client=client,
                         batch=batch,
-                        input_file_ids=uploaded_file_ids,
+                        input_file_ids=input_file_ids,
                     )
                 )
                 in_flight[task_handle] = batch
@@ -353,11 +355,10 @@ class LlmTaskExecutor:
                     start(batches[next_index])
                     next_index += 1
         finally:
-            await _delete_uploaded_files(
+            await _finalize_openai_client(
                 client=client,
-                file_ids=uploaded_file_ids,
+                file_ids=tuple(uploaded_file_ids),
             )
-            await client.close()
 
     async def _process_batch(
         self,
@@ -633,8 +634,8 @@ async def _upload_input_files(
     *,
     client: AsyncOpenAI,
     paths: tuple[Path, ...],
-) -> tuple[str, ...]:
-    file_ids: list[str] = []
+    file_ids: list[str],
+) -> None:
     for path in paths:
         try:
             with path.open("rb") as handle:
@@ -643,33 +644,32 @@ async def _upload_input_files(
                     purpose="user_data",
                 )
             file_id = uploaded.id
-        except asyncio.CancelledError:
-            await _delete_uploaded_files_after_cancellation(
-                client=client,
-                file_ids=tuple(file_ids),
-            )
-            raise
         except Exception as error:
-            await _delete_uploaded_files(client=client, file_ids=tuple(file_ids))
             raise RuntimeError(_format_file_upload_error(path, error)) from error
         file_ids.append(file_id)
-    return tuple(file_ids)
 
 
-async def _delete_uploaded_files_after_cancellation(
+async def _finalize_openai_client(
     *,
     client: AsyncOpenAI,
     file_ids: tuple[str, ...],
 ) -> None:
-    cleanup_task = asyncio.create_task(
-        _delete_uploaded_files(client=client, file_ids=file_ids)
-    )
+    async def cleanup() -> None:
+        try:
+            await _delete_uploaded_files(client=client, file_ids=file_ids)
+        finally:
+            await client.close()
+
+    cleanup_task = asyncio.create_task(cleanup())
+    cancellation: asyncio.CancelledError | None = None
     while not cleanup_task.done():
         try:
             await asyncio.shield(cleanup_task)
-        except asyncio.CancelledError:
-            continue
+        except asyncio.CancelledError as error:
+            cancellation = error
     await cleanup_task
+    if cancellation is not None:
+        raise cancellation
 
 
 async def _delete_uploaded_files(

--- a/ankiops/llm/planning.py
+++ b/ankiops/llm/planning.py
@@ -92,6 +92,7 @@ class TaskPlanResult:
     serializer_scope: str
     system_prompt_path: str | None
     user_prompt_path: str | None
+    input_file_paths: tuple[str, ...]
     system_prompt: str
     user_prompt: str
     request_defaults: str
@@ -578,6 +579,7 @@ def _build_task_plan_result(
         user_prompt_path=(
             str(task.user_prompt_path) if task.user_prompt_path is not None else None
         ),
+        input_file_paths=tuple(str(path) for path in task.input_files),
         system_prompt=task.system_prompt,
         user_prompt=task.user_prompt,
         request_defaults=_format_request_defaults(task.request),

--- a/ankiops/llm/resources/README.md
+++ b/ankiops/llm/resources/README.md
@@ -62,7 +62,7 @@ Task files accept these top-level keys:
 - `fields`: Sets `default_access` and field rules for `editable`, `read_only`, or `hidden` access. Rules map note-type patterns to field-name patterns. Patterns use shell-style wildcards such as `*`.
 - `tags`: Sets tag access to `editable`, `read_only`, or `hidden`. Tags default to `hidden` when you omit this key.
 - `request`: Requires `max_notes_per_request`. It can also set `temperature` and `reasoning`. AnkiOps accepts `none`, `low`, `medium`, `high`, or `xhigh`, but each model supports a subset.
-- `input_files`: Optional relative file paths sent to every request for the task. Files are uploaded once per run and deleted afterward. Their combined size must not exceed 50 MB.
+- `input_files`: Optional relative file paths sent to every request for the task. Files are uploaded once per run and expire automatically after one hour. Their combined size must not exceed 50 MB.
 
 ## Running tasks
 

--- a/ankiops/llm/resources/README.md
+++ b/ankiops/llm/resources/README.md
@@ -22,7 +22,8 @@ LLM tasks read notes from your Markdown decks and write selected fields or tags 
 ```yaml
 # fix-grammar.yaml
 model: gpt-5.4-mini
-system_prompt: !file _system_prompt.md
+system_prompt:
+  file: _system_prompt.md
 user_prompt: |
   Correct grammar, spelling, and punctuation in editable fields.
   Preserve meaning, Markdown structure, cloze syntax, code fences, math, and URLs.
@@ -54,10 +55,27 @@ Further, field access can be set for specific note types or via `*` wildcards. F
 Task files accept these top-level keys:
 
 - `model`: An alias from `_models.yaml`
-- `system_prompt` and `user_prompt`: Inline text or `!file path.md` (file paths stay within this `llm` folder)
+- `system_prompt` and `user_prompt`: Inline text or a `file` mapping. File paths are relative to the task YAML and must stay within the collection.
+- `input_files`: Optional relative file paths sent to every request for the task. Files are uploaded once per run and deleted afterward. Their combined size must not exceed 50 MB.
 - `fields`: Sets `default_access` and field rules for `editable`, `read_only`, or `hidden` access. Rules map note-type patterns to field-name patterns. Patterns use shell-style wildcards such as `*`.
 - `tags`: Sets tag access to `editable`, `read_only`, or `hidden`. Tags default to `hidden` when you omit this key.
 - `request`: Requires `max_notes_per_request`. It can also set `temperature` and `reasoning`. AnkiOps accepts `none`, `low`, `medium`, `high`, or `xhigh`, but each model supports a subset.
+
+For example, a task can use a shared prompt file and attach reference material:
+
+```yaml
+system_prompt:
+  file: _system_prompt.md
+user_prompt: |
+  Review each note against the attached reference material.
+input_files:
+  - references/rubric.pdf
+  - references/terminology.md
+```
+
+Input files are passed directly to the Responses API. PDF processing uses the
+API's automatic detail setting. The dry-run cost estimate does not include
+tokens derived from input files.
 
 ## Running tasks
 

--- a/ankiops/llm/resources/README.md
+++ b/ankiops/llm/resources/README.md
@@ -42,6 +42,9 @@ tags: hidden
 request:
   max_notes_per_request: 3
   reasoning: low
+
+input_files:
+  - references/terminology.pdf
 ```
 
 Apart from the prompts, the most important part of a task is the `fields` section. It controls which fields the model can read and write. There are three access levels:
@@ -56,26 +59,10 @@ Task files accept these top-level keys:
 
 - `model`: An alias from `_models.yaml`
 - `system_prompt` and `user_prompt`: Inline text or a `file` mapping. File paths are relative to the task YAML and must stay within the collection.
-- `input_files`: Optional relative file paths sent to every request for the task. Files are uploaded once per run and deleted afterward. Their combined size must not exceed 50 MB.
 - `fields`: Sets `default_access` and field rules for `editable`, `read_only`, or `hidden` access. Rules map note-type patterns to field-name patterns. Patterns use shell-style wildcards such as `*`.
 - `tags`: Sets tag access to `editable`, `read_only`, or `hidden`. Tags default to `hidden` when you omit this key.
 - `request`: Requires `max_notes_per_request`. It can also set `temperature` and `reasoning`. AnkiOps accepts `none`, `low`, `medium`, `high`, or `xhigh`, but each model supports a subset.
-
-For example, a task can use a shared prompt file and attach reference material:
-
-```yaml
-system_prompt:
-  file: _system_prompt.md
-user_prompt: |
-  Review each note against the attached reference material.
-input_files:
-  - references/rubric.pdf
-  - references/terminology.md
-```
-
-Input files are passed directly to the Responses API. PDF processing uses the
-API's automatic detail setting. The dry-run cost estimate does not include
-tokens derived from input files.
+- `input_files`: Optional relative file paths sent to every request for the task. Files are uploaded once per run and deleted afterward. Their combined size must not exceed 50 MB.
 
 ## Running tasks
 

--- a/ankiops/llm/resources/fix-grammar.yaml
+++ b/ankiops/llm/resources/fix-grammar.yaml
@@ -1,5 +1,6 @@
 model: gpt-5.6-luna
-system_prompt: !file _system_prompt.md
+system_prompt:
+  file: _system_prompt.md
 user_prompt: |
   Correct grammar, spelling, and punctuation in editable fields.
   Preserve meaning, Markdown structure, cloze syntax, code fences, math, and URLs.

--- a/ankiops/llm/resources/fix-html.yaml
+++ b/ankiops/llm/resources/fix-html.yaml
@@ -1,5 +1,6 @@
 model: gpt-5.6-luna
-system_prompt: !file _system_prompt.md
+system_prompt:
+  file: _system_prompt.md
 user_prompt: |
   The following markdown text might contain artifacts from a HTML to Markdown conversion. 
   Please fix any artifacts while preserving the original meaning, structure, cloze syntax, code fences, math, and URLs. 

--- a/ankiops/llm/resources/review.yaml
+++ b/ankiops/llm/resources/review.yaml
@@ -1,5 +1,6 @@
 model: gpt-5.6-luna
-system_prompt: !file _system_prompt.md
+system_prompt:
+  file: _system_prompt.md
 user_prompt: |
   Review the following note. If the information is correct, comprehensive and up to date, return nothing. 
   If there are any issues with the content of the card, add a detailed explanation of your thoughts to the "AI Notes" field.

--- a/ankiops/llm/resources/tag.yaml
+++ b/ankiops/llm/resources/tag.yaml
@@ -1,5 +1,6 @@
 model: gpt-5.6-luna
-system_prompt: !file _system_prompt.md
+system_prompt:
+  file: _system_prompt.md
 user_prompt: |
   Add or update Anki tags based only on the readable note text.
   Preserve useful existing tags and existing tag namespace style.

--- a/ankiops/llm/resources/translate.yaml
+++ b/ankiops/llm/resources/translate.yaml
@@ -1,5 +1,6 @@
 model: gpt-5.6-luna
-system_prompt: !file _system_prompt.md
+system_prompt:
+  file: _system_prompt.md
 user_prompt: |
   Translate the following text from English to German.
   Preserve meaning, Markdown structure, cloze syntax, code fences, math, and URLs.

--- a/ankiops/llm/tasks.py
+++ b/ankiops/llm/tasks.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-from yaml.nodes import ScalarNode
 
 from ankiops.collection import LLM_DIR
 from ankiops.note_types import NoteType
@@ -27,10 +26,12 @@ _SUPPORTED_TASK_KEYS = (
     "model",
     "system_prompt",
     "user_prompt",
+    "input_files",
     "request",
     "fields",
     "tags",
 )
+_MAX_INPUT_FILE_BYTES = 50 * 1024 * 1024
 _SUPPORTED_REQUEST_KEYS = (
     "max_notes_per_request",
     "temperature",
@@ -103,6 +104,7 @@ class TaskConfig:
     user_prompt: str
     system_prompt_path: Path | None = None
     user_prompt_path: Path | None = None
+    input_files: tuple[Path, ...] = ()
     decks: DeckScope = field(default_factory=DeckScope)
     default_field_access: FieldAccess = FieldAccess.EDITABLE
     field_rules: list[FieldAccessRule] = field(default_factory=list)
@@ -133,43 +135,6 @@ class TaskConfig:
 class TaskCatalog:
     tasks_by_name: dict[str, TaskConfig]
     errors: dict[str, str]
-
-
-class _FileSource:
-    def __init__(self, text: str, path: Path) -> None:
-        self.text = text
-        self.path = path
-
-
-class _TaskConfigLoader(yaml.SafeLoader):
-    task_path: Path
-    llm_dir: Path
-
-
-def _construct_file_source(
-    loader: _TaskConfigLoader,
-    node: Any,
-) -> _FileSource:
-    if not isinstance(node, ScalarNode):
-        raise LlmConfigError(
-            f"{loader.task_path}: !file tag must be used with a scalar path"
-        )
-
-    raw_reference = loader.construct_scalar(node).strip()
-    if not raw_reference:
-        raise LlmConfigError(
-            f"{loader.task_path}: !file path must be a non-empty string"
-        )
-
-    resolved_path = _resolve_relative_file(
-        loader.task_path,
-        raw_reference,
-        llm_dir=loader.llm_dir,
-    )
-    return _FileSource(text=_read_text_file(resolved_path), path=resolved_path)
-
-
-_TaskConfigLoader.add_constructor("!file", _construct_file_source)
 
 
 def is_task_config_file(path: Path) -> bool:
@@ -210,7 +175,7 @@ def load_llm_task_catalog(
             task = _parse_task(
                 path,
                 note_type_configs=note_type_configs,
-                llm_dir=llm_dir,
+                collection_root=collection_root,
                 model_registry=model_registry,
             )
             if task.name in tasks_by_name:
@@ -226,10 +191,10 @@ def _parse_task(
     path: Path,
     *,
     note_type_configs: list[NoteType],
-    llm_dir: Path,
+    collection_root: Path,
     model_registry: ModelRegistry,
 ) -> TaskConfig:
-    mapping = _read_yaml_mapping(path, llm_dir=llm_dir)
+    mapping = _read_yaml_mapping(path)
     _validate_task_keys(mapping, path)
 
     model_name = _require_str(mapping, "model", path)
@@ -243,11 +208,18 @@ def _parse_task(
         mapping,
         key="system_prompt",
         path=path,
+        collection_root=collection_root,
     )
     user_prompt, user_prompt_path = _parse_text_source(
         mapping,
         key="user_prompt",
         path=path,
+        collection_root=collection_root,
+    )
+    input_files = _parse_input_files(
+        mapping.get("input_files"),
+        task_path=path,
+        collection_root=collection_root,
     )
     default_field_access, field_rules = _parse_field_rules(
         mapping.get("fields"),
@@ -264,6 +236,7 @@ def _parse_task(
         user_prompt=user_prompt,
         system_prompt_path=system_prompt_path,
         user_prompt_path=user_prompt_path,
+        input_files=input_files,
         default_field_access=default_field_access,
         field_rules=field_rules,
         tag_access=tag_access,
@@ -275,17 +248,12 @@ def _iter_yaml_files(directory: Path) -> list[Path]:
     return sorted([*directory.glob("*.yaml"), *directory.glob("*.yml")])
 
 
-def _read_yaml_mapping(path: Path, *, llm_dir: Path) -> dict[str, Any]:
+def _read_yaml_mapping(path: Path) -> dict[str, Any]:
     with path.open("r", encoding="utf-8") as handle:
-        loader = _TaskConfigLoader(handle)
-        loader.task_path = path
-        loader.llm_dir = llm_dir
         try:
-            raw = loader.get_single_data() or {}
+            raw = yaml.safe_load(handle) or {}
         except yaml.YAMLError as error:
             raise LlmConfigError(f"{path}: invalid YAML ({error})") from error
-        finally:
-            loader.dispose()
     if not isinstance(raw, dict):
         raise LlmConfigError(f"{path}: config must be a YAML mapping")
     return raw
@@ -313,37 +281,102 @@ def _parse_text_source(
     *,
     key: str,
     path: Path,
+    collection_root: Path,
 ) -> tuple[str, Path | None]:
     raw_value = mapping.get(key)
-    if isinstance(raw_value, _FileSource):
-        return raw_value.text, raw_value.path
     if isinstance(raw_value, str) and raw_value.strip():
         return raw_value.strip(), None
-    raise LlmConfigError(f"{path}: '{key}' must be a non-empty string")
+    if not isinstance(raw_value, dict):
+        raise LlmConfigError(
+            f"{path}: '{key}' must be inline text or a mapping with 'file'"
+        )
+    unknown = sorted(set(raw_value) - {"file"})
+    if unknown:
+        raise LlmConfigError(f"{path}: unknown '{key}' key(s): {', '.join(unknown)}")
+    if set(raw_value) != {"file"}:
+        raise LlmConfigError(f"{path}: '{key}.file' is required")
+    resolved_path = _resolve_file_reference(
+        task_path=path,
+        raw_reference=raw_value["file"],
+        collection_root=collection_root,
+        key=f"{key}.file",
+    )
+    return _read_text_file(resolved_path), resolved_path
+
+
+def _parse_input_files(
+    value: Any,
+    *,
+    task_path: Path,
+    collection_root: Path,
+) -> tuple[Path, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise LlmConfigError(f"{task_path}: 'input_files' must be a list")
+
+    resolved: list[Path] = []
+    seen: set[Path] = set()
+    total_bytes = 0
+    for index, raw_reference in enumerate(value):
+        path = _resolve_file_reference(
+            task_path=task_path,
+            raw_reference=raw_reference,
+            collection_root=collection_root,
+            key=f"input_files[{index}]",
+        )
+        if path in seen:
+            raise LlmConfigError(
+                f"{task_path}: 'input_files' contains duplicate path '{raw_reference}'"
+            )
+        size = path.stat().st_size
+        if size >= _MAX_INPUT_FILE_BYTES:
+            raise LlmConfigError(
+                f"{task_path}: 'input_files[{index}]' must be under 50 MB"
+            )
+        total_bytes += size
+        if total_bytes > _MAX_INPUT_FILE_BYTES:
+            raise LlmConfigError(
+                f"{task_path}: combined 'input_files' size must not exceed 50 MB"
+            )
+        seen.add(path)
+        resolved.append(path)
+    return tuple(resolved)
 
 
 def _read_text_file(path: Path) -> str:
-    if not path.exists() or not path.is_file():
-        raise LlmConfigError(f"{path}: file not found")
-    value = path.read_text(encoding="utf-8")
+    try:
+        value = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as error:
+        raise LlmConfigError(f"{path}: prompt file must be UTF-8 text") from error
     if not value.strip():
         raise LlmConfigError(f"{path}: file must be non-empty")
     return value.strip()
 
 
-def _resolve_relative_file(
-    task_path: Path,
-    raw_reference: str,
+def _resolve_file_reference(
     *,
-    llm_dir: Path,
+    task_path: Path,
+    raw_reference: Any,
+    collection_root: Path,
+    key: str,
 ) -> Path:
-    candidate = (task_path.parent / raw_reference).resolve()
+    if not isinstance(raw_reference, str) or not raw_reference.strip():
+        raise LlmConfigError(f"{task_path}: '{key}' must be a non-empty relative path")
+    reference = Path(raw_reference.strip())
+    if reference.is_absolute():
+        raise LlmConfigError(f"{task_path}: '{key}' must be a relative path")
+    candidate = (task_path.parent / reference).resolve()
     try:
-        candidate.relative_to(llm_dir.resolve())
+        candidate.relative_to(collection_root.resolve())
     except ValueError as error:
         raise LlmConfigError(
-            f"{task_path}: !file path must stay within {llm_dir}"
+            f"{task_path}: '{key}' must stay within {collection_root}"
         ) from error
+    if not candidate.exists() or not candidate.is_file():
+        raise LlmConfigError(f"{task_path}: '{key}' file not found: {candidate}")
+    if candidate.stat().st_size == 0:
+        raise LlmConfigError(f"{task_path}: '{key}' file must be non-empty")
     return candidate
 
 

--- a/docs/cli-output.md
+++ b/docs/cli-output.md
@@ -587,8 +587,9 @@ row confirms that AnkiOps did not call the API or edit files.
   Scope      all decks
   Notes      128 checked · 116 eligible · 12 skipped
   Requests   39 estimated · up to 3 notes each · low reasoning
-  Cost       $0.18 estimated
+  Cost       $0.18 estimated · excludes input-file tokens
   Prompts    llm/fix-grammar.yaml · llm/_system_prompt.md
+  Inputs     llm/references/rubric.pdf
   Dry run    API not called · files unchanged
 
   Field access
@@ -602,9 +603,10 @@ row confirms that AnkiOps did not call the API or edit files.
     ankiops llm fix-grammar --run
 ```
 
-Keep prompt paths clickable. Do not print the full prompt in default output;
-the task and prompt files provide the review surface in VS Code. Preserve model
-and deck overrides in the run command under `Next`.
+Keep prompt and input-file paths clickable. Do not print the full prompt in
+default output; the task, prompt, and input files provide the review surface in
+VS Code. State that cost estimates exclude tokens derived from input files.
+Preserve model and deck overrides in the run command under `Next`.
 
 If the plan finds no eligible notes, use `No notes eligible for LLM task`, show
 the skipped count and reason, and omit the run command.

--- a/tests/unit/llm/test_execution.py
+++ b/tests/unit/llm/test_execution.py
@@ -14,9 +14,28 @@ from ankiops.sync.state import SyncState
 from tests.support.deck_files import DeckFileHarness
 
 
+class _FakeFiles:
+    def __init__(self) -> None:
+        self.created: list[tuple[str, bytes]] = []
+        self.deleted: list[str] = []
+
+    async def create(self, *, file, purpose):
+        assert purpose == "user_data"
+        content = file.read()
+        file_id = f"file-{len(self.created) + 1}"
+        self.created.append((file.name, content))
+        return SimpleNamespace(id=file_id)
+
+    async def delete(self, file_id):
+        self.deleted.append(file_id)
+
+
 class _FakeAsyncOpenAI:
+    instances: list[_FakeAsyncOpenAI] = []
+
     def __init__(self, **_kwargs) -> None:
-        pass
+        self.files = _FakeFiles()
+        self.instances.append(self)
 
     async def close(self) -> None:
         pass
@@ -187,6 +206,227 @@ def test_executor_persists_successful_field_updates(
     assert "<!-- tags: keep-me -->" in content
     assert "E: Book" in content
     assert "Q: Already good" in content
+
+
+def test_executor_uploads_input_file_once_for_multiple_batches_and_deletes_it(
+    llm_collection,
+    write_file,
+    monkeypatch,
+):
+    _init_collection(llm_collection)
+    write_file(
+        llm_collection / "Deck.md",
+        """
+        <!-- note_key: nk-1 -->
+        Q: First
+        A: Answer
+
+        ---
+
+        <!-- note_key: nk-2 -->
+        Q: Second
+        A: Answer
+        """,
+    )
+    write_file(llm_collection / "llm/references/reference.txt", "Shared reference")
+    write_file(
+        llm_collection / "llm/review.yaml",
+        """
+        model: test
+        system_prompt: system
+        user_prompt: user
+        input_files:
+          - references/reference.txt
+        request:
+          max_notes_per_request: 1
+        fields:
+          default_access: hidden
+          editable:
+            "AnkiOpsQA": ["Question"]
+        """,
+    )
+    seen_file_ids: list[tuple[str, ...]] = []
+
+    async def fake_call_openai(*, input_file_ids, **_kwargs):
+        seen_file_ids.append(input_file_ids)
+        return _success(_parsed_response(), input_tokens=5, output_tokens=1)
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr("ankiops.llm.execution.AsyncOpenAI", _FakeAsyncOpenAI)
+    monkeypatch.setattr("ankiops.llm.execution._call_openai", fake_call_openai)
+
+    result = run_task(
+        collection_root=llm_collection,
+        task_name="review",
+        no_auto_commit=True,
+    )
+
+    client = _FakeAsyncOpenAI.instances[-1]
+    assert not result.failed
+    assert result.summary.requests == 2
+    assert seen_file_ids == [("file-1",), ("file-1",)]
+    assert client.files.created == [
+        (
+            str(llm_collection / "llm/references/reference.txt"),
+            b"Shared reference\n",
+        )
+    ]
+    assert client.files.deleted == ["file-1"]
+
+
+def test_executor_deletes_partial_uploads_after_upload_failure(
+    llm_collection,
+    write_file,
+    monkeypatch,
+):
+    class _FailingFiles(_FakeFiles):
+        async def create(self, *, file, purpose):
+            if self.created:
+                raise RuntimeError("upload failed")
+            return await super().create(file=file, purpose=purpose)
+
+    class _FailingAsyncOpenAI(_FakeAsyncOpenAI):
+        def __init__(self, **_kwargs) -> None:
+            self.files = _FailingFiles()
+            self.instances.append(self)
+
+    _init_collection(llm_collection)
+    write_file(
+        llm_collection / "Deck.md",
+        """
+        <!-- note_key: nk-1 -->
+        Q: Question
+        A: Answer
+        """,
+    )
+    write_file(llm_collection / "llm/references/first.txt", "First")
+    write_file(llm_collection / "llm/references/second.txt", "Second")
+    write_file(
+        llm_collection / "llm/review.yaml",
+        """
+        model: test
+        system_prompt: system
+        user_prompt: user
+        input_files:
+          - references/first.txt
+          - references/second.txt
+        request:
+          max_notes_per_request: 1
+        fields:
+          default_access: hidden
+          editable:
+            "AnkiOpsQA": ["Question"]
+        """,
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr("ankiops.llm.execution.AsyncOpenAI", _FailingAsyncOpenAI)
+
+    result = run_task(
+        collection_root=llm_collection,
+        task_name="review",
+        no_auto_commit=True,
+    )
+
+    client = _FailingAsyncOpenAI.instances[-1]
+    assert result.failed
+    assert result.summary.canceled == 1
+    assert client.files.deleted == ["file-1"]
+
+
+def test_executor_deletes_uploaded_files_after_fatal_request_error(
+    llm_collection,
+    write_file,
+    monkeypatch,
+):
+    _init_collection(llm_collection)
+    write_file(
+        llm_collection / "Deck.md",
+        """
+        <!-- note_key: nk-1 -->
+        Q: Question
+        A: Answer
+        """,
+    )
+    write_file(llm_collection / "llm/references/reference.txt", "Reference")
+    write_file(
+        llm_collection / "llm/review.yaml",
+        """
+        model: test
+        system_prompt: system
+        user_prompt: user
+        input_files:
+          - references/reference.txt
+        request:
+          max_notes_per_request: 1
+        fields:
+          default_access: hidden
+          editable:
+            "AnkiOpsQA": ["Question"]
+        """,
+    )
+
+    async def fake_call_openai(**_kwargs):
+        return _fatal_error()
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr("ankiops.llm.execution.AsyncOpenAI", _FakeAsyncOpenAI)
+    monkeypatch.setattr("ankiops.llm.execution._call_openai", fake_call_openai)
+
+    result = run_task(
+        collection_root=llm_collection,
+        task_name="review",
+        no_auto_commit=True,
+    )
+
+    client = _FakeAsyncOpenAI.instances[-1]
+    assert result.failed
+    assert client.files.deleted == ["file-1"]
+
+
+def test_executor_does_not_upload_files_without_eligible_notes(
+    llm_collection,
+    write_file,
+    monkeypatch,
+):
+    _init_collection(llm_collection)
+    write_file(
+        llm_collection / "Deck.md",
+        """
+        <!-- note_key: nk-1 -->
+        Q: Question
+        A: Answer
+        """,
+    )
+    write_file(llm_collection / "llm/references/reference.txt", "Reference")
+    write_file(
+        llm_collection / "llm/review.yaml",
+        """
+        model: test
+        system_prompt: system
+        user_prompt: user
+        input_files:
+          - references/reference.txt
+        request:
+          max_notes_per_request: 1
+        fields:
+          default_access: hidden
+        """,
+    )
+
+    def fail_if_created(**_kwargs):
+        raise AssertionError("OpenAI client should not be created")
+
+    monkeypatch.setattr("ankiops.llm.execution.AsyncOpenAI", fail_if_created)
+
+    result = run_task(
+        collection_root=llm_collection,
+        task_name="review",
+        no_auto_commit=True,
+    )
+
+    assert not result.failed
+    assert result.summary.skipped == 1
+    assert result.summary.requests == 0
 
 
 def test_executor_snapshots_only_queued_local_deck_paths(

--- a/tests/unit/llm/test_execution.py
+++ b/tests/unit/llm/test_execution.py
@@ -17,17 +17,14 @@ from tests.support.deck_files import DeckFileHarness
 class _FakeFiles:
     def __init__(self) -> None:
         self.created: list[tuple[str, bytes]] = []
-        self.deleted: list[str] = []
 
-    async def create(self, *, file, purpose):
+    async def create(self, *, file, purpose, expires_after):
         assert purpose == "user_data"
+        assert expires_after == {"anchor": "created_at", "seconds": 3600}
         content = file.read()
         file_id = f"file-{len(self.created) + 1}"
         self.created.append((file.name, content))
         return SimpleNamespace(id=file_id)
-
-    async def delete(self, file_id):
-        self.deleted.append(file_id)
 
 
 class _FakeAsyncOpenAI:
@@ -208,7 +205,7 @@ def test_executor_persists_successful_field_updates(
     assert "Q: Already good" in content
 
 
-def test_executor_uploads_input_file_once_for_multiple_batches_and_deletes_it(
+def test_executor_uploads_expiring_input_file_once_for_multiple_batches(
     llm_collection,
     write_file,
     monkeypatch,
@@ -271,19 +268,22 @@ def test_executor_uploads_input_file_once_for_multiple_batches_and_deletes_it(
             b"Shared reference\n",
         )
     ]
-    assert client.files.deleted == ["file-1"]
 
 
-def test_executor_deletes_partial_uploads_after_upload_failure(
+def test_executor_partial_uploads_expire_after_upload_failure(
     llm_collection,
     write_file,
     monkeypatch,
 ):
     class _FailingFiles(_FakeFiles):
-        async def create(self, *, file, purpose):
+        async def create(self, *, file, purpose, expires_after):
             if self.created:
                 raise RuntimeError("upload failed")
-            return await super().create(file=file, purpose=purpose)
+            return await super().create(
+                file=file,
+                purpose=purpose,
+                expires_after=expires_after,
+            )
 
     class _FailingAsyncOpenAI(_FakeAsyncOpenAI):
         def __init__(self, **_kwargs) -> None:
@@ -330,10 +330,10 @@ def test_executor_deletes_partial_uploads_after_upload_failure(
     client = _FailingAsyncOpenAI.instances[-1]
     assert result.failed
     assert result.summary.canceled == 1
-    assert client.files.deleted == ["file-1"]
+    assert len(client.files.created) == 1
 
 
-def test_executor_deletes_uploaded_files_after_fatal_request_error(
+def test_executor_uses_expiring_files_before_fatal_request_error(
     llm_collection,
     write_file,
     monkeypatch,
@@ -380,7 +380,7 @@ def test_executor_deletes_uploaded_files_after_fatal_request_error(
 
     client = _FakeAsyncOpenAI.instances[-1]
     assert result.failed
-    assert client.files.deleted == ["file-1"]
+    assert len(client.files.created) == 1
 
 
 def test_executor_does_not_upload_files_without_eligible_notes(

--- a/tests/unit/llm/test_execution_responses.py
+++ b/tests/unit/llm/test_execution_responses.py
@@ -12,6 +12,7 @@ from ankiops.llm.execution import (
     _apply_batch_parsed_response,
     _build_request_content,
     _delete_uploaded_files,
+    _upload_input_files,
     build_response_model,
 )
 from ankiops.llm.jobs import LlmItemStatus
@@ -168,6 +169,39 @@ def test_delete_uploaded_files_logs_cleanup_failures(caplog):
     )
 
     assert "Could not delete uploaded OpenAI file file-a" in caplog.text
+
+
+def test_upload_input_files_cleans_up_completed_uploads_on_cancellation(tmp_path):
+    class _CancelingFiles:
+        def __init__(self):
+            self.upload_count = 0
+            self.deleted = []
+
+        async def create(self, *, file, purpose):
+            self.upload_count += 1
+            if self.upload_count == 2:
+                raise asyncio.CancelledError
+            return SimpleNamespace(id="file-first")
+
+        async def delete(self, file_id):
+            self.deleted.append(file_id)
+
+    first = tmp_path / "first.txt"
+    second = tmp_path / "second.txt"
+    first.write_text("first")
+    second.write_text("second")
+    files = _CancelingFiles()
+    client = SimpleNamespace(files=files)
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(
+            _upload_input_files(
+                client=client,
+                paths=(first, second),
+            )
+        )
+
+    assert files.deleted == ["file-first"]
 
 
 def test_response_model_accepts_only_known_note_keys_and_editable_fields():

--- a/tests/unit/llm/test_execution_responses.py
+++ b/tests/unit/llm/test_execution_responses.py
@@ -12,6 +12,7 @@ from ankiops.llm.execution import (
     _apply_batch_parsed_response,
     _build_request_content,
     _delete_uploaded_files,
+    _finalize_openai_client,
     _upload_input_files,
     build_response_model,
 )
@@ -171,11 +172,10 @@ def test_delete_uploaded_files_logs_cleanup_failures(caplog):
     assert "Could not delete uploaded OpenAI file file-a" in caplog.text
 
 
-def test_upload_input_files_cleans_up_completed_uploads_on_cancellation(tmp_path):
+def test_upload_input_files_retains_completed_ids_on_cancellation(tmp_path):
     class _CancelingFiles:
         def __init__(self):
             self.upload_count = 0
-            self.deleted = []
 
         async def create(self, *, file, purpose):
             self.upload_count += 1
@@ -183,57 +183,63 @@ def test_upload_input_files_cleans_up_completed_uploads_on_cancellation(tmp_path
                 raise asyncio.CancelledError
             return SimpleNamespace(id="file-first")
 
-        async def delete(self, file_id):
-            self.deleted.append(file_id)
-
     first = tmp_path / "first.txt"
     second = tmp_path / "second.txt"
     first.write_text("first")
     second.write_text("second")
     files = _CancelingFiles()
     client = SimpleNamespace(files=files)
+    file_ids = []
 
     with pytest.raises(asyncio.CancelledError):
         asyncio.run(
             _upload_input_files(
                 client=client,
                 paths=(first, second),
+                file_ids=file_ids,
             )
         )
 
-    assert files.deleted == ["file-first"]
+    assert file_ids == ["file-first"]
 
 
-def test_upload_cleanup_survives_repeated_cancellation(tmp_path):
-    class _RepeatedlyCancelingFiles:
+def test_final_cleanup_survives_repeated_cancellation():
+    class _CancelingFiles:
         def __init__(self):
-            self.upload_count = 0
-            self.upload_task = None
+            self.owner = None
             self.deleted = []
-
-        async def create(self, *, file, purpose):
-            self.upload_task = asyncio.current_task()
-            self.upload_count += 1
-            if self.upload_count == 4:
-                raise asyncio.CancelledError
-            return SimpleNamespace(id=f"file-{self.upload_count}")
 
         async def delete(self, file_id):
             if file_id == "file-1":
-                self.upload_task.cancel()
+                self.owner.cancel()
                 await asyncio.sleep(0)
             self.deleted.append(file_id)
 
-    paths = tuple(tmp_path / f"input-{index}.txt" for index in range(4))
-    for path in paths:
-        path.write_text(path.name)
-    files = _RepeatedlyCancelingFiles()
-    client = SimpleNamespace(files=files)
+    class _Client:
+        def __init__(self):
+            self.files = _CancelingFiles()
+            self.closed = False
+
+        async def close(self):
+            self.closed = True
+
+    client = _Client()
+
+    async def finalize():
+        client.files.owner = asyncio.current_task()
+        try:
+            raise asyncio.CancelledError
+        finally:
+            await _finalize_openai_client(
+                client=client,
+                file_ids=("file-1", "file-2", "file-3"),
+            )
 
     with pytest.raises(asyncio.CancelledError):
-        asyncio.run(_upload_input_files(client=client, paths=paths))
+        asyncio.run(finalize())
 
-    assert files.deleted == ["file-1", "file-2", "file-3"]
+    assert client.files.deleted == ["file-1", "file-2", "file-3"]
+    assert client.closed
 
 
 def test_response_model_accepts_only_known_note_keys_and_editable_fields():

--- a/tests/unit/llm/test_execution_responses.py
+++ b/tests/unit/llm/test_execution_responses.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -11,9 +10,6 @@ from pydantic import ValidationError
 from ankiops.llm.execution import (
     _apply_batch_parsed_response,
     _build_request_content,
-    _delete_uploaded_files,
-    _finalize_openai_client,
-    _upload_input_files,
     build_response_model,
 )
 from ankiops.llm.jobs import LlmItemStatus
@@ -153,93 +149,6 @@ def test_build_request_content_places_files_before_text(llm_qa_config):
             ],
         }
     ]
-
-
-def test_delete_uploaded_files_logs_cleanup_failures(caplog):
-    class _FailingFiles:
-        async def delete(self, _file_id):
-            raise RuntimeError("delete failed")
-
-    client = SimpleNamespace(files=_FailingFiles())
-
-    asyncio.run(
-        _delete_uploaded_files(
-            client=client,
-            file_ids=("file-a",),
-        )
-    )
-
-    assert "Could not delete uploaded OpenAI file file-a" in caplog.text
-
-
-def test_upload_input_files_retains_completed_ids_on_cancellation(tmp_path):
-    class _CancelingFiles:
-        def __init__(self):
-            self.upload_count = 0
-
-        async def create(self, *, file, purpose):
-            self.upload_count += 1
-            if self.upload_count == 2:
-                raise asyncio.CancelledError
-            return SimpleNamespace(id="file-first")
-
-    first = tmp_path / "first.txt"
-    second = tmp_path / "second.txt"
-    first.write_text("first")
-    second.write_text("second")
-    files = _CancelingFiles()
-    client = SimpleNamespace(files=files)
-    file_ids = []
-
-    with pytest.raises(asyncio.CancelledError):
-        asyncio.run(
-            _upload_input_files(
-                client=client,
-                paths=(first, second),
-                file_ids=file_ids,
-            )
-        )
-
-    assert file_ids == ["file-first"]
-
-
-def test_final_cleanup_survives_repeated_cancellation():
-    class _CancelingFiles:
-        def __init__(self):
-            self.owner = None
-            self.deleted = []
-
-        async def delete(self, file_id):
-            if file_id == "file-1":
-                self.owner.cancel()
-                await asyncio.sleep(0)
-            self.deleted.append(file_id)
-
-    class _Client:
-        def __init__(self):
-            self.files = _CancelingFiles()
-            self.closed = False
-
-        async def close(self):
-            self.closed = True
-
-    client = _Client()
-
-    async def finalize():
-        client.files.owner = asyncio.current_task()
-        try:
-            raise asyncio.CancelledError
-        finally:
-            await _finalize_openai_client(
-                client=client,
-                file_ids=("file-1", "file-2", "file-3"),
-            )
-
-    with pytest.raises(asyncio.CancelledError):
-        asyncio.run(finalize())
-
-    assert client.files.deleted == ["file-1", "file-2", "file-3"]
-    assert client.closed
 
 
 def test_response_model_accepts_only_known_note_keys_and_editable_fields():

--- a/tests/unit/llm/test_execution_responses.py
+++ b/tests/unit/llm/test_execution_responses.py
@@ -2,14 +2,22 @@
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 
 import pytest
 from pydantic import ValidationError
 
-from ankiops.llm.execution import _apply_batch_parsed_response, build_response_model
+from ankiops.llm.execution import (
+    _apply_batch_parsed_response,
+    _build_request_content,
+    _delete_uploaded_files,
+    build_response_model,
+)
 from ankiops.llm.jobs import LlmItemStatus
+from ankiops.llm.models import ModelSpec
 from ankiops.llm.planning import EligibleBatch, EligibleCandidate, NotePayload
+from ankiops.llm.tasks import TaskConfig
 
 
 def _parsed_response(*updates, tag_updates=()):
@@ -89,6 +97,77 @@ def _batch(candidate: EligibleCandidate) -> EligibleBatch:
         note_type_config=candidate.note_type_config,
         candidates=(candidate,),
     )
+
+
+def _task() -> TaskConfig:
+    return TaskConfig(
+        name="test",
+        model=ModelSpec(
+            model="test",
+            model_id="gpt-test",
+            base_url="https://api.openai.com/v1",
+            api_key="$OPENAI_API_KEY",
+        ),
+        system_prompt="system",
+        user_prompt="user",
+    )
+
+
+def test_build_request_content_preserves_text_input_without_files(llm_qa_config):
+    instructions, user_input = _build_request_content(
+        task=_task(),
+        batch=_batch(_candidate(llm_qa_config)),
+        input_file_ids=(),
+    )
+
+    assert instructions == "system"
+    assert isinstance(user_input, str)
+    assert '"user_prompt": "user"' in user_input
+
+
+def test_build_request_content_places_files_before_text(llm_qa_config):
+    instructions, user_input = _build_request_content(
+        task=_task(),
+        batch=_batch(_candidate(llm_qa_config)),
+        input_file_ids=("file-a", "file-b"),
+    )
+
+    assert instructions == "system"
+    assert user_input == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_file", "file_id": "file-a"},
+                {"type": "input_file", "file_id": "file-b"},
+                {
+                    "type": "input_text",
+                    "text": (
+                        '{"user_prompt": "user", "note_type": "AnkiOpsQA", '
+                        '"notes": [{"note_key": "nk-1", "editable_fields": '
+                        '{"Question": "Broken"}, "read_only_fields": '
+                        '{"Extra": "Book"}}]}'
+                    ),
+                },
+            ],
+        }
+    ]
+
+
+def test_delete_uploaded_files_logs_cleanup_failures(caplog):
+    class _FailingFiles:
+        async def delete(self, _file_id):
+            raise RuntimeError("delete failed")
+
+    client = SimpleNamespace(files=_FailingFiles())
+
+    asyncio.run(
+        _delete_uploaded_files(
+            client=client,
+            file_ids=("file-a",),
+        )
+    )
+
+    assert "Could not delete uploaded OpenAI file file-a" in caplog.text
 
 
 def test_response_model_accepts_only_known_note_keys_and_editable_fields():

--- a/tests/unit/llm/test_execution_responses.py
+++ b/tests/unit/llm/test_execution_responses.py
@@ -204,6 +204,38 @@ def test_upload_input_files_cleans_up_completed_uploads_on_cancellation(tmp_path
     assert files.deleted == ["file-first"]
 
 
+def test_upload_cleanup_survives_repeated_cancellation(tmp_path):
+    class _RepeatedlyCancelingFiles:
+        def __init__(self):
+            self.upload_count = 0
+            self.upload_task = None
+            self.deleted = []
+
+        async def create(self, *, file, purpose):
+            self.upload_task = asyncio.current_task()
+            self.upload_count += 1
+            if self.upload_count == 4:
+                raise asyncio.CancelledError
+            return SimpleNamespace(id=f"file-{self.upload_count}")
+
+        async def delete(self, file_id):
+            if file_id == "file-1":
+                self.upload_task.cancel()
+                await asyncio.sleep(0)
+            self.deleted.append(file_id)
+
+    paths = tuple(tmp_path / f"input-{index}.txt" for index in range(4))
+    for path in paths:
+        path.write_text(path.name)
+    files = _RepeatedlyCancelingFiles()
+    client = SimpleNamespace(files=files)
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(_upload_input_files(client=client, paths=paths))
+
+    assert files.deleted == ["file-1", "file-2", "file-3"]
+
+
 def test_response_model_accepts_only_known_note_keys_and_editable_fields():
     response_model = build_response_model(
         note_type="AnkiOpsQA",

--- a/tests/unit/llm/test_planning.py
+++ b/tests/unit/llm/test_planning.py
@@ -58,6 +58,7 @@ def test_plan_task_summarizes_scope_surface_and_does_not_persist(
         AI: private
         """,
     )
+    write_file(llm_collection / "llm/references/reference.txt", "Reference material")
     write_file(
         llm_collection / "llm/grammar.yaml",
         """
@@ -66,6 +67,8 @@ def test_plan_task_summarizes_scope_surface_and_does_not_persist(
           You are a strict editor.
         user_prompt: |
           Fix grammar.
+        input_files:
+          - references/reference.txt
         request:
           max_notes_per_request: 4
         fields:
@@ -85,6 +88,9 @@ def test_plan_task_summarizes_scope_surface_and_does_not_persist(
     assert plan.summary.notes_seen == 3
     assert plan.summary.eligible == 3
     assert plan.requests_estimate == 2
+    assert plan.input_file_paths == (
+        str((llm_collection / "llm/references/reference.txt").resolve()),
+    )
     assert plan.input_tokens_estimate > 0
     expected_cost = plan.model.estimate_cost(
         input_tokens=plan.input_tokens_estimate,

--- a/tests/unit/llm/test_tasks.py
+++ b/tests/unit/llm/test_tasks.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import pytest
 
+from ankiops.llm import tasks as tasks_module
 from ankiops.llm.tasks import FieldAccess, TaskRequestOptions, load_llm_task_catalog
 
 
-def test_load_llm_task_catalog_loads_files_fields_and_request(
+def test_load_llm_task_catalog_loads_prompt_and_input_files_fields_and_request(
     llm_collection,
     write_file,
     llm_qa_config,
@@ -15,12 +16,17 @@ def test_load_llm_task_catalog_loads_files_fields_and_request(
 ):
     write_file(llm_collection / "llm/prompts/system.md", "System rules")
     write_file(llm_collection / "llm/prompts/user.md", "Fix grammar")
+    write_file(llm_collection / "references/rubric.md", "Reference rubric")
     write_file(
         llm_collection / "llm/grammar.yaml",
         """
         model: test
-        system_prompt: !file prompts/system.md
-        user_prompt: !file prompts/user.md
+        system_prompt:
+          file: prompts/system.md
+        user_prompt:
+          file: prompts/user.md
+        input_files:
+          - ../references/rubric.md
         request:
           max_notes_per_request: 3
           temperature: 0.25
@@ -49,6 +55,7 @@ def test_load_llm_task_catalog_loads_files_fields_and_request(
         task.system_prompt_path == (llm_collection / "llm/prompts/system.md").resolve()
     )
     assert task.user_prompt_path == (llm_collection / "llm/prompts/user.md").resolve()
+    assert task.input_files == ((llm_collection / "references/rubric.md").resolve(),)
     assert task.request == TaskRequestOptions(
         max_notes_per_request=3,
         temperature=0.25,
@@ -130,10 +137,11 @@ def test_load_llm_task_catalog_defaults_tags_hidden(
         (
             """
             model: test
-            system_prompt: !file ../outside.md
+            system_prompt: system
             user_prompt: user
+            input_files: reference.md
             """,
-            "!file path must stay within",
+            "'input_files' must be a list",
         ),
         (
             """
@@ -166,7 +174,6 @@ def test_load_llm_task_catalog_reports_invalid_task_config(
     task_yaml,
     expected_error,
 ):
-    write_file(llm_collection / "outside.md", "outside")
     write_file(llm_collection / "llm/grammar.yaml", task_yaml)
 
     catalog = load_llm_task_catalog(
@@ -200,5 +207,256 @@ def test_load_llm_task_catalog_requires_max_notes_per_request(
     assert not catalog.tasks_by_name
     assert (
         "request.max_notes_per_request' is required"
+        in catalog.errors[str(llm_collection / "llm/grammar.yaml")]
+    )
+
+
+def test_load_llm_task_catalog_rejects_legacy_file_tag(
+    llm_collection,
+    write_file,
+    llm_qa_config,
+):
+    write_file(
+        llm_collection / "llm/grammar.yaml",
+        """
+        model: test
+        system_prompt: !file prompt.md
+        user_prompt: user
+        request:
+          max_notes_per_request: 1
+        """,
+    )
+
+    catalog = load_llm_task_catalog(
+        llm_collection,
+        note_type_configs=[llm_qa_config],
+    )
+
+    assert not catalog.tasks_by_name
+    assert "invalid YAML" in catalog.errors[str(llm_collection / "llm/grammar.yaml")]
+
+
+@pytest.mark.parametrize(
+    ("prompt_value", "expected_error"),
+    [
+        ("{}", "'system_prompt.file' is required"),
+        ("{file: prompt.md, extra: true}", "unknown 'system_prompt' key"),
+        ("{file: ''}", "'system_prompt.file' must be a non-empty relative path"),
+    ],
+)
+def test_load_llm_task_catalog_rejects_invalid_prompt_file_mapping(
+    llm_collection,
+    write_file,
+    llm_qa_config,
+    prompt_value,
+    expected_error,
+):
+    write_file(
+        llm_collection / "llm/grammar.yaml",
+        f"""
+        model: test
+        system_prompt: {prompt_value}
+        user_prompt: user
+        request:
+          max_notes_per_request: 1
+        """,
+    )
+
+    catalog = load_llm_task_catalog(
+        llm_collection,
+        note_type_configs=[llm_qa_config],
+    )
+
+    assert expected_error in catalog.errors[str(llm_collection / "llm/grammar.yaml")]
+
+
+def test_load_llm_task_catalog_rejects_paths_outside_collection(
+    llm_collection,
+    write_file,
+    llm_qa_config,
+):
+    write_file(llm_collection.parent / "outside.md", "outside")
+    write_file(
+        llm_collection / "llm/grammar.yaml",
+        """
+        model: test
+        system_prompt:
+          file: ../../outside.md
+        user_prompt: user
+        request:
+          max_notes_per_request: 1
+        """,
+    )
+
+    catalog = load_llm_task_catalog(
+        llm_collection,
+        note_type_configs=[llm_qa_config],
+    )
+
+    assert (
+        "must stay within" in catalog.errors[str(llm_collection / "llm/grammar.yaml")]
+    )
+
+
+def test_load_llm_task_catalog_rejects_absolute_input_file_path(
+    llm_collection,
+    write_file,
+    llm_qa_config,
+):
+    input_path = llm_collection / "reference.md"
+    write_file(input_path, "reference")
+    write_file(
+        llm_collection / "llm/grammar.yaml",
+        f"""
+        model: test
+        system_prompt: system
+        user_prompt: user
+        input_files:
+          - {input_path}
+        request:
+          max_notes_per_request: 1
+        """,
+    )
+
+    catalog = load_llm_task_catalog(
+        llm_collection,
+        note_type_configs=[llm_qa_config],
+    )
+
+    assert (
+        "must be a relative path"
+        in catalog.errors[str(llm_collection / "llm/grammar.yaml")]
+    )
+
+
+def test_load_llm_task_catalog_rejects_input_symlink_outside_collection(
+    llm_collection,
+    write_file,
+    llm_qa_config,
+):
+    outside = llm_collection.parent / "outside.md"
+    write_file(outside, "outside")
+    link = llm_collection / "reference.md"
+    link.symlink_to(outside)
+    write_file(
+        llm_collection / "llm/grammar.yaml",
+        """
+        model: test
+        system_prompt: system
+        user_prompt: user
+        input_files:
+          - ../reference.md
+        request:
+          max_notes_per_request: 1
+        """,
+    )
+
+    catalog = load_llm_task_catalog(
+        llm_collection,
+        note_type_configs=[llm_qa_config],
+    )
+
+    assert (
+        "must stay within" in catalog.errors[str(llm_collection / "llm/grammar.yaml")]
+    )
+
+
+def test_load_llm_task_catalog_rejects_missing_empty_and_duplicate_input_files(
+    llm_collection,
+    write_file,
+    llm_qa_config,
+):
+    empty = llm_collection / "empty.txt"
+    empty.touch()
+    write_file(
+        llm_collection / "llm/grammar.yaml",
+        """
+        model: test
+        system_prompt: system
+        user_prompt: user
+        input_files:
+          - ../empty.txt
+        request:
+          max_notes_per_request: 1
+        """,
+    )
+    catalog = load_llm_task_catalog(
+        llm_collection,
+        note_type_configs=[llm_qa_config],
+    )
+    assert (
+        "file must be non-empty"
+        in catalog.errors[str(llm_collection / "llm/grammar.yaml")]
+    )
+
+    write_file(llm_collection / "reference.txt", "reference")
+    write_file(
+        llm_collection / "llm/grammar.yaml",
+        """
+        model: test
+        system_prompt: system
+        user_prompt: user
+        input_files:
+          - ../reference.txt
+          - .././reference.txt
+        request:
+          max_notes_per_request: 1
+        """,
+    )
+    catalog = load_llm_task_catalog(
+        llm_collection,
+        note_type_configs=[llm_qa_config],
+    )
+    assert "duplicate path" in catalog.errors[str(llm_collection / "llm/grammar.yaml")]
+
+    write_file(
+        llm_collection / "llm/grammar.yaml",
+        """
+        model: test
+        system_prompt: system
+        user_prompt: user
+        input_files:
+          - ../missing.txt
+        request:
+          max_notes_per_request: 1
+        """,
+    )
+    catalog = load_llm_task_catalog(
+        llm_collection,
+        note_type_configs=[llm_qa_config],
+    )
+    assert "file not found" in catalog.errors[str(llm_collection / "llm/grammar.yaml")]
+
+
+def test_load_llm_task_catalog_enforces_combined_input_file_size(
+    llm_collection,
+    write_file,
+    llm_qa_config,
+    monkeypatch,
+):
+    monkeypatch.setattr(tasks_module, "_MAX_INPUT_FILE_BYTES", 10)
+    write_file(llm_collection / "first.txt", "12345")
+    write_file(llm_collection / "second.txt", "1234")
+    write_file(
+        llm_collection / "llm/grammar.yaml",
+        """
+        model: test
+        system_prompt: system
+        user_prompt: user
+        input_files:
+          - ../first.txt
+          - ../second.txt
+        request:
+          max_notes_per_request: 1
+        """,
+    )
+
+    catalog = load_llm_task_catalog(
+        llm_collection,
+        note_type_configs=[llm_qa_config],
+    )
+
+    assert (
+        "combined 'input_files' size"
         in catalog.errors[str(llm_collection / "llm/grammar.yaml")]
     )


### PR DESCRIPTION
## Summary

- Add input-file handling across LLM commands, planning, execution, and task workflows
- Update bundled task resources and document CLI output behavior
- Expand unit test coverage for planning, execution responses, execution flow, and tasks

## Testing

- Added and updated unit tests covering the new input-file workflows

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds reusable task input files to LLM execution, resolves task-relative resource paths, uploads files for request reuse, and surfaces input-file details in planning and CLI output.

A failure during a later input-file open or upload leaves files uploaded earlier in the same run undeleted. Mocked executions covered both a missing second file and a failed second provider upload; each recorded a successful first upload with no corresponding delete request. This should be fixed before merging so failed runs do not retain unnecessary temporary provider files.

<h3>Confidence Score: 4/5</h3>

Not ready to merge until partial input uploads are cleaned up after a later input-file failure.

The remaining issue was reproduced through both later-file-open and later-provider-upload failures, each leaving an earlier successful upload without a delete request.

**Files Needing Attention:** ankiops/llm/execution.py, particularly the exception handling in `_upload_input_files`.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A proof was produced for a posted P2 finding and linked to its review comment.
- A focused mocked reproduction source and two execution logs were prepared to validate the partial input upload cleanup.
- A second finding-comment-proof was produced and linked to its review comment.
- A general-contract-validation-proof was created, describing the open and upload failure scenarios and noting that the reproduction source and command outputs were saved.
- The reproduction source and the command-output logs described in the contract-validation proof were saved as artifacts for inspection.

<a href="https://app.greptile.com/trex/runs/16782196/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (7)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Legacy file task prompts are omitted from the LLM task catalog**

   - **Bug**
     - Existing task YAML using `system_prompt: !file prompt.md` (or the analogous user prompt) now fails parsing. The loader records an invalid-YAML error and excludes that task from `tasks_by_name`, whereas the PR baseline loaded it successfully.
   - **Cause**
     - The PR replaces the dedicated `_TaskConfigLoader` and its registered `!file` constructor with `yaml.safe_load` at `ankiops/llm/tasks.py:251-256`. PyYAML SafeLoader does not recognize the custom tag.
   - **Fix**
     - Preserve support for `!file` while adding the new mapping form: retain/register a safe custom loader constructor (with the existing path validation) or provide an equivalent constructor to the loader used for task YAML.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Cancellation during a later input-file upload leaks earlier uploaded files**

   - **Bug**
     - When the second fake upload raises `asyncio.CancelledError`, the first upload completes as `file-first`, but neither the helper nor the enclosing executor deletes it. The executed helper and executor captures both report `deleted=[]` while propagating `CancelledError`.
   - **Cause**
     - `_upload_input_files` catches only `Exception` at lines 646-648, while `asyncio.CancelledError` is not caught there. The helper exits without returning accumulated IDs; consequently `uploaded_file_ids` remains `()` at the caller and the enclosing `finally` deletes no IDs at lines 355-359.
   - **Fix**
     - Ensure cancellation also triggers deletion of the locally accumulated IDs before re-raising, while preserving cancellation semantics (for example, handle `asyncio.CancelledError` separately, clean up `file_ids`, then `raise`).

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

3. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Second cancellation aborts uploaded-file cleanup and strands private file IDs**

   - **Bug**
     - When `_upload_input_files` catches its first `CancelledError`, it awaits `_delete_uploaded_files`. A subsequent cancellation injected while deletion of the first uploaded file is suspended raises from that await, exits the cleanup loop, and prevents attempts for the remaining uploaded files. Because the upload helper raises rather than returns its accumulated IDs, its caller cannot retry deletion.
   - **Cause**
     - The cleanup await at `ankiops/llm/execution.py:647` is not protected from subsequent task cancellation, and ownership of the partially accumulated `file_ids` remains local to `_upload_input_files`.
   - **Fix**
     - Perform cancellation-resilient cleanup (for example, run cleanup in a separate task and await it under shielding while correctly preserving cancellation), and retain or propagate completed upload IDs so a higher-level cleanup path can retry if necessary.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

4. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Repeated cancellation aborts executor final cleanup**

   - **Bug**
     - `_execute_candidates` awaits `_delete_uploaded_files(...)` and then `client.close()` directly in its `finally` block. `CancelledError` raised by a second cancellation while `client.files.delete()` is suspended is not caught by `_delete_uploaded_files` (which catches only `Exception`), so it escapes the loop and prevents both later deletes and `client.close()`.
   - **Cause**
     - The cancellation-resilient helper `_delete_uploaded_files_after_cancellation` protects only the upload cancellation branch (`ankiops/llm/execution.py:646-651`). The finalizer at `ankiops/llm/execution.py:355-360` has no equivalent shielded task/retry loop around cleanup and close.
   - **Fix**
     - Run final deletion and client closure in a dedicated cleanup task and await it through `asyncio.shield()` in a loop that absorbs repeated `CancelledError`, then re-raise the original cancellation after cleanup completes. Ensure the cleanup task encompasses both `_delete_uploaded_files(...)` and `client.close()`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

5. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Cancellation-safe input-file cleanup can hang forever**

   - **Bug**
     - Confirmed. If OpenAI file deletion or client close never returns after the task is cancelled, `_finalize_openai_client` waits indefinitely for its shielded cleanup task. The deterministic reproduction entered mocked delete and was terminated only by `timeout 2s` (exit 124). This prevents command cancellation from completing.
   - **Cause**
     - `ankiops/llm/execution.py:663-669` creates a cleanup task then repeatedly awaits `asyncio.shield(cleanup_task)` until it is done, with no bounded cleanup timeout or escape path. Repeated cancellation is saved but cannot terminate the non-completing cleanup task.
   - **Fix**
     - Bound cleanup I/O with an explicit timeout/deadline and, after recording cancellation, stop waiting once that deadline expires; preserve and re-raise the original cancellation while logging cleanup timeout/failure.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

6. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **OpenAI cleanup failure masks expected cancellation**

   - **Bug**
     - Confirmed. A task already raising `CancelledError` enters finalization; when mocked `client.close()` raises `RuntimeError`, the observed exception is `RuntimeError: mock close failure` rather than the original cancellation. This violates the intended cancellation-safe cleanup behavior.
   - **Cause**
     - At `ankiops/llm/execution.py:670`, `await cleanup_task` propagates a cleanup exception before line 671 can test the saved cancellation and line 672 can re-raise it. `cleanup()` itself propagates `client.close()` failures from line 661.
   - **Fix**
     - Catch cleanup-task exceptions after cleanup completes, log them, and if cancellation was recorded re-raise that cancellation preferentially. Only propagate cleanup failure when no cancellation is pending.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

7. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Partial input uploads are not cleaned up after a later file failure**

   - **Bug**
     - When an earlier input file is uploaded successfully and a later path cannot be opened or its `files.create` call fails, `_upload_input_files` raises immediately. The earlier returned file ID is not deleted, so the temporary OpenAI file remains until its configured expiry.
   - **Cause**
     - `file_ids` accumulates IDs, but the broad exception handler at `ankiops/llm/execution.py:642-643` formats and re-raises the failure without iterating over previously accumulated IDs and calling `client.files.delete`.
   - **Fix**
     - Before re-raising the formatted RuntimeError, best-effort delete every ID already accumulated in `file_ids` (while preserving the original upload/open error). Add focused tests for both a later `Path.open` failure and a later `files.create` failure that assert deletion of prior IDs.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["Use expiring OpenAI files instead of man..."](https://github.com/visserle/ankiops/commit/e2c146338a2ba8847449244417e59012198d5d06) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49036235)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->